### PR TITLE
Check all specs in the context of top level data

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -384,9 +384,13 @@ class SchemaBase(object):
                 "{} instance has both a value and properties : "
                 "cannot serialize to dict".format(self.__class__)
             )
+
         if validate:
             try:
-                self.validate(result)
+                if "top_level_data" in context and "mark" in result:
+                    self.validate({**result, "data": context["top_level_data"]})
+                else:
+                    self.validate(result)
             except jsonschema.ValidationError as err:
                 raise SchemaValidationError(self, err)
         return result

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -551,6 +551,12 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
         if original_data is not Undefined:
             context["data"] = original_data
+            # Set top level data so that layered/concat specs don't fail
+            # because data is not present in each layer/concat
+            if isinstance(copy["data"], dict) or copy["data"] is None:
+                context["top_level_data"] = copy["data"]
+            else:
+                context["top_level_data"] = copy["data"].to_dict()
 
         # remaining to_dict calls are not at top level
         context["top_level"] = False


### PR DESCRIPTION
This PR fixes #2609 and half of #2744 (and would likely have prevented #2495). There is more detail in #2609, but in brief this allows layer/concat specs to be validated correctly with `validate='deep'` and take top level data into account for each layer, instead of failing because the mark in each layer is missing data.

Example:

```py
points = alt.Chart(data.cars.url).mark_point().encode(
    x='Horsepower:Q',
    y='Miles_per_Gallon:Q',
)
(points & points).properties(width=400)
```

The spec above would previously raise the error:

```
'data' is a required property
```

which should not be raised here since there is data in the spec (see https://github.com/altair-viz/altair/issues/2744#issuecomment-1378704707 for more info). After this PR, the correct error is raised instead, pointing to that the issue is that concat charts do not take `width` (it has to be specified on each individual chart):

```
Additional properties are not allowed ('width' was unexpected)
```

The change here feels a bit ineloquent to me, and I would still like to see if I can figure out a way to only add the top level data if the spec contains a layer or concat. However, I am not super hopeful that I will succeed with that and it took my quite a long time to understand what was going on here and what changes could be made (there are many functions with similar names, exceptions, and functions calling themselves which made this section tricky for me to comprehend and thus slow to work on).

It seems like the suggested solution doesn't break any tests or cause any regressions, although I haven't checked if it adds performance overhead. If there are any regressions you can think of where this would hide a correctly raised `'data' is a required property`-error, please let me know (I tried with empty data and `None` and they both pass both before and after this PR).
