### PR TITLE
Shorten page title

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,7 +32,7 @@ it can be helpful to also browse the `Vega-Lite documentation <https://vega.gith
    Getting Started <getting_started/overview>
    User Guide <user_guide/data>
    Examples <gallery/index>
-   API Reference <user_guide/API>
+   API <user_guide/API>
    user_guide/ecosystem
    releases/changes
 


### PR DESCRIPTION
Currently there is a window width that makes the navbar looks like this, which I think is rather ugly:

![image](https://user-images.githubusercontent.com/4560057/223005071-0656d92c-7515-4aab-be3f-eaf5001aa336.png)

This PR changes the title so that the navbar always looks like the following until it is collapsed in the hamburger menu:

![image](https://user-images.githubusercontent.com/4560057/223005150-e552c43a-d8b1-4f9f-ad2c-604761ce421c.png)
