### PR TITLE
MAINT: Replace `iteritems` with `items`

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -314,7 +314,7 @@ def sanitize_dataframe(df):  # noqa: C901
         else:
             return val
 
-    for col_name, dtype in df.dtypes.iteritems():
+    for col_name, dtype in df.dtypes.items():
         if str(dtype) == "category":
             # XXXX: work around bug in to_json for categorical types
             # https://github.com/pydata/pandas/issues/10778

--- a/altair/utils/tests/test_utils.py
+++ b/altair/utils/tests/test_utils.py
@@ -129,9 +129,9 @@ def test_sanitize_nullable_integers():
     )
 
     df_clean = sanitize_dataframe(df)
-    assert {col.dtype.name for _, col in df_clean.iteritems()} == {"object"}
+    assert {col.dtype.name for _, col in df_clean.items()} == {"object"}
 
-    result_python = {col_name: list(col) for col_name, col in df_clean.iteritems()}
+    result_python = {col_name: list(col) for col_name, col in df_clean.items()}
     assert result_python == {
         "int_np": [1, 2, 3, 4, 5],
         "int64": [1, 2, 3, None, 5],
@@ -157,9 +157,9 @@ def test_sanitize_string_dtype():
     )
 
     df_clean = sanitize_dataframe(df)
-    assert {col.dtype.name for _, col in df_clean.iteritems()} == {"object"}
+    assert {col.dtype.name for _, col in df_clean.items()} == {"object"}
 
-    result_python = {col_name: list(col) for col_name, col in df_clean.iteritems()}
+    result_python = {col_name: list(col) for col_name, col in df_clean.items()}
     assert result_python == {
         "string_object": ["a", "b", "c", "d"],
         "string_string": ["a", "b", "c", "d"],
@@ -182,9 +182,9 @@ def test_sanitize_boolean_dtype():
     )
 
     df_clean = sanitize_dataframe(df)
-    assert {col.dtype.name for _, col in df_clean.iteritems()} == {"object"}
+    assert {col.dtype.name for _, col in df_clean.items()} == {"object"}
 
-    result_python = {col_name: list(col) for col_name, col in df_clean.iteritems()}
+    result_python = {col_name: list(col) for col_name, col in df_clean.items()}
     assert result_python == {
         "bool_none": [True, False, None],
         "none": [None, None, None],


### PR DESCRIPTION
`iteritems` is raising a warning in pandas >=1.5 [as it is now deprecated](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.5.0.html#other-deprecations). The recommended replacement is `items`.
