### PR TITLE
Allow a named Series to be passed as the shorthand

### DIFF
--- a/altair/schema/_wrappers/channel_wrappers.py
+++ b/altair/schema/_wrappers/channel_wrappers.py
@@ -4,7 +4,7 @@
 import traitlets as T
 import pandas as pd
 
-from ...utils import parse_shorthand, infer_vegalite_type
+from ...utils import parse_shorthand, preparse_shorthand, infer_vegalite_type
 
 from .._interface import ChannelDefWithLegend, FieldDef, OrderChannelDef, PositionChannelDef
 
@@ -43,7 +43,7 @@ class PositionChannel(PositionChannelDef):
 
     # Class Methods
     def __init__(self, shorthand='', aggregate=None, axis=None, bin=None, field=None, scale=None, sort=None, timeUnit=None, title=None, type=None, value=None, **kwargs):
-        kwargs['shorthand'] = shorthand
+        kwargs['shorthand'] = preparse_shorthand(shorthand)
         kwds = dict(aggregate=aggregate, axis=axis, bin=bin, field=field, scale=scale, sort=sort, timeUnit=timeUnit, title=title, type=type, value=value)
         kwargs.update({k:v for k, v in kwds.items() if v is not None})
         super(PositionChannel, self).__init__(**kwargs)
@@ -97,7 +97,7 @@ class ChannelWithLegend(ChannelDefWithLegend):
 
     # Class Methods
     def __init__(self, shorthand='', aggregate=None, bin=None, field=None, legend=None, scale=None, sort=None, timeUnit=None, title=None, type=None, value=None, **kwargs):
-        kwargs['shorthand'] = shorthand
+        kwargs['shorthand'] = preparse_shorthand(shorthand)
         kwds = dict(aggregate=aggregate, bin=bin, field=field, legend=legend, scale=scale, sort=sort, timeUnit=timeUnit, title=title, type=type, value=value)
         kwargs.update({k:v for k, v in kwds.items() if v is not None})
         super(ChannelWithLegend, self).__init__(**kwargs)
@@ -145,7 +145,7 @@ class Field(FieldDef):
 
     # Class Methods
     def __init__(self, shorthand='', aggregate=None, bin=None, field=None, timeUnit=None, title=None, type=None, value=None, **kwargs):
-        kwargs['shorthand'] = shorthand
+        kwargs['shorthand'] = preparse_shorthand(shorthand)
         kwds = dict(aggregate=aggregate, bin=bin, field=field, timeUnit=timeUnit, title=title, type=type, value=value)
         kwargs.update({k:v for k, v in kwds.items() if v is not None})
         super(Field, self).__init__(**kwargs)
@@ -195,7 +195,7 @@ class OrderChannel(OrderChannelDef):
 
     # Class Methods
     def __init__(self, shorthand='', aggregate=None, bin=None, field=None, sort=None, timeUnit=None, title=None, type=None, value=None, **kwargs):
-        kwargs['shorthand'] = shorthand
+        kwargs['shorthand'] = preparse_shorthand(shorthand)
         kwds = dict(aggregate=aggregate, bin=bin, field=field, sort=sort, timeUnit=timeUnit, title=title, type=type, value=value)
         kwargs.update({k:v for k, v in kwds.items() if v is not None})
         super(OrderChannel, self).__init__(**kwargs)

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -69,6 +69,16 @@ def parse_shorthand(shorthand):
     return match
 
 
+def preparse_shorthand(shorthand):
+    """Allow a Pandas Series to be passed as a field shorthand name."""
+    if isinstance(shorthand, pd.Series):
+        if not shorthand.name:
+            raise ValueError('Series object does not have a name.')
+        return shorthand.name
+    else:
+        return shorthand
+
+
 def construct_shorthand(field=None, aggregate=None, type=None):
     """Construct a shorthand representation.
 

--- a/tools/templates/channel_wrappers.tpl
+++ b/tools/templates/channel_wrappers.tpl
@@ -4,7 +4,7 @@
 import traitlets as T
 import pandas as pd
 
-from ...utils import parse_shorthand, infer_vegalite_type
+from ...utils import parse_shorthand, preparse_shorthand, infer_vegalite_type
 
 {% for import_statement in objects|merge_imports -%}
   {{ import_statement }}
@@ -34,7 +34,7 @@ class {{ object.name }}({{ object.base.name }}):
     # Class Methods
     {%- set comma = joiner(", ") %}
     def __init__(self, shorthand='', {% for attr in object.base.attributes %}{{ attr.name }}=None, {% endfor %}**kwargs):
-        kwargs['shorthand'] = shorthand
+        kwargs['shorthand'] = preparse_shorthand(shorthand)
         kwds = dict({% for attr in object.base.attributes %}{{ comma() }}{{ attr.name }}={{ attr.name }}{% endfor %})
         kwargs.update({k:v for k, v in kwds.items() if v is not None})
         super({{ object.name }}, self).__init__(**kwargs)


### PR DESCRIPTION
This makes the following work:

```
Chart(data).mark_point().encode(x=data.column)
```

After thinking a bit more, not sure we should do this as users may think that you can pass actual data to the `encode` method. But all this does is grab the _name_ of the column from the Series. What do you think @jakevdp ?

Addresses #141 
