### PR TITLE
Display more helpful error message when two fields strings are used in condition

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -775,7 +775,7 @@ def condition(predicate, if_true, if_false, **kwargs):
     elif isinstance(if_true, str):
         if isinstance(if_false, str):
             raise ValueError(
-                "A field cannot be used in both the `if_true` and `if_false` branches of a condition. One of the them has to specify a `value` or `datum` definition."
+                "A field cannot be used as both the `if_true` and `if_false` values of a condition. One of them has to specify a `value` or `datum` definition."
             )
         else:
             if_true = utils.parse_shorthand(if_true)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -774,7 +774,7 @@ def condition(predicate, if_true, if_false, **kwargs):
         if_true = if_true.to_dict()
     elif isinstance(if_true, str):
         if isinstance(if_false, str):
-            raise ValueError('A field cannot be used in both the `if_true` and `if_false` branches of a condition. One of the them has to specify a `value` or `datum` definition.')
+            raise ValueError("A field cannot be used in both the `if_true` and `if_false` branches of a condition. One of the them has to specify a `value` or `datum` definition.")
         else:
             if_true = utils.parse_shorthand(if_true)
             if_true.update(kwargs)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -773,8 +773,11 @@ def condition(predicate, if_true, if_false, **kwargs):
         # dict in the appropriate schema
         if_true = if_true.to_dict()
     elif isinstance(if_true, str):
-        if_true = utils.parse_shorthand(if_true)
-        if_true.update(kwargs)
+        if isinstance(if_false, str):
+            raise ValueError('A field cannot be used in both the `if_true` and `if_false` branches of a condition. One of the them has to specify a `value` or `datum` definition.')
+        else:
+            if_true = utils.parse_shorthand(if_true)
+            if_true.update(kwargs)
     condition.update(if_true)
 
     if isinstance(if_false, core.SchemaBase):

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -775,7 +775,7 @@ def condition(predicate, if_true, if_false, **kwargs):
     elif isinstance(if_true, str):
         if isinstance(if_false, str):
             raise ValueError(
-                "A field cannot be used as both the `if_true` and `if_false` values of a condition. One of them has to specify a `value` or `datum` definition."
+                "A field cannot be used for both the `if_true` and `if_false` values of a condition. One of them has to specify a `value` or `datum` definition."
             )
         else:
             if_true = utils.parse_shorthand(if_true)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -774,7 +774,9 @@ def condition(predicate, if_true, if_false, **kwargs):
         if_true = if_true.to_dict()
     elif isinstance(if_true, str):
         if isinstance(if_false, str):
-            raise ValueError("A field cannot be used in both the `if_true` and `if_false` branches of a condition. One of the them has to specify a `value` or `datum` definition.")
+            raise ValueError(
+                "A field cannot be used in both the `if_true` and `if_false` branches of a condition. One of the them has to specify a `value` or `datum` definition."
+            )
         else:
             if_true = utils.parse_shorthand(if_true)
             if_true.update(kwargs)

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -24,6 +24,7 @@ Enhancements
 - Substantially improved error handling. Both in terms of finding the more relevant error (#2842), and in terms of improving the formatting and clarity of the error messages (#2824, #2568).
 - Include experimental support for the DataFrame Interchange Protocol (through ``__dataframe__`` attribute). This requires ``pyarrow>=11.0.0`` (#2888).
 - Support data type inference for columns with special characters (#2905).
+- Changed error message to be more informative when two field strings are using in a condition (#2979).
 
 Grammar Changes
 ~~~~~~~~~~~~~~~

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -619,7 +619,7 @@ def test_multiple_field_strings_in_condition():
             .mark_circle()
             .add_params(selection)
             .encode(
-                color=alt.condition(selection, 'Origin', 'Origin'),
+                color=alt.condition(selection, "Origin", "Origin"),
             )
         ).to_dict()
 

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -612,7 +612,7 @@ def test_chart_validation_errors(chart_func, expected_error_message):
 
 def test_multiple_field_strings_in_condition():
     selection = alt.selection_point()
-    expected_error_message = "A field cannot be used in both the `if_true` and `if_false` branches of a condition. One of the them has to specify a `value` or `datum` definition."
+    expected_error_message = "A field cannot be used as both the `if_true` and `if_false` values of a condition. One of them has to specify a `value` or `datum` definition."
     with pytest.raises(ValueError, match=expected_error_message):
         (
             alt.Chart(data.cars())

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -612,7 +612,7 @@ def test_chart_validation_errors(chart_func, expected_error_message):
 
 def test_multiple_field_strings_in_condition():
     selection = alt.selection_point()
-    expected_error_message = "A field cannot be used as both the `if_true` and `if_false` values of a condition. One of them has to specify a `value` or `datum` definition."
+    expected_error_message = "A field cannot be used for both the `if_true` and `if_false` values of a condition. One of them has to specify a `value` or `datum` definition."
     with pytest.raises(ValueError, match=expected_error_message):
         (
             alt.Chart(data.cars())

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -610,6 +610,20 @@ def test_chart_validation_errors(chart_func, expected_error_message):
         chart.to_dict()
 
 
+def test_multiple_field_strings_in_condition():
+    selection = alt.selection_point()
+    expected_error_message = "A field cannot be used in both the `if_true` and `if_false` branches of a condition. One of the them has to specify a `value` or `datum` definition."
+    with pytest.raises(ValueError, match=expected_error_message):
+        (
+            alt.Chart(data.cars())
+            .mark_circle()
+            .add_params(selection)
+            .encode(
+                color=alt.condition(selection, 'Origin', 'Origin'),
+            )
+        ).to_dict()
+
+
 def test_serialize_numpy_types():
     m = MySchema(
         a={"date": np.datetime64("2019-01-01")},


### PR DESCRIPTION
This is an attempt to resolve https://github.com/altair-viz/altair/issues/2935.

If there are other string that can be passed to conditions that are not references for fields, then that would be an issue for this PR, but I can't think of any on the top of my head. It could also be argued that maybe this should be fixed in VegaLite, but it seems helpful and straightforward to fix it directly in Altair.
