### PR TITLE
Prefer method-based syntax in docs and add tabbed interface for method and attribute syntax in gallery

### DIFF
--- a/doc/case_studies/exploring-weather.rst
+++ b/doc/case_studies/exploring-weather.rst
@@ -54,7 +54,7 @@ The result is a histogram of precipitation values:
 .. altair-plot::
 
     alt.Chart(df).mark_bar().encode(
-        alt.X('precipitation', bin=True),
+        alt.X('precipitation').bin(),
         y='count()'
     )
 
@@ -177,7 +177,7 @@ meaning of the plot more clear:
 .. altair-plot::
 
     alt.Chart(df).mark_bar().encode(
-        x=alt.X('month(date):N', title='Month of the year'),
+        x=alt.X('month(date):N').title('Month of the year'),
         y='count()',
         color=alt.Color('weather', legend=alt.Legend(title='Weather type'), scale=scale),
     )
@@ -191,10 +191,10 @@ and to allow interactive panning and zooming with the mouse:
 .. altair-plot::
 
     alt.Chart(df).mark_point().encode(
-        alt.X('temp_max', title='Maximum Daily Temperature (C)'),
-        alt.Y('temp_range:Q', title='Daily Temperature Range (C)'),
-        alt.Color('weather', scale=scale),
-        alt.Size('precipitation', scale=alt.Scale(range=[1, 200]))
+        alt.X('temp_max').title('Maximum Daily Temperature (C)'),
+        alt.Y('temp_range:Q').title('Daily Temperature Range (C)'),
+        alt.Color('weather').scale(scale),
+        alt.Size('precipitation').scale(range=[1, 200])
     ).transform_calculate(
         "temp_range", "datum.temp_max - datum.temp_min"
     ).properties(
@@ -215,7 +215,7 @@ by weather type:
     alt.Chart(df).mark_bar().encode(
         x='count()',
         y='weather:N',
-        color=alt.Color('weather:N', scale=scale),
+        color=alt.Color('weather:N').scale(scale),
     )
 
 And now we can vertically concatenate this histogram to the points plot above,
@@ -228,10 +228,10 @@ of the selection (for more information on selections, see
     brush = alt.selection_interval()
 
     points = alt.Chart().mark_point().encode(
-        alt.X('temp_max:Q', title='Maximum Daily Temperature (C)'),
-        alt.Y('temp_range:Q', title='Daily Temperature Range (C)'),
+        alt.X('temp_max:Q').title('Maximum Daily Temperature (C)'),
+        alt.Y('temp_range:Q').title('Daily Temperature Range (C)'),
         color=alt.condition(brush, 'weather:N', alt.value('lightgray'), scale=scale),
-        size=alt.Size('precipitation:Q', scale=alt.Scale(range=[1, 200]))
+        size=alt.Size('precipitation:Q').scale(range=[1, 200])
     ).transform_calculate(
         "temp_range", "datum.temp_max - datum.temp_min"
     ).properties(
@@ -244,7 +244,7 @@ of the selection (for more information on selections, see
     bars = alt.Chart().mark_bar().encode(
         x='count()',
         y='weather:N',
-        color=alt.Color('weather:N', scale=scale),
+        color=alt.Color('weather:N').scale(scale),
     ).transform_calculate(
         "temp_range", "datum.temp_max - datum.temp_min"
     ).transform_filter(

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,7 @@ extensions = [
     "sphinxext.schematable",
     "sphinx_copybutton",
     "sphinx_design"
-    # "sphinxext.rediraffe",
+    "sphinx_design",
 ]
 
 altair_plot_links = {"editor": True, "source": False, "export": False}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,6 @@ extensions = [
     "sphinxext.altairgallery",
     "sphinxext.schematable",
     "sphinx_copybutton",
-    "sphinx_design"
     "sphinx_design",
 ]
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinxext.altairgallery",
     "sphinxext.schematable",
     "sphinx_copybutton",
+    "sphinx_design"
     # "sphinxext.rediraffe",
 ]
 

--- a/doc/getting_started/starting.rst
+++ b/doc/getting_started/starting.rst
@@ -221,16 +221,16 @@ Customizing your Visualization
 By default, Altair via Vega-Lite makes some choices about default properties
 of the visualization.
 Altair also provides an API to customize the look of the visualization.
-For example, we can specify the axis titles using the ``axis`` attribute
-of channel classes, and we can specify the color of the marking by setting
-the ``color`` keyword of the ``Chart.mark_*`` methods to any valid HTML
+For example, we can specify the axis titles using the :meth:`title` method
+of channel classes, and we can specify the color of the mark by setting
+the ``color`` keyword of the ``Chart.mark_*`` method to any valid HTML
 color string:
 
 .. altair-plot::
 
     alt.Chart(data).mark_bar(color='firebrick').encode(
-        alt.Y('a', title='category'),
-        alt.X('average(b)', title='avg(b) by category')
+        alt.Y('a').title('category'),
+        alt.X('average(b)').title('avg(b) by category')
     )
 
 

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -29,7 +29,7 @@ Enhancements
 Grammar Changes
 ~~~~~~~~~~~~~~~
 
-- Channel options can now be set via a method based syntax in addition to the previous helper class syntax. For example, in addition to ``alt.X(..., bin=alt.Bin(...))`` it is now possible to do ``alt.X(...).bin(...)```) (#2795). See :ref:`method-based-attribute-setting` for details.
+- Channel options can now be set via a more convenient method-based syntax in addition to the previous attribute-based syntax. For example, instead of ``alt.X(..., bin=alt.Bin(...))`` it is now recommend to use ``alt.X(...).bin(...)```) (#2795). See :ref:`method-based-attribute-setting` for details.
 - ``selection_single`` and ``selection_multi`` are now deprecated; use ``selection_point`` instead.  Similarly, ``type=point`` should be used instead of ``type=single`` and ``type=multi``.
 - ``add_selection`` is deprecated; use ``add_params`` instead.
 - The ``selection`` keyword argument must in many cases be replaced by ``param`` (e.g., when specifying a filter transform).

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,3 +7,4 @@ pydata-sphinx-theme
 geopandas
 myst-parser
 sphinx_copybutton
+sphinx-design

--- a/doc/user_guide/compound_charts.rst
+++ b/doc/user_guide/compound_charts.rst
@@ -34,9 +34,8 @@ same data; for example:
 .. altair-plot::
 
     import altair as alt
-    from altair.expr import datum
-
     from vega_datasets import data
+
     stocks = data.stocks.url
 
     base = alt.Chart(stocks).encode(
@@ -44,7 +43,7 @@ same data; for example:
         y='price:Q',
         color='symbol:N'
     ).transform_filter(
-        datum.symbol == 'GOOG'
+        alt.datum.symbol == 'GOOG'
     )
 
     base.mark_line() + base.mark_point()
@@ -82,9 +81,9 @@ heat-map:
     source = data.movies.url
 
     heatmap = alt.Chart(source).mark_rect().encode(
-        alt.X('IMDB_Rating:Q', bin=True),
-        alt.Y('Rotten_Tomatoes_Rating:Q', bin=True),
-        alt.Color('count()', scale=alt.Scale(scheme='greenblue'))
+        alt.X('IMDB_Rating:Q').bin(),
+        alt.Y('Rotten_Tomatoes_Rating:Q').bin(),
+        alt.Color('count()').scale(scheme='greenblue')
     )
 
     points = alt.Chart(source).mark_circle(
@@ -137,7 +136,7 @@ distribution of its points:
 
     chart2 = alt.Chart(iris).mark_bar().encode(
         x='count()',
-        y=alt.Y('petalWidth:Q', bin=alt.Bin(maxbins=30)),
+        y=alt.Y('petalWidth:Q').bin(maxbins=30),
         color='species:N'
     ).properties(
         height=300,
@@ -189,9 +188,7 @@ with a ``brush`` selection to add interaction:
         height=200
     )
 
-    upper = base.encode(
-        alt.X('date:T', scale=alt.Scale(domain=brush))
-    )
+    upper = base.encode(alt.X('date:T').scale(domain=brush))
 
     lower = base.properties(
         height=60
@@ -282,8 +279,8 @@ using ``alt.repeat('layer')``:
     source = data.movies()
 
     alt.Chart(source).mark_line().encode(
-        x=alt.X("IMDB_Rating", bin=True),
-        y=alt.Y(alt.repeat('layer'), aggregate='mean', title="Mean of US and Worldwide Gross"),
+        x=alt.X("IMDB_Rating").bin(),
+        y=alt.Y(alt.repeat('layer')).aggregate('mean').title("Mean of US and Worldwide Gross"),
         color=alt.ColorDatum(alt.repeat('layer'))
     ).repeat(layer=["US_Gross", "Worldwide_Gross"])
 
@@ -305,8 +302,8 @@ concatenation:
 .. altair-plot::
 
     import altair as alt
-    from altair.expr import datum
     from vega_datasets import data
+
     iris = data.iris.url
 
     base = alt.Chart(iris).mark_point().encode(
@@ -320,7 +317,7 @@ concatenation:
 
     chart = alt.hconcat()
     for species in ['setosa', 'versicolor', 'virginica']:
-        chart |= base.transform_filter(datum.species == species)
+        chart |= base.transform_filter(alt.datum.species == species)
     chart
 
 As with the manual approach to :ref:`repeat-chart`, this is straightforward,

--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -134,7 +134,7 @@ By default an Altair chart does not have a title, as seen in this example.
    
    alt.Chart(iowa).mark_area().encode(
        x="year:T",
-       y=alt.Y("net_generation:Q", stack="normalize"),
+       y=alt.Y("net_generation:Q").stack("normalize"),
        color="source:N"
    )
 
@@ -144,7 +144,7 @@ You can add a simple title by passing the `title` keyword argument with the data
 
    alt.Chart(iowa, title="Iowa's green energy boom").mark_area().encode(
        x="year:T",
-       y=alt.Y("net_generation:Q", stack="normalize"),
+       y=alt.Y("net_generation:Q").stack("normalize"),
        color="source:N"
    )
 
@@ -160,7 +160,7 @@ It is also possible to add a subtitle by passing in an `alt.Title` object.
       )
    ).mark_area().encode(
        x="year:T",
-       y=alt.Y("net_generation:Q", stack="normalize"),
+       y=alt.Y("net_generation:Q").stack("normalize"),
        color="source:N"
    )
 
@@ -176,7 +176,7 @@ The subtitle can run to two lines by passing a list where each list item is a li
       )
    ).mark_area().encode(
        x="year:T",
-       y=alt.Y("net_generation:Q", stack="normalize"),
+       y=alt.Y("net_generation:Q").stack("normalize"),
        color="source:N"
    )
 
@@ -195,7 +195,7 @@ The ``Title`` object can also configure a number of other attributes, e.g., the 
       )
    ).mark_area().encode(
        x="year:T",
-       y=alt.Y("net_generation:Q", stack="normalize"),
+       y=alt.Y("net_generation:Q").stack("normalize"),
        color="source:N"
    )
 
@@ -226,9 +226,7 @@ in quantitative axes; if you would like to turn this off, you can add a
 .. altair-plot::
 
     alt.Chart(cars).mark_point().encode(
-        alt.X('Acceleration:Q',
-            scale=alt.Scale(zero=False)
-        ),
+        alt.X('Acceleration:Q').scale(zero=False),
         y='Horsepower:Q'
     )
 
@@ -237,9 +235,7 @@ To specify exact axis limits, you can use the ``domain`` property of the scale:
 .. altair-plot::
 
     alt.Chart(cars).mark_point().encode(
-        alt.X('Acceleration:Q',
-            scale=alt.Scale(domain=(5, 20))
-        ),
+        alt.X('Acceleration:Q').scale(domain=(5, 20)),
         y='Horsepower:Q'
     )
 
@@ -250,9 +246,7 @@ the ``"clip"`` property of the mark to True:
 .. altair-plot::
 
     alt.Chart(cars).mark_point(clip=True).encode(
-        alt.X('Acceleration:Q',
-            scale=alt.Scale(domain=(5, 20))
-        ),
+        alt.X('Acceleration:Q').scale(domain=(5, 20)),
         y='Horsepower:Q'
     )
 
@@ -262,12 +256,7 @@ limit to the edge of the domain:
 .. altair-plot::
 
     alt.Chart(cars).mark_point().encode(
-        alt.X('Acceleration:Q',
-            scale=alt.Scale(
-                domain=(5, 20),
-                clamp=True
-            )
-        ),
+        alt.X('Acceleration:Q').scale(domain=(5, 20), clamp=True),
         y='Horsepower:Q'
     ).interactive()
 
@@ -301,8 +290,8 @@ the y labels as a dollar value:
 .. altair-plot::
 
    alt.Chart(df).mark_circle().encode(
-       x=alt.X('x', axis=alt.Axis(format='%', title='percentage')),
-       y=alt.Y('y', axis=alt.Axis(format='$', title='dollar amount'))
+       alt.X('x').axis(format='%').title('percentage'),
+       alt.Y('y').axis(format='$').title('dollar amount')
    )
 
 Axis labels can also be easily removed:
@@ -310,8 +299,8 @@ Axis labels can also be easily removed:
 .. altair-plot::
 
    alt.Chart(df).mark_circle().encode(
-       x=alt.X('x', axis=alt.Axis(labels=False)),
-       y=alt.Y('y', axis=alt.Axis(labels=False))
+       alt.X('x').axis(labels=False),
+       alt.Y('y').axis(labels=False)
    )
 
 Additional formatting codes are available; for a listing of these see the
@@ -350,7 +339,7 @@ The legend option on all of them expects a :class:`Legend` object as its input, 
   alt.Chart(iris).mark_point().encode(
       x='petalWidth',
       y='petalLength',
-      color=alt.Color('species', legend=alt.Legend(title="Species by color"))
+      color=alt.Color('species').title("Species by color")
   )
 
 Another thing you can do is move the legend to another position with the `orient` argument.
@@ -365,7 +354,7 @@ Another thing you can do is move the legend to another position with the `orient
   alt.Chart(iris).mark_point().encode(
       x='petalWidth',
       y='petalLength',
-      color=alt.Color('species', legend=alt.Legend(orient="left")),
+      color=alt.Color('species').legend(orient="left")
   )
 
 You can remove the legend entirely by submitting a null value.
@@ -380,7 +369,7 @@ You can remove the legend entirely by submitting a null value.
   alt.Chart(iris).mark_point().encode(
       x='petalWidth',
       y='petalLength',
-      color=alt.Color('species', legend=None),
+      color=alt.Color('species').legend(None),
   )
 
 Removing the Chart Border
@@ -453,8 +442,8 @@ combining the above option with setting ``axis`` to ``None`` during encoding.
     iris = data.iris()
 
     alt.Chart(iris).mark_point().encode(
-        alt.X('petalWidth', axis=None),
-        alt.Y('petalLength', axis=None),
+        alt.X('petalWidth').axis(None),
+        alt.Y('petalLength').axis(None),
         color='species'
     ).configure_axis(
         grid=False
@@ -491,7 +480,7 @@ can be passed to the `scheme` argument of the :class:`Scale` class:
   alt.Chart(iris).mark_point().encode(
       x='petalWidth',
       y='petalLength',
-      color=alt.Color('species', scale=alt.Scale(scheme='dark2'))
+      color=alt.Color('species').scale(scheme='dark2')
   )
 
 Color Domain and Range
@@ -513,7 +502,7 @@ values and colors respectively.
   alt.Chart(iris).mark_point().encode(
       x='petalWidth',
       y='petalLength',
-      color=alt.Color('species', scale=alt.Scale(domain=domain, range=range_))
+      color=alt.Color('species').scale(domain=domain, range=range_)
   )
 
 Raw Color Values
@@ -537,7 +526,7 @@ you can set ``scale=None`` to use those colors directly:
       size=100
   ).encode(
       x='x',
-      color=alt.Color('color', scale=None)
+      color=alt.Color('color').scale(None)
   )
 
 Adjusting the Width of Bar Marks

--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -402,7 +402,7 @@ for the ordinal structured data.
 .. altair-plot::
 
    alt.Chart(data_obj_geojson, title="Vega-Altair - ordinal scale").mark_geoshape().encode(
-       alt.Color("properties.location:O").scale(alt.Scale(scheme='magma'))
+       alt.Color("properties.location:O").scale(scheme='magma')
    ).project(type="identity", reflectY=True)
 
 

--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -351,14 +351,14 @@ GeoDataFrame and visualize these using the ``mark_geoshape``.
 
 Since the spatial data in our example is not geographic, 
 we use ``project`` configuration ``type="identity", reflectY=True`` to draw the
-geometries without applying a geographic projection. By using ``alt.Color(..., scale=None)`` we
+geometries without applying a geographic projection. By using ``alt.Color(...).scale(None)`` we
 disable the automatic color assignment in Altair
 and instead directly use the provided Hex color codes.
 
 .. altair-plot::
 
    alt.Chart(gdf_geoms, title="Vega-Altair").mark_geoshape().encode(
-       color=alt.Color("color:N", scale=None)
+       alt.Color("color:N").scale(None)
    ).project(type="identity", reflectY=True)
 
 
@@ -402,7 +402,7 @@ for the ordinal structured data.
 .. altair-plot::
 
    alt.Chart(data_obj_geojson, title="Vega-Altair - ordinal scale").mark_geoshape().encode(
-       color=alt.Color("properties.location:O", scale=alt.Scale(scheme='magma'))
+       alt.Color("properties.location:O").scale(alt.Scale(scheme='magma'))
    ).project(type="identity", reflectY=True)
 
 
@@ -519,7 +519,7 @@ as we hover over it with the mouse.
    alt.Chart(data_url_topojson, title="London-Boroughs").mark_geoshape(
        tooltip=True
    ).encode(
-       color=alt.Color("id:N", scale=alt.Scale(scheme='tableau20'), legend=alt.Legend(columns=2, symbolLimit=33))
+       alt.Color("id:N").scale(scheme='tableau20').legend(columns=2, symbolLimit=33)
    )
 
 Similar to the ``feature`` option, there also exists the ``mesh``
@@ -572,7 +572,7 @@ in the list of dictionaries:
     
    alt.Chart(data_nested_features, title="Vega-Altair").mark_geoshape().encode(
        shape="geo:G", 
-       color=alt.Color("color:N", scale=None)
+       color=alt.Color("color:N").scale(None)
    ).project(type="identity", reflectY=True)
 
 

--- a/doc/user_guide/encodings/channels.rst
+++ b/doc/user_guide/encodings/channels.rst
@@ -125,7 +125,7 @@ For stacked marks, this controls the order of components of the stack. Here, the
         x='variety:N',
         y='sum(yield):Q',
         color='site:N',
-        order=alt.Order("site", sort="ascending")
+        order=alt.Order("site").sort("ascending")
     )
 
 The order can be reversed by changing the sort option to `descending`.
@@ -141,7 +141,7 @@ The order can be reversed by changing the sort option to `descending`.
         x='variety:N',
         y='sum(yield):Q',
         color='site:N',
-        order=alt.Order("site", sort="descending")
+        order=alt.Order("site").sort("descending")
     )
 
 The same approach works for other mark types, like stacked areas charts.
@@ -157,7 +157,7 @@ The same approach works for other mark types, like stacked areas charts.
         x='variety:N',
         y='sum(yield):Q',
         color='site:N',
-        order=alt.Order("site", sort="ascending")
+        order=alt.Order("site").sort("ascending")
     )
 
 Note that unlike the ``sort`` parameter to positional encoding channels,
@@ -175,8 +175,8 @@ For line marks, the :class:`Order` channel encodes the order in which data point
     driving = data.driving()
 
     alt.Chart(driving).mark_line(point=True).encode(
-        alt.X('miles', scale=alt.Scale(zero=False)),
-        alt.Y('gas', scale=alt.Scale(zero=False)),
+        alt.X('miles').scale(zero=False),
+        alt.Y('gas').scale(zero=False),
         order='year'
     )
 

--- a/doc/user_guide/encodings/index.rst
+++ b/doc/user_guide/encodings/index.rst
@@ -35,7 +35,7 @@ Channel Options
 
 Each encoding channel accepts a number of **channel options** (see :ref:`user-guide-encoding-channel-options` for details) which can be used to further configure
 the chart.
-Altair 5.0 introduced an method-based syntax for setting channel options as a more convenient alternative to the traditional attribute-based syntax described in :ref:`attribute-based-attribute-setting` (but you can still use the attribute-based syntax if you prefer)
+Altair 5.0 introduced a method-based syntax for setting channel options as a more convenient alternative to the traditional attribute-based syntax described in :ref:`attribute-based-attribute-setting` (but you can still use the attribute-based syntax if you prefer).
 
 .. note::
 
@@ -52,7 +52,7 @@ Method-Based Syntax
 The method-based syntax replaces *keyword arguments* with *methods*.
 For example, an ``axis`` option of the ``x`` channel encoding would traditionally be set using the ``axis`` keyword argument: ``x=alt.X('Horsepower', axis=alt.Axis(tickMinStep=50))``. To define the same :class:`X` object using the method-based syntax, we can instead use the more succinct ``x=alt.X('Horsepower').axis(tickMinStep=50)``.
 
-The same technique works with all encoding channels and all channel options.  For example, notice how we make the analogous change with respect to the ``title`` option of the ``y`` channel.  The following produces the same chart as the previous example.
+The same technique works with all encoding channels and all channel options.  For example, notice how we make the analogous change with respect to the ``title`` option of the ``y`` channel. The following produces the same chart as the previous example.
 
 .. altair-plot::
     alt.Chart(cars).mark_point().encode(

--- a/doc/user_guide/encodings/index.rst
+++ b/doc/user_guide/encodings/index.rst
@@ -199,7 +199,7 @@ that contains integers specifying a year:
     pop = data.population.url
 
     base = alt.Chart(pop).mark_bar().encode(
-        alt.Y('mean(people):Q', title='total population')
+        alt.Y('mean(people):Q').title('total population')
     ).properties(
         width=200,
         height=200
@@ -276,7 +276,7 @@ you will need to escape the special characters using a backslash:
     alt.Chart(source).mark_bar().encode(
         x='col\:colon',
         # Remove the backslash in the title
-        y=alt.Y('col\.period', title='col.period'),
+        y=alt.Y('col\.period').title('col.period'),
         # Specify the data type
         color='col\[brackets\]:N',
     )
@@ -313,7 +313,7 @@ In Altair, such an operation looks like this:
 .. altair-plot::
 
    alt.Chart(cars).mark_bar().encode(
-       alt.X('Horsepower', bin=True),
+       alt.X('Horsepower').bin(),
        y='count()'
        # could also use alt.Y(aggregate='count', type='quantitative')
    )
@@ -330,8 +330,8 @@ a "Bubble Plot"):
 .. altair-plot::
 
    alt.Chart(cars).mark_point().encode(
-       alt.X('Horsepower', bin=True),
-       alt.Y('Miles_per_Gallon', bin=True),
+       alt.X('Horsepower').bin(),
+       alt.Y('Miles_per_Gallon').bin(),
        size='count()',
    )
 
@@ -342,16 +342,16 @@ represents the mean of a third quantity, such as acceleration:
 .. altair-plot::
 
    alt.Chart(cars).mark_circle().encode(
-       alt.X('Horsepower', bin=True),
-       alt.Y('Miles_per_Gallon', bin=True),
+       alt.X('Horsepower').bin(),
+       alt.Y('Miles_per_Gallon').bin(),
        size='count()',
-       color='average(Acceleration):Q'
+       color='mean(Acceleration):Q'
    )
 
 Aggregation Functions
 ^^^^^^^^^^^^^^^^^^^^^
 
-In addition to ``count`` and ``average``, there are a large number of available
+In addition to ``count`` and ``mean``, there are a large number of available
 aggregation functions built into Altair:
 
 =========  ===========================================================================  =====================================
@@ -416,51 +416,52 @@ x-axis, using the barley dataset:
 
     base = alt.Chart(barley).mark_bar().encode(
         y='mean(yield):Q',
-        color=alt.Color('mean(yield):Q', legend=None)
+        color=alt.Color('mean(yield):Q').legend(None)
     ).properties(width=100, height=100)
 
     # Sort x in ascending order
     ascending = base.encode(
-        alt.X(field='site', type='nominal', sort='ascending')
+        alt.X('site:N').sort('ascending')
     ).properties(
         title='Ascending'
     )
 
     # Sort x in descending order
     descending = base.encode(
-        alt.X(field='site', type='nominal', sort='descending')
+        alt.X('site:N').sort('descending')
     ).properties(
         title='Descending'
     )
 
     # Sort x in an explicitly-specified order
     explicit = base.encode(
-        alt.X(field='site', type='nominal',
-              sort=['Duluth', 'Grand Rapids', 'Morris',
-                    'University Farm', 'Waseca', 'Crookston'])
+        alt.X('site:N').sort(
+            ['Duluth', 'Grand Rapids', 'Morris', 'University Farm', 'Waseca', 'Crookston']
+        )
     ).properties(
         title='Explicit'
     )
 
     # Sort according to encoding channel
     sortchannel = base.encode(
-        alt.X(field='site', type='nominal',
-              sort='y')
+        alt.X('site:N').sort('y')
     ).properties(
         title='By Channel'
     )
 
     # Sort according to another field
     sortfield = base.encode(
-        alt.X(field='site', type='nominal',
-              sort=alt.EncodingSortField(field='yield', op='mean'))
+        alt.X('site:N').sort(field='yield', op='mean')
     ).properties(
         title='By Yield'
     )
 
     alt.concat(
-        ascending, descending, explicit,
-        sortchannel, sortfield,
+        ascending,
+        descending,
+        explicit,
+        sortchannel,
+        sortfield,
         columns=3
     )
 
@@ -481,16 +482,14 @@ following example where we don't aggregate the data:
 
     # Sort according to encoding channel
     sortchannel = base.encode(
-        alt.X(field='site', type='nominal',
-              sort='y')
+        alt.X('site:N').sort('y')
     ).properties(
         title='By Channel'
     )
 
     # Sort according to another field
     sortfield = base.encode(
-        alt.X(field='site', type='nominal',
-              sort=alt.EncodingSortField(field='yield', op='min'))
+        alt.X('site:N').sort(field='yield', op='max')
     ).properties(
         title='By Min Yield'
     )
@@ -510,12 +509,11 @@ While the above examples show sorting of axes by specifying ``sort`` in the
 .. altair-plot::
 
     alt.Chart(barley).mark_rect().encode(
-        alt.X('mean(yield):Q', sort='ascending'),
-        alt.Y('site:N', sort='descending'),
-        alt.Color('site:N',
-            sort=['Morris', 'Duluth', 'Grand Rapids',
-                  'University Farm', 'Waseca', 'Crookston']
-        )
+        alt.X('mean(yield):Q').sort('ascending'),
+        alt.Y('site:N').sort('descending'),
+        alt.Color('site:N').sort([
+            'Morris', 'Duluth', 'Grand Rapids', 'University Farm', 'Waseca', 'Crookston'
+        ])
     )
 
 Here the y-axis is sorted reverse-alphabetically, while the color legend is
@@ -620,12 +618,10 @@ One caution is that ``alt.datum`` and ``alt.value`` do not possess the (newly in
     
     import altair as alt
 
-    bar = alt.Chart().mark_bar().encode(
+    alt.Chart().mark_bar().encode(
         y=alt.YDatum(220).scale(domain=(0,500)),
         color=alt.value("darkkhaki")
     )
-
-    bar
 
 If you were to instead use ``y=alt.datum(220).scale(domain=(0,500))``, an ``AttributeError`` would be raised, due to the fact that ``alt.datum(220)`` simply returns a Python dictionary and does not possess a ``scale`` attribute.  If you insisted on producing the preceding example using ``alt.datum``, one option would be to use ``y=alt.datum(220, scale={"domain": (0,500)})``.  Nevertheless, the ``alt.YDatum`` approach is strongly preferred to this "by-hand" approach of supplying a dictionary to ``scale``.  As one benefit, tab-completions are available using the ``alt.YDatum`` approach.  For example, typing ``alt.YDatum(220).scale(do`` and hitting ``tab`` in an environment such as JupyterLab will offer ``domain``, ``domainMax``, ``domainMid``, and ``domainMin`` as possible completions.
 

--- a/doc/user_guide/encodings/index.rst
+++ b/doc/user_guide/encodings/index.rst
@@ -30,39 +30,27 @@ For example, here we will visualize the cars dataset using four of the available
        shape='Origin'
    )
 
+Channel Options
+~~~~~~~~~~~~~~~
+
 Each encoding channel accepts a number of **channel options** (see :ref:`user-guide-encoding-channel-options` for details) which can be used to further configure
-the chart. For example, below we adjust the y-axis title and increase the step between the x-axis ticks:
-
-.. altair-plot::
-    import altair as alt
-    from vega_datasets import data
-    cars = data.cars()
-
-    alt.Chart(cars).mark_point().encode(
-        x=alt.X('Horsepower', axis=alt.Axis(tickMinStep=50)),
-        y=alt.Y('Miles_per_Gallon', title="Miles per Gallon"),
-        color='Origin',
-        shape='Origin'
-    )
-
+the chart.
+Altair 5.0 introduced an method-based syntax for setting channel options as a more convenient alternative to the traditional attribute-based syntax described in :ref:`attribute-based-attribute-setting` (but you can still use the attribute-based syntax if you prefer)
 
 .. _method-based-attribute-setting:
 
-Alternative Syntax for Channel Options
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Method-Based Syntax
+^^^^^^^^^^^^^^^^^^^
 
-Altair 5.0 introduced an alternative method-based syntax for setting channel options.  In the example above, the ``axis`` option of the ``x`` channel encoding is set using the ``axis`` keyword argument: ``x=alt.X('Horsepower', axis=alt.Axis(tickMinStep=50))``.  To define the same :class:`X` object using the alternative method-based syntax, we can use ``x=alt.X('Horsepower').axis(tickMinStep=50)``.  In other words, the use of the ``axis`` keyword argument is replaced by the use of the ``axis`` method.
+The method-based syntax replaces *keyword arguments* with *methods*.
+For example, an ``axis`` option of the ``x`` channel encoding would traditionally be set using the ``axis`` keyword argument: ``x=alt.X('Horsepower', axis=alt.Axis(tickMinStep=50))``. To define the same :class:`X` object using the method-based syntax, we can instead use the more succinct ``x=alt.X('Horsepower').axis(tickMinStep=50)``.
 
 The same technique works with all encoding channels and all channel options.  For example, notice how we make the analogous change with respect to the ``title`` option of the ``y`` channel.  The following produces the same chart as the previous example.
 
 .. altair-plot::
-    import altair as alt
-    from vega_datasets import data
-    cars = data.cars()
-
     alt.Chart(cars).mark_point().encode(
-        x=alt.X('Horsepower').axis(tickMinStep=50),
-        y=alt.Y('Miles_per_Gallon').title('Miles per Gallon'),
+        alt.X('Horsepower').axis(tickMinStep=50),
+        alt.Y('Miles_per_Gallon').title('Miles per Gallon'),
         color='Origin',
         shape='Origin'
     )
@@ -70,16 +58,45 @@ The same technique works with all encoding channels and all channel options.  Fo
 These option-setter methods can also be chained together, as in the following, in which we set the ``axis``, ``bin``, and ``scale`` options of the ``x`` channel by using the corresponding methods (``axis``, ``bin``, and ``scale``).  We can break the ``x`` definition over multiple lines to improve readability.  (This is valid syntax because of the enclosing parentheses from ``encode``.)
 
 .. altair-plot::
-    import altair as alt
-    from vega_datasets import data
-    cars = data.cars()
-
     alt.Chart(cars).mark_point().encode(
-        x=alt.X('Horsepower')
-                .axis(ticks=False)
-                .bin(maxbins=10)
-                .scale(domain=(30,300), reverse=True),
-        y=alt.Y('Miles_per_Gallon').title('Miles per Gallon'),
+        alt.X('Horsepower')
+            .axis(ticks=False)
+            .bin(maxbins=10)
+            .scale(domain=(30,300), reverse=True),
+        alt.Y('Miles_per_Gallon').title('Miles per Gallon'),
+        color='Origin',
+        shape='Origin'
+    )
+
+
+.. _attribute-based-attribute-setting:
+
+Attribute-Based Syntax
+^^^^^^^^^^^^^^^^^^^^^^
+
+The two examples from the section above
+would look as follows with the traditional attribute-based syntax:
+
+.. altair-plot::
+    alt.Chart(cars).mark_point().encode(
+        alt.X('Horsepower', axis=alt.Axis(tickMinStep=50)),
+        alt.Y('Miles_per_Gallon', title="Miles per Gallon"),
+        color='Origin',
+        shape='Origin'
+    )
+
+For specs making extensive use of channel options,
+the attribute-based syntax can become quite verbose:
+
+.. altair-plot::
+    alt.Chart(cars).mark_point().encode(
+        alt.X(
+            'Horsepower',
+            axis=alt.Axis(ticks=False),
+            bin=alt.Bin(maxbins=10),
+            scale=alt.Scale(domain=(30,300), reverse=True)
+        ),
+        alt.Y('Miles_per_Gallon', title='Miles per Gallon'),
         color='Origin',
         shape='Origin'
     )

--- a/doc/user_guide/encodings/index.rst
+++ b/doc/user_guide/encodings/index.rst
@@ -37,6 +37,13 @@ Each encoding channel accepts a number of **channel options** (see :ref:`user-gu
 the chart.
 Altair 5.0 introduced an method-based syntax for setting channel options as a more convenient alternative to the traditional attribute-based syntax described in :ref:`attribute-based-attribute-setting` (but you can still use the attribute-based syntax if you prefer)
 
+.. note::
+
+    With the release of Altair 5,
+    the documentation was updated to prefer the method-based syntax.
+    The gallery examples still include the attribute-based syntax
+    in addition to the method-based syntax.
+
 .. _method-based-attribute-setting:
 
 Method-Based Syntax

--- a/doc/user_guide/interactions.rst
+++ b/doc/user_guide/interactions.rst
@@ -379,7 +379,7 @@ with a matching ``Origin``.
     selection = alt.selection_point(fields=['Origin'])
     color = alt.condition(
         selection,
-        alt.Color('Origin:N', legend=None),
+        alt.Color('Origin:N').legend(None),
         alt.value('lightgray')
     )
 
@@ -391,7 +391,7 @@ with a matching ``Origin``.
     )
 
     legend = alt.Chart(cars).mark_point().encode(
-        y=alt.Y('Origin:N', axis=alt.Axis(orient='right')),
+        alt.Y('Origin:N').axis(orient='right'),
         color=color
     ).add_params(
         selection
@@ -415,7 +415,7 @@ cylinders:
     selection = alt.selection_point(fields=['Origin', 'Cylinders'])
     color = alt.condition(
         selection,
-        alt.Color('Origin:N', legend=None),
+        alt.Color('Origin:N').legend(None),
         alt.value('lightgray')
     )
 
@@ -427,7 +427,7 @@ cylinders:
     )
 
     legend = alt.Chart(cars).mark_rect().encode(
-        y=alt.Y('Origin:N', axis=alt.Axis(orient='right')),
+        alt.Y('Origin:N').axis(orient='right'),
         x='Cylinders:O',
         color=color
     ).add_params(
@@ -537,7 +537,7 @@ where a drop-down is used to highlight cars of a specific ``Origin``:
     selection = alt.selection_point(fields=['Origin'], bind=input_dropdown)
     color = alt.condition(
         selection,
-        alt.Color('Origin:N', legend=None),
+        alt.Color('Origin:N').legend(None),
         alt.value('lightgray')
     )
 
@@ -589,7 +589,7 @@ after a selection has been made in a radio button or drop-down
         y='Miles_per_Gallon:Q',
         # We need to set a constant domain to preserve the colors
         # when only one region is shown at a time
-        color=alt.Color('Origin:N', scale=alt.Scale(domain=options)),
+        color=alt.Color('Origin:N').scale(domain=options),
     ).add_params(
         selection
     ).transform_filter(
@@ -799,7 +799,7 @@ There is no direct way to map an encoding channel to a widget in order to dynami
     )
 
     alt.Chart(data.cars.url).mark_circle().encode(
-        x=alt.X('x:Q', title=''),
+        x=alt.X('x:Q').title(''),
         y='Miles_per_Gallon:Q',
         color='Origin:N'
     ).transform_calculate(

--- a/doc/user_guide/interactions.rst
+++ b/doc/user_guide/interactions.rst
@@ -676,7 +676,8 @@ which would have been the case if we just wrote ``xval < selector``.
        color=alt.condition(
            alt.datum.xval < selector,
            # 'datum.xval < SelectorName',  # An equivalent alternative
-           alt.value('red'), alt.value('blue')
+           alt.value('red'),
+           alt.value('blue')
        )
     ).add_params(
        selector
@@ -703,7 +704,8 @@ points based on whether they are smaller or larger than the value:
         color=alt.condition(
             alt.datum.xval < selector.cutoff,
             # 'datum.xval < SelectorName.cutoff',  # An equivalent alternative
-            alt.value('red'), alt.value('blue')
+            alt.value('red'),
+            alt.value('blue')
         )
     ).add_params(
         selector
@@ -747,7 +749,7 @@ just if the value of the check box is True (checked) or False (unchecked):
         y='Miles_per_Gallon:Q',
         size=alt.condition(
             param_checkbox,
-            alt.Size('Acceleration:Q'),
+            'Acceleration:Q',
             alt.value(25)
         )
     ).add_params(
@@ -883,8 +885,8 @@ Using these two expressions defined as a parameter, we can connect them to an en
     param_color_py_expr = alt.param(expr=alt.expr.if_(param_width < 200, 'red', 'black'))
 
     chart = alt.Chart(df).mark_point().encode(
-        x=alt.X('xval').axis(titleColor=param_color_js_expr),
-        y=alt.Y('yval').axis(titleColor=param_color_py_expr)
+        alt.X('xval').axis(titleColor=param_color_js_expr),
+        alt.Y('yval').axis(titleColor=param_color_py_expr)
     ).add_params(
         param_width,
         param_color_js_expr,
@@ -924,8 +926,8 @@ Another option to include an expression within a chart specification is as a val
     # which is why we use this nested quotation.
     title=alt.Title(alt.expr(f'"This chart is " + {param_width.name} + " px wide"'))
     alt.Chart(df, title=title).mark_point().encode(
-        x=alt.X('xval'),
-        y=alt.Y('yval')
+        alt.X('xval'),
+        alt.Y('yval')
     ).add_params(
         param_width,
     )
@@ -959,8 +961,8 @@ To try this out, you can type ``mazda|ford`` in the search input box below.
         opacity=alt.condition(
             alt.expr.test(alt.expr.regexp(search_input, 'i'), alt.datum.Name),
             # f"test(regexp({search_input.name}, 'i'), datum.Name)",  # Equivalent js alternative
-            alt.value(0.8),
-            alt.value(0.1)
+            alt.value(1),
+            alt.value(0.05)
         )
     ).add_params(
         search_input

--- a/doc/user_guide/large_datasets.rst
+++ b/doc/user_guide/large_datasets.rst
@@ -184,7 +184,7 @@ it is convenient to pass the unaggregated data to Altair:
 
     alt.Chart(source).mark_bar().encode(
         x="sum(yield):Q",
-        y=alt.Y("site:N", sort="-x")
+        y=alt.Y("site:N").sort("-x")
     )
 
 
@@ -197,14 +197,13 @@ only the necessary columns:
 
     alt.Chart(source[["yield", "site"]]).mark_bar().encode(
         x="sum(yield):Q",
-        y=alt.Y("site:N",
-        sort="-x")
+        y=alt.Y("site:N").sort("-x")
     )
 
 You could also precalculate the sum in Pandas which would reduce the size of the dataset even more:
 
 .. altair-plot::
-    
+
     import altair as alt
     from vega_datasets import data
 
@@ -215,7 +214,7 @@ You could also precalculate the sum in Pandas which would reduce the size of the
 
     alt.Chart(source_aggregated).mark_bar().encode(
         x="sum_yield:Q",
-        y=alt.Y("site:N", sort="-x")
+        y=alt.Y("site:N").sort("-x")
     )
 
 
@@ -233,7 +232,7 @@ in Altair.
     alt.Chart(df).mark_boxplot().encode(
         x="Miles_per_Gallon:Q",
         y="Origin:N",
-        color=alt.Color("Origin", legend=None)
+        color=alt.Color("Origin").legend(None)
     )
 
 If you have a lot of data, you can perform the necessary calculations in Pandas and only
@@ -308,14 +307,14 @@ summary statistics to Altair instead of the full dataset.
     )
 
     rules = base.mark_rule().encode(
-        x=alt.X("lower", title="Miles_per_Gallon"),
+        x=alt.X("lower").title("Miles_per_Gallon"),
         x2="upper",
     )
 
     bars = base.mark_bar(size=14).encode(
         x="25%",
         x2="75%",
-        color=alt.Color("Origin", legend=None),
+        color=alt.Color("Origin").legend(None),
     )
 
     ticks = base.mark_tick(color="white", size=14).encode(

--- a/doc/user_guide/large_datasets.rst
+++ b/doc/user_guide/large_datasets.rst
@@ -379,4 +379,4 @@ display.
 .. _VegaFusion mime renderer: https://vegafusion.io/mime_renderer.html
 .. _VegaFusion widget renderer: https://vegafusion.io/widget_renderer.html
 .. _vl-convert: https://github.com/vega/vl-convert
-.. _altair_saver: http://github.com/altair-viz/altair_saver/
+.. _altair_saver: https://github.com/altair-viz/altair_saver/

--- a/doc/user_guide/marks/arc.rst
+++ b/doc/user_guide/marks/arc.rst
@@ -113,8 +113,8 @@ You can also add a text layer to add labels to a pie chart.
     )
 
     base = alt.Chart(source).encode(
-        theta=alt.Theta("value:Q", stack=True),
-        color=alt.Color("category:N", legend=None),
+        theta=alt.Theta("value:Q").stack(True),
+        color=alt.Color("category:N").legend(None),
     )
 
     pie = base.mark_arc(outerRadius=120)

--- a/doc/user_guide/marks/area.rst
+++ b/doc/user_guide/marks/area.rst
@@ -86,7 +86,7 @@ to ``true`` or an object defining a property of the overlaying point marks, we c
         x="date:T",
         y="price:Q",
     ).transform_filter(
-        datum.symbol == "GOOG"
+        alt.datum.symbol == "GOOG"
     )
 
 Instead of using a single color as the fill color of the area, we can set it to a gradient.
@@ -99,7 +99,7 @@ In this example, we are also customizing the overlay. For more information about
 
     source = data.stocks()
 
-    alt.Chart(source).transform_filter('datum.symbol==="GOOG"').mark_area(
+    alt.Chart(source).transform_filter(alt.datum.symbol=="GOOG").mark_area(
         line={"color": "darkgreen"},
         color=alt.Gradient(
             gradient="linear",
@@ -129,9 +129,9 @@ Adding a color field to area chart creates stacked area chart by default. For ex
     source = data.unemployment_across_industries.url
 
     alt.Chart(source).mark_area().encode(
-        alt.X("yearmonth(date):T", axis=alt.Axis(format="%Y", domain=False, tickSize=0)),
+        alt.X("yearmonth(date):T").axis(format="%Y", domain=False, tickSize=0),
         alt.Y("sum(count):Q"),
-        alt.Color("series:N", scale=alt.Scale(scheme="category20b")),
+        alt.Color("series:N").scale(scheme="category20b"),
     )
 
 
@@ -147,9 +147,9 @@ You can also create a normalized stacked area chart by setting ``stack`` to ``"n
     source = data.unemployment_across_industries.url
 
     alt.Chart(source).mark_area().encode(
-        alt.X("yearmonth(date):T", axis=alt.Axis(format="%Y", domain=False, tickSize=0)),
-        alt.Y("sum(count):Q", stack="normalize"),
-        alt.Color("series:N", scale=alt.Scale(scheme="category20b")),
+        alt.X("yearmonth(date):T").axis(format="%Y", domain=False, tickSize=0),
+        alt.Y("sum(count):Q").stack("normalize"),
+        alt.Color("series:N").scale(scheme="category20b"),
     )
 
 
@@ -166,9 +166,9 @@ Adding the ``interactive`` method allows for zooming and panning the x-scale.
     source = data.unemployment_across_industries.url
 
     alt.Chart(source).mark_area().encode(
-        alt.X("yearmonth(date):T", axis=alt.Axis(format="%Y", domain=False, tickSize=0)),
-        alt.Y("sum(count):Q", stack="center", axis=None),
-        alt.Color("series:N", scale=alt.Scale(scheme="category20b")),
+        alt.X("yearmonth(date):T").axis(format="%Y", domain=False, tickSize=0),
+        alt.Y("sum(count):Q").stack("center").axis(None),
+        alt.Color("series:N").scale(scheme="category20b"),
     ).interactive()
 
 
@@ -184,10 +184,8 @@ Specifying ``x2`` or ``y2`` for the quantitative axis of area marks produce rang
     source = data.seattle_weather()
 
     alt.Chart(source).mark_area(opacity=0.7).encode(
-        alt.X("monthdate(date):T", title="Date"),
-        alt.Y("mean(temp_max):Q", title="Daily Temperature Range (C)"),
-        alt.Y2(
-            "mean(temp_min):Q",
-        ),
+        alt.X("monthdate(date):T").title("Date"),
+        alt.Y("mean(temp_max):Q").title("Daily Temperature Range (C)"),
+        alt.Y2("mean(temp_min):Q"),
     ).properties(width=600, height=300)
 

--- a/doc/user_guide/marks/area.rst
+++ b/doc/user_guide/marks/area.rst
@@ -99,7 +99,7 @@ In this example, we are also customizing the overlay. For more information about
 
     source = data.stocks()
 
-    alt.Chart(source).transform_filter(alt.datum.symbol=="GOOG").mark_area(
+    alt.Chart(source).transform_filter(alt.datum.symbol == "GOOG").mark_area(
         line={"color": "darkgreen"},
         color=alt.Gradient(
             gradient="linear",

--- a/doc/user_guide/marks/bar.rst
+++ b/doc/user_guide/marks/bar.rst
@@ -27,7 +27,7 @@ Bar Mark Properties
     )
 
     alt.Chart(source).mark_bar(cornerRadius=corner_var).encode(
-        x=alt.X("a:N", axis=alt.Axis(labelAngle=0)),
+        x=alt.X("a:N").axis(labelAngle=0),
         y="b:Q",
     ).add_params(corner_var)
 
@@ -54,7 +54,7 @@ Mapping a quantitative field to either ``x`` or ``y`` of the ``bar`` mark produc
     source = data.population.url
 
     alt.Chart(source).mark_bar().encode(
-        alt.X("sum(people):Q", title="Population")
+        alt.X("sum(people):Q").title("Population")
     ).transform_filter(
         datum.year == 2000
     )
@@ -72,7 +72,7 @@ If we map a different discrete field to the ``y`` channel, we can produce a hori
     source = data.population.url
 
     alt.Chart(source).mark_bar().encode(
-        alt.X("sum(people):Q", title="Population"),
+        alt.X("sum(people):Q").title("Population"),
         alt.Y("age:O"),
     ).transform_filter(
         datum.year == 2000
@@ -95,7 +95,7 @@ bars on continuous scales will be set based on the ``continuousBandSize`` config
     source = data.seattle_weather()
 
     alt.Chart(source).mark_bar().encode(
-        alt.X("month(date):T", title="Date"),
+        alt.X("month(date):T").title("Date"),
         alt.Y("mean(precipitation):Q"),
     )
 
@@ -112,7 +112,7 @@ If the data is not pre-aggregated (i.e. each record in the data field represents
     source = data.movies.url
 
     alt.Chart(source).mark_bar().encode(
-        alt.X("IMDB_Rating:Q", bin=True),
+        alt.X("IMDB_Rating:Q").bin(),
         y='count()',
     )
 

--- a/doc/user_guide/marks/boxplot.rst
+++ b/doc/user_guide/marks/boxplot.rst
@@ -32,7 +32,7 @@ By default, the extent is ``1.5``.
     source = data.cars()
 
     alt.Chart(source).mark_boxplot().encode(
-        alt.X("Miles_per_Gallon:Q", scale=alt.Scale(zero=False))
+        alt.X("Miles_per_Gallon:Q").scale(zero=False)
     )
 
 
@@ -45,7 +45,7 @@ By default, the extent is ``1.5``.
     source = data.cars()
 
     alt.Chart(source).mark_boxplot(extent="min-max").encode(
-        alt.X("Miles_per_Gallon:Q", scale=alt.Scale(zero=False)),
+        alt.X("Miles_per_Gallon:Q").scale(zero=False),
         alt.Y("Origin:N"),
     )
 
@@ -64,7 +64,7 @@ A box plot’s orientation is automatically determined by the continuous field a
     source = data.cars()
 
     alt.Chart(source).mark_boxplot().encode(
-        alt.Y("Miles_per_Gallon:Q", scale=alt.Scale(zero=False))
+        alt.Y("Miles_per_Gallon:Q").scale(zero=False)
     )
 
 2D box plot shows the distribution of a continuous field, broken down by categories.
@@ -86,8 +86,8 @@ An example of a box plot where the ``color`` encoding channel is specified.
 
     alt.Chart(source).mark_boxplot(extent="min-max").encode(
         alt.X("Origin:N"),
-        alt.Y("Miles_per_Gallon:Q", scale=alt.Scale(zero=False)),
-        alt.Color("Origin:N", legend=None),
+        alt.Y("Miles_per_Gallon:Q").scale(zero=False),
+        alt.Color("Origin:N").legend(None),
     )
 
 
@@ -105,7 +105,7 @@ If the field in the tooltip encoding is unaggregated, it replaces the tooltips o
     source = data.cars()
 
     alt.Chart(source).mark_boxplot(extent="min-max").encode(
-        alt.X("Miles_per_Gallon:Q", scale=alt.Scale(zero=False)),
+        alt.X("Miles_per_Gallon:Q").scale(zero=False),
         alt.Y("Origin:N"),
         alt.Tooltip("mean(Miles_per_Gallon)"),
     )

--- a/doc/user_guide/marks/errorband.rst
+++ b/doc/user_guide/marks/errorband.rst
@@ -116,7 +116,7 @@ A **1D error band** shows the error range of a continuous field; it can be used 
     source = data.cars.url
 
     band = alt.Chart(source).mark_errorband(extent="stdev").encode(
-        alt.Y("Miles_per_Gallon:Q", title="Miles per Gallon")
+        alt.Y("Miles_per_Gallon:Q").title("Miles per Gallon")
     )
 
     points = alt.Chart(source).mark_point().encode(
@@ -142,7 +142,7 @@ A **2D error** band shows the error range of a continuous field for each dimensi
 
     band = alt.Chart(source).mark_errorband(extent="ci").encode(
         x="Year",
-        y=alt.Y("Miles_per_Gallon", title="Miles/Gallon"),
+        y=alt.Y("Miles_per_Gallon").title("Miles/Gallon"),
     )
 
     band + line
@@ -162,11 +162,9 @@ Here is an example of a ``errorband`` with the ``color`` encoding channel set to
 
     alt.Chart(source).mark_errorband(extent="ci", borders=True).encode(
         x="year(Year)",
-        y=alt.Y(
-            "Miles_per_Gallon:Q",
-            scale=alt.Scale(zero=False),
-            title="Miles per Gallon (95% CIs)",
-        ),
+        y=alt.Y("Miles_per_Gallon:Q")
+            .scale(zero=False),
+            .title("Miles per Gallon (95% CIs)"),
         color=alt.value("black"),
     )
 

--- a/doc/user_guide/marks/errorbar.rst
+++ b/doc/user_guide/marks/errorbar.rst
@@ -34,7 +34,7 @@ If the data is not aggregated yet, Altair will aggregate the data based on the `
     source = data.barley()
 
     error_bars = alt.Chart(source).mark_errorbar().encode(
-        x=alt.X('yield:Q', scale=alt.Scale(zero=False)),
+        x=alt.X('yield:Q').scale(zero=False),
         y=alt.Y('variety:N')
     )
 
@@ -42,7 +42,7 @@ If the data is not aggregated yet, Altair will aggregate the data based on the `
         filled=True,
         color="black",
     ).encode(
-        x=alt.X("yield:Q", aggregate="mean"),
+        x=alt.X("mean(yield)"),
         y=alt.Y("variety:N"),
     )
 
@@ -57,12 +57,12 @@ If the data is not aggregated yet, Altair will aggregate the data based on the `
     source = data.barley()
 
     error_bars = alt.Chart(source).mark_errorbar(extent="stdev").encode(
-        x=alt.X("yield:Q", scale=alt.Scale(zero=False)),
+        x=alt.X("yield:Q").scale(zero=False),
         y=alt.Y("variety:N"),
     )
 
     points = alt.Chart(source).mark_point(filled=True, color="black").encode(
-        x=alt.X("yield:Q", aggregate="mean"),
+        x=alt.X("mean(yield)"),
         y=alt.Y("variety:N"),
     )
 
@@ -78,7 +78,7 @@ If the data is not aggregated yet, Altair will aggregate the data based on the `
     source = data.barley()
 
     error_bars = alt.Chart(source).mark_errorbar(extent="iqr").encode(
-        x=alt.X("yield:Q", scale=alt.Scale(zero=False)),
+        x=alt.X("yield:Q").scale(zero=False),
         y=alt.Y("variety:N"),
     )
 
@@ -86,7 +86,7 @@ If the data is not aggregated yet, Altair will aggregate the data based on the `
         filled=True,
         color="black"
     ).encode(
-        x=alt.X("yield:Q", aggregate="mean"),
+        x=alt.X("mean(yield)"),
         y=alt.Y("variety:N"),
     )
 
@@ -109,7 +109,7 @@ If the data is already pre-aggregated with low and high values of the error bars
     })
 
     bar = alt.Chart(source).mark_errorbar().encode(
-        alt.X("upper_yield:Q", scale=alt.Scale(zero=False), title="yield"),
+        alt.X("upper_yield:Q").scale(zero=False).title("yield"),
         alt.X2("lower_yield:Q"),
         alt.Y("variety:N"),
     )
@@ -138,7 +138,7 @@ If the data is already pre-aggregated with center and error values of the error 
     })
 
     bar = alt.Chart(source).mark_errorbar().encode(
-        x=alt.X("yield_center:Q", scale=alt.Scale(zero=False), title="yield"),
+        x=alt.X("yield_center:Q").scale(zero=False).title("yield"),
         xError=("yield_error:Q"),
         y=alt.Y("variety:N"),
     )
@@ -170,14 +170,14 @@ The orientation of an error bar is automatically determined by the continuous fi
     source = data.barley()
 
     error_bars = alt.Chart(source).mark_errorbar().encode(
-        alt.Y("yield:Q", scale=alt.Scale(zero=False))
+        alt.Y("yield:Q").scale(zero=False)
     )
 
     points = alt.Chart(source).mark_point(
         filled=True,
         color="black"
     ).encode(
-        alt.Y("yield:Q", aggregate="mean")
+        alt.Y("mean(yield)")
     )
 
     error_bars + points
@@ -193,7 +193,7 @@ For 2D error bars with one continuous field and one discrete field, the error ba
     source = data.barley()
 
     error_bars = alt.Chart(source).mark_errorbar(extent="stdev").encode(
-        alt.Y("yield:Q", scale=alt.Scale(zero=False)),
+        alt.Y("yield:Q").scale(zero=False),
         alt.X("variety:N"),
     )
 
@@ -201,7 +201,7 @@ For 2D error bars with one continuous field and one discrete field, the error ba
         filled=True,
         color="black",
     ).encode(
-        alt.Y("yield:Q", aggregate="mean"),
+        alt.Y("mean(yield)"),
         alt.X("variety:N"),
     )
 
@@ -220,7 +220,7 @@ Here is an example of a ``errorbar`` with the ``color`` encoding channel set to 
     source = data.barley()
 
     error_bars = alt.Chart(source).mark_errorbar(ticks=True).encode(
-        alt.X("yield:Q", scale=alt.Scale(zero=False)),
+        alt.X("yield:Q").scale(zero=False),
         alt.Y("variety:N"),
         color=alt.value("#4682b4"),
     )
@@ -229,7 +229,7 @@ Here is an example of a ``errorbar`` with the ``color`` encoding channel set to 
         filled=True,
         color="black"
     ).encode(
-        alt.X("yield:Q", aggregate="mean"),
+        alt.X("mean(yield)"),
         alt.Y("variety:N"),
     )
 
@@ -246,7 +246,7 @@ You can add custom tooltips to error bars. The custom tooltip will override the 
     source = data.barley()
 
     alt.Chart(source).mark_errorbar().encode(
-        alt.X("yield:Q", scale=alt.Scale(zero=False)),
+        alt.X("yield:Q").scale(zero=False),
         alt.Y("variety:N"),
         tooltip="variety:N",
     )

--- a/doc/user_guide/marks/geoshape.rst
+++ b/doc/user_guide/marks/geoshape.rst
@@ -471,7 +471,7 @@ will make the following not work for geographic visualization:
 
     alt.Chart(gdf_comb).mark_geoshape().encode(
         color=alt.Color('value:Q'),
-        facet=alt.Facet('variable:N', columns=3)
+        facet=alt.Facet('variable:N').columns(3)
     ).properties(
         width=180,
         height=130
@@ -545,7 +545,7 @@ populous states. Using an ``alt.selection_point()`` we define a selection parame
             x="population",
             opacity=alt.condition(click_state, alt.value(1), alt.value(0.2)),
             color="population",
-            y=alt.Y("state", sort="-x"),
+            y=alt.Y("state").sort("-x"),
         )
     )
 

--- a/doc/user_guide/marks/line.rst
+++ b/doc/user_guide/marks/line.rst
@@ -197,12 +197,16 @@ The same method can be used to group lines for a ranged dot plot.
     source = data.countries()
 
     base = alt.Chart(source).encode(
-        alt.X("life_expect:Q", title="Life Expectancy (years)", scale=alt.Scale(zero=False)),
-        alt.Y("country:N", title="Country", axis=alt.Axis(offset=5, ticks=False, minExtent=70, domain=False)),
+        alt.X("life_expect:Q")
+            .scale(zero=False)
+            .title("Life Expectancy (years)"),
+        alt.Y("country:N")
+            .axis(offset=5, ticks=False, minExtent=70, domain=False)
+            .title("Country")
     ).transform_filter(
         alt.FieldOneOfPredicate(field="country", oneOf=["China", "India", "United States", "Indonesia", "Brazil"])
     )
-    
+
 
     line = base.mark_line().encode(
         detail="country",
@@ -212,9 +216,7 @@ The same method can be used to group lines for a ranged dot plot.
     )
 
     point = base.mark_point(filled=True).encode(
-        alt.Color(
-            field="year", scale=alt.Scale(range=["#e6959c", "#911a24"], domain=[1995, 2000])
-        ),
+        alt.Color("year").scale(range=["#e6959c", "#911a24"], domain=[1995, 2000]),
         size=alt.value(100),
         opacity=alt.value(1),
     )
@@ -271,8 +273,8 @@ For example, to show a pattern of data change over time between gasoline price a
     source = data.driving()
 
     alt.Chart(source).mark_line(point=True).encode(
-        alt.X("miles", scale=alt.Scale(zero=False)),
-        alt.Y("gas", scale=alt.Scale(zero=False)),
+        alt.X("miles").scale(zero=False),
+        alt.Y("gas").scale(zero=False),
         order="year",
     )
 

--- a/doc/user_guide/marks/point.rst
+++ b/doc/user_guide/marks/point.rst
@@ -133,8 +133,8 @@ Fields can also be encoded in the scatter plot using the ``color`` or ``shape`` 
     source = data.cars()
 
     alt.Chart(source).mark_point().encode(
-        alt.X("Miles_per_Gallon:Q", scale=alt.Scale(zero=False)),
-        alt.Y("Horsepower:Q", scale=alt.Scale(zero=False)),
+        alt.X("Miles_per_Gallon:Q").scale(zero=False),
+        alt.Y("Horsepower:Q").scale(zero=False),
         color="Origin:N",
         shape="Origin:N",
     )
@@ -174,11 +174,9 @@ We can also use point mark with ``wedge`` as ``shape`` and ``angle`` encoding to
     alt.Chart(source).mark_point(shape="wedge", filled=True).encode(
         latitude="latitude",
         longitude="longitude",
-        color=alt.Color(
-            "dir", scale=alt.Scale(domain=[0, 360], scheme="rainbow"), legend=None
-        ),
-        angle=alt.Angle("dir", scale=alt.Scale(domain=[0, 360], range=[180, 540])),
-        size=alt.Size("speed", scale=alt.Scale(rangeMax=500)),
+        color=alt.Color("dir").scale(domain=[0, 360], scheme="rainbow").legend(None),
+        angle=alt.Angle("dir").scale(domain=[0, 360], range=[180, 540]),
+        size=alt.Size("speed").scale(rangeMax=500),
     ).project("equalEarth")
 
 Geo Point

--- a/doc/user_guide/marks/rect.rst
+++ b/doc/user_guide/marks/rect.rst
@@ -58,9 +58,9 @@ Using the ``rect`` marks with discrete fields on ``x`` and ``y`` channels create
     source = data.seattle_weather()
 
     alt.Chart(source).mark_rect().encode(
-        alt.X("date(date):O", title="Day", axis=alt.Axis(labelAngle=0, format="%e")),
-        alt.Y("month(date):O", title="Month"),
-        alt.Color("max(temp_max):Q", title="Max Temp"),
+        alt.X("date(date):O").axis(labelAngle=0, format="%e").title("Day"),
+        alt.Y("month(date):O").title("Month"),
+        alt.Color("max(temp_max):Q").title("Max Temp"),
     )
 
 

--- a/doc/user_guide/marks/rule.rst
+++ b/doc/user_guide/marks/rule.rst
@@ -114,7 +114,7 @@ We can also use a rule mark to show global mean value over a histogram.
 
     base = alt.Chart(source)
     bar = base.mark_bar().encode(
-        x=alt.X("IMDB_Rating:Q", bin=True, axis=None),
+        x=alt.X("IMDB_Rating:Q").bin().axis(None),
         y="count()"
     )
     rule = base.mark_rule(color="red").encode(

--- a/doc/user_guide/marks/text.rst
+++ b/doc/user_guide/marks/text.rst
@@ -60,8 +60,8 @@ Text Mark Properties
     )
 
     base = alt.Chart(source).encode(
-        x=alt.X("a:Q", axis=alt.Axis(labelAngle=0), scale=alt.Scale(domain=[0, 100])),
-        y=alt.Y("b:Q", scale=alt.Scale(domain=[0, 100])),
+        x=alt.X("a:Q").axis(labelAngle=0).scale(domain=[0, 100]),
+        y=alt.Y("b:Q").scale(domain=[0, 100]),
     )
 
     pts = base.mark_point()
@@ -117,16 +117,14 @@ Text Table Heatmap
         num_cars="count()",
         groupby=["Origin", "Cylinders"],
     ).encode(
-        alt.X("Cylinders:O", scale=alt.Scale(paddingInner=0)),
-        alt.Y("Origin:O", scale=alt.Scale(paddingInner=0)),
+        alt.X("Cylinders:O").scale(paddingInner=0),
+        alt.Y("Origin:O").scale(paddingInner=0),
     )
 
     heatmap = base.mark_rect().encode(
-        color=alt.Color(
-            "num_cars:Q",
-            scale=alt.Scale(scheme="viridis"),
-            legend=alt.Legend(direction="horizontal"),
-        )
+        alt.Color("num_cars:Q")
+            .scale(scheme="viridis")
+            .legend(direction="horizontal")
     )
 
     text = base.mark_text(baseline="middle").encode(
@@ -155,7 +153,7 @@ You can also use ``text`` marks as labels for other marks and set offset (``dx``
 
     bar = alt.Chart(source).mark_bar().encode(
         y="a:N",
-        x=alt.X("b:Q", scale=alt.Scale(domain=[0, 60]))
+        x=alt.X("b:Q").scale(domain=[0, 60])
     )
     text = bar.mark_text(
         align="left",

--- a/doc/user_guide/marks/trail.rst
+++ b/doc/user_guide/marks/trail.rst
@@ -36,36 +36,35 @@ Comet Chart Showing Changes Between Two States
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. altair-plot::
     import altair as alt
-    import vega_datasets
+    from vega_datasets import data
 
-    (
-        alt.Chart(vega_datasets.data.barley.url)
-        .transform_pivot("year", value="yield", groupby=["variety", "site"])
-        .transform_fold(["1931", "1932"], as_=["year", "yield"])
-        .transform_calculate(calculate="datum['1932'] - datum['1931']", as_="delta")
-        .mark_trail()
-        .encode(
-            x=alt.X("year:O", title=None),
-            y=alt.Y("variety:N", title="Variety"),
-            size=alt.Size(
-                "yield:Q",
-                scale=alt.Scale(range=[0, 12]),
-                legend=alt.Legend(values=[20, 60], title="Barley Yield (bushels/acre)"),
-            ),
-            color=alt.Color(
-                "delta:Q",
-                scale=alt.Scale(domainMid=0),
-                legend=alt.Legend(title="Yield Delta (%)"),
-            ),
-            tooltip=alt.Tooltip(["year:O", "yield:Q"]),
-            column=alt.Column("site:N", title="Site"),
-        )
-        .configure_view(stroke=None)
-        .configure_legend(
-            orient="bottom",
-            direction="horizontal"
-        )
-        .properties(
-            title="Barley Yield comparison between 1932 and 1931"
-        )
+    alt.Chart(data.barley.url).transform_pivot(
+        "year",
+        value="yield",
+        groupby=["variety", "site"]
+    ).transform_fold(
+        ["1931", "1932"],
+        as_=["year", "yield"]
+    ).transform_calculate(
+        calculate="datum['1932'] - datum['1931']",
+        as_="delta"
+    ).mark_trail().encode(
+        alt.X("year:O").title(None),
+        alt.Y("variety:N").title("Variety"),
+        alt.Size("yield:Q")
+            .scale(range=[0, 12])
+            .legend(values=[20, 60])
+            .title("Barley Yield (bushels/acre)"),
+        alt.Color("delta:Q")
+            .scale(domainMid=0)
+            .title("Yield Delta (%)"),
+        alt.Tooltip(["year:O", "yield:Q"]),
+        alt.Column("site:N").title("Site"),
+    ).configure_legend(
+        orient='bottom',
+        direction='horizontal'
+    ).configure_view(
+        stroke=None
+    ).properties(
+        title="Barley Yield comparison between 1932 and 1931"
     )

--- a/doc/user_guide/scale_resolve.rst
+++ b/doc/user_guide/scale_resolve.rst
@@ -60,16 +60,14 @@ each layer.
 
     source = data.cars()
 
-    base = alt.Chart(source).encode(
-            alt.X('year(Year):T')
-    )
+    base = alt.Chart(source).encode(x='year(Year):T')
 
     line_A = base.mark_line(color='#5276A7').encode(
-        alt.Y('average(Horsepower):Q', axis=alt.Axis(titleColor='#5276A7'))
+        alt.Y('average(Horsepower):Q').axis(titleColor='#5276A7')
     )
 
     line_B = base.mark_line(color='#F18727').encode(
-        alt.Y('average(Miles_per_Gallon):Q', axis=alt.Axis(titleColor='#F18727'))
+        alt.Y('average(Miles_per_Gallon):Q').axis(titleColor='#F18727')
     )
 
     alt.layer(line_A, line_B).resolve_scale(y='independent')
@@ -92,13 +90,13 @@ Vega-Lite to represent an encoding.
     line_A = base.transform_filter(
         alt.datum.Measure == 'Horsepower'
     ).encode(
-        alt.Y('average(Value):Q', axis=alt.Axis(title='Horsepower')),
+        alt.Y('average(Value):Q').title('Horsepower')
     )
 
     line_B = base.transform_filter(
         alt.datum.Measure == 'Miles_per_Gallon'
     ).encode(
-        alt.Y('average(Value):Q',axis=alt.Axis(title='Miles_per_Gallon'))
+        alt.Y('average(Value):Q').title('Miles_per_Gallon')
     )
 
     alt.layer(line_A, line_B).resolve_scale(y='independent')

--- a/doc/user_guide/times_and_dates.rst
+++ b/doc/user_guide/times_and_dates.rst
@@ -64,9 +64,9 @@ x-axis, and day of the month on the y-axis:
 .. altair-plot::
 
     alt.Chart(temps).mark_rect().encode(
-        alt.X('hoursminutes(date):O', title='hour of day'),
-        alt.Y('monthdate(date):O', title='date'),
-        alt.Color('temp:Q', title='temperature (F)')
+        alt.X('hoursminutes(date):O').title('hour of day'),
+        alt.Y('monthdate(date):O').title('date'),
+        alt.Color('temp:Q').title('temperature (F)')
     )
 
 Unless you are using a non-ES6 browser (See :ref:`note-browser-compliance`),
@@ -103,9 +103,9 @@ render **according to the timezone of the browser rendering it**:
 .. altair-plot::
 
     alt.Chart(temps).mark_rect().encode(
-        alt.X('hoursminutes(date_pacific):O', title='hour of day'),
-        alt.Y('monthdate(date_pacific):O', title='date'),
-        alt.Color('temp:Q', title='temperature (F)')
+        alt.X('hoursminutes(date_pacific):O').title('hour of day'),
+        alt.Y('monthdate(date_pacific):O').title('date'),
+        alt.Color('temp:Q').title('temperature (F)')
     )
 
 If you are viewing this chart on a computer whose time is set to the west coast
@@ -131,9 +131,9 @@ regardless of the system location:
 .. altair-plot::
 
     alt.Chart(temps).mark_rect().encode(
-        alt.X('utchoursminutes(date_pacific):O', title='UTC hour of day'),
-        alt.Y('utcmonthdate(date_pacific):O', title='UTC date'),
-        alt.Color('temp:Q', title='temperature (F)')
+        alt.X('utchoursminutes(date_pacific):O').title('UTC hour of day'),
+        alt.Y('utcmonthdate(date_pacific):O').title('UTC date'),
+        alt.Color('temp:Q').title('temperature (F)')
     )
 
 To make your charts as portable as possible (even in non-ES6 browsers which parse
@@ -146,9 +146,9 @@ in UTC time, both on the Pandas side and on the Vega-Lite side:
    temps['date_utc'] = temps['date'].dt.tz_localize('UTC')
 
    alt.Chart(temps).mark_rect().encode(
-       alt.X('utchoursminutes(date_utc):O', title='hour of day'),
-       alt.Y('utcmonthdate(date_utc):O', title='date'),
-       alt.Color('temp:Q', title='temperature (F)')
+       alt.X('utchoursminutes(date_utc):O').title('hour of day'),
+       alt.Y('utcmonthdate(date_utc):O').title('date'),
+       alt.Color('temp:Q').title('temperature (F)')
    )
 
 This is somewhat less convenient than the default behavior for timezone-agnostic

--- a/doc/user_guide/transform/bin.rst
+++ b/doc/user_guide/transform/bin.rst
@@ -18,7 +18,7 @@ An common application of a bin transform is when creating a histogram:
     movies = data.movies.url
 
     alt.Chart(movies).mark_bar().encode(
-        alt.X("IMDB_Rating:Q", bin=True),
+        alt.X("IMDB_Rating:Q").bin(),
         y='count()',
     )
 
@@ -35,12 +35,13 @@ bin a continuous field to create a discrete color map:
     alt.Chart(cars).mark_point().encode(
         x='Horsepower:Q',
         y='Miles_per_Gallon:Q',
-        color=alt.Color('Acceleration:Q', bin=alt.Bin(maxbins=5))
+        color=alt.Color('Acceleration:Q').bin(maxbins=5)
     )
 
-In the first case we set ``bin = True``, which uses the default bin settings.
+In the first case we use ``bin()`` without any arguments,
+which uses the default bin settings.
 In the second case, we exercise more fine-tuned control over the bin parameters
-by passing a :class:`~altair.Bin` object.
+by passing the ``maxbins`` argument.
 
 If you are using the same bins in multiple chart components, it can be useful
 to instead define the binning at the top level, using :meth:`~Chart.transform_bin`

--- a/doc/user_guide/transform/impute.rst
+++ b/doc/user_guide/transform/impute.rst
@@ -31,7 +31,7 @@ data directly, the line skips the missing entries:
    import altair as alt
 
    raw = alt.Chart(data).mark_line(point=True).encode(
-       x=alt.X('t:Q'),
+       x='t:Q',
        y='value:Q',
        color='variable:N'
    )
@@ -42,7 +42,7 @@ no points) it can imply the existence of data that is not there.
 
 Impute via Encodings
 ^^^^^^^^^^^^^^^^^^^^
-To address this, you can use an impute argument to the encoding channel.
+To address this, you can use the impute method of the encoding channel.
 For example, we can impute using a constant value (we'll show the raw chart
 lightly in the background for reference):
 
@@ -51,7 +51,7 @@ lightly in the background for reference):
    background = raw.encode(opacity=alt.value(0.2))
    chart = alt.Chart(data).mark_line(point=True).encode(
        x='t:Q',
-       y=alt.Y('value:Q', impute=alt.ImputeParams(value=0)),
+       y=alt.Y('value:Q').impute(value=0),
        color='variable:N'
    )
    background + chart
@@ -62,7 +62,7 @@ Or we can impute using any supported aggregate:
 
    chart = alt.Chart(data).mark_line(point=True).encode(
        x='t:Q',
-       y=alt.Y('value:Q', impute=alt.ImputeParams(method='mean')),
+       y=alt.Y('value:Q').impute(method='mean'),
        color='variable:N'
    )
    background + chart

--- a/doc/user_guide/transform/lookup.rst
+++ b/doc/user_guide/transform/lookup.rst
@@ -27,8 +27,8 @@ We know how to visualize each of these datasets separately; for example:
     import altair as alt
 
     top = alt.Chart(people).mark_square(size=200).encode(
-        x=alt.X('age:Q', scale=alt.Scale(zero=False)),
-        y=alt.Y('height:Q', scale=alt.Scale(zero=False)),
+        x=alt.X('age:Q').scale(zero=False),
+        y=alt.Y('height:Q').scale(zero=False),
         color='name:N',
         tooltip='name:N'
     ).properties(

--- a/doc/user_guide/transform/stack.rst
+++ b/doc/user_guide/transform/stack.rst
@@ -39,7 +39,7 @@ We can construct that same chart manually using the stack transform:
         sort=[alt.SortField('site', 'descending')]
     ).mark_bar().encode(
         column='year:O',
-        x=alt.X('yield_1:Q', title='yield'),
+        x=alt.X('yield_1:Q').title('yield'),
         x2='yield_2:Q',
         y='variety:N',
         color='site:N',

--- a/doc/user_guide/transform/timeunit.rst
+++ b/doc/user_guide/transform/timeunit.rst
@@ -73,8 +73,8 @@ to give a profile of Seattle temperatures through the year:
 .. altair-plot::
 
     alt.Chart(temps).mark_rect().encode(
-        alt.X('date(date):O', title='day'),
-        alt.Y('month(date):O', title='month'),
+        alt.X('date(date):O').title('day'),
+        alt.Y('month(date):O').title('month'),
         color='max(temp):Q'
     ).properties(
         title="2010 Daily High Temperatures in Seattle (F)"
@@ -90,7 +90,7 @@ method. For example:
 .. altair-plot::
 
     alt.Chart(temps).mark_line().encode(
-        alt.X('month:T', axis=alt.Axis(format='%b')),
+        alt.X('month:T').axis(format='%b'),
         y='mean(temp):Q'
     ).transform_timeunit(
         month='month(date)'

--- a/sphinxext/altairgallery.py
+++ b/sphinxext/altairgallery.py
@@ -124,7 +124,7 @@ EXAMPLE_TEMPLATE = jinja2.Template(
 {{ docstring }}
 
 .. altair-plot::
-    {% if code_below %}:code-below:{% endif %}
+    {% if code_below %}:remove-code:{% endif %}
     {% if strict %}:strict:{% endif %}
 
 {{ code | indent(4) }}

--- a/sphinxext/altairgallery.py
+++ b/sphinxext/altairgallery.py
@@ -204,17 +204,19 @@ def populate_examples(**kwds):
     """Iterate through Altair examples and extract code"""
 
     examples = sorted(iter_examples_arguments_syntax(), key=itemgetter("name"))
-    method_examples = {x['name']: x for x in iter_examples_methods_syntax()}
+    method_examples = {x["name"]: x for x in iter_examples_methods_syntax()}
 
     for example in examples:
         docstring, category, code, lineno = get_docstring_and_rest(example["filename"])
-        if example['name'] in method_examples.keys():
-            _, _, method_code, _ = get_docstring_and_rest(method_examples[example['name']]["filename"])
+        if example["name"] in method_examples.keys():
+            _, _, method_code, _ = get_docstring_and_rest(
+                method_examples[example["name"]]["filename"]
+            )
         else:
             method_code = code
             code += (
-                '# No channel encoding options are specified in this chart\n'
-                '# so the code is the same as for the method-based syntax.\n'
+                "# No channel encoding options are specified in this chart\n"
+                "# so the code is the same as for the method-based syntax.\n"
             )
         example.update(kwds)
         if category is None:

--- a/sphinxext/altairgallery.py
+++ b/sphinxext/altairgallery.py
@@ -203,12 +203,19 @@ def save_example_pngs(examples, image_dir, make_thumbnails=True):
 def populate_examples(**kwds):
     """Iterate through Altair examples and extract code"""
 
-    method_examples = sorted(iter_examples_methods_syntax(), key=itemgetter("name"))
     examples = sorted(iter_examples_arguments_syntax(), key=itemgetter("name"))
+    method_examples = {x['name']: x for x in iter_examples_methods_syntax()}
 
-    for example, method_example in zip(examples, method_examples):
+    for example in examples:
         docstring, category, code, lineno = get_docstring_and_rest(example["filename"])
-        _, _, method_code, _ = get_docstring_and_rest(method_example["filename"])
+        if example['name'] in method_examples.keys():
+            _, _, method_code, _ = get_docstring_and_rest(method_examples[example['name']]["filename"])
+        else:
+            method_code = code
+            code += (
+                '# No channel encoding options are specified in this chart\n'
+                '# so the code is the same as for the method-based syntax.\n'
+            )
         example.update(kwds)
         if category is None:
             raise Exception(

--- a/sphinxext/altairgallery.py
+++ b/sphinxext/altairgallery.py
@@ -24,6 +24,7 @@ from .utils import (
 )
 from altair.utils.execeval import eval_block
 from tests.examples_arguments_syntax import iter_examples_arguments_syntax
+from tests.examples_methods_syntax import iter_examples_methods_syntax
 
 
 EXAMPLE_MODULE = "altair.examples"
@@ -126,7 +127,23 @@ EXAMPLE_TEMPLATE = jinja2.Template(
     {% if code_below %}:code-below:{% endif %}
     {% if strict %}:strict:{% endif %}
 
-    {{ code | indent(4) }}
+{{ code | indent(4) }}
+
+.. tab-set::
+
+    .. tab-item:: Method syntax
+        :sync: method
+
+        .. code:: python
+
+{{ method_code | indent(12) }}
+
+    .. tab-item:: Attribute syntax
+        :sync: attribute
+
+        .. code:: python
+
+{{ code | indent(12) }}
 """
 )
 
@@ -186,10 +203,12 @@ def save_example_pngs(examples, image_dir, make_thumbnails=True):
 def populate_examples(**kwds):
     """Iterate through Altair examples and extract code"""
 
+    method_examples = sorted(iter_examples_methods_syntax(), key=itemgetter("name"))
     examples = sorted(iter_examples_arguments_syntax(), key=itemgetter("name"))
 
-    for example in examples:
+    for example, method_example in zip(examples, method_examples):
         docstring, category, code, lineno = get_docstring_and_rest(example["filename"])
+        _, _, method_code, _ = get_docstring_and_rest(method_example["filename"])
         example.update(kwds)
         if category is None:
             raise Exception(
@@ -200,6 +219,7 @@ def populate_examples(**kwds):
                 "docstring": docstring,
                 "title": docstring.strip().split("\n")[0],
                 "code": code,
+                "method_code": method_code,
                 "category": category.title(),
                 "lineno": lineno,
             }

--- a/sphinxext/altairplot.py
+++ b/sphinxext/altairplot.py
@@ -32,6 +32,7 @@ The directives have the following options::
     .. altair-plot::
         :namespace:  # specify a plotting namespace that is persistent within the doc
         :hide-code:  # if set, then hide the code and only show the plot
+        :remove-code:  # if set, then remove the code and only show the plot
         :code-below:  # if set, then code is below rather than above the figure
         :output:  [plot|repr|stdout|none]
         :alt: text  # Alternate text when plot cannot be rendered
@@ -141,6 +142,7 @@ class AltairPlotDirective(Directive):
 
     option_spec = {
         "hide-code": flag,
+        "remove-code": flag,
         "code-below": flag,
         "namespace": unchanged,
         "output": validate_output,
@@ -156,6 +158,7 @@ class AltairPlotDirective(Directive):
         app = env.app
 
         hide_code = "hide-code" in self.options
+        remove_code = "remove-code" in self.options
         code_below = "code-below" in self.options
         strict = "strict" in self.options
         div_class = self.options.get("div_class", None)
@@ -216,7 +219,8 @@ class AltairPlotDirective(Directive):
             raw_html = nodes.raw("", html, format="html")
             result += [raw_html]
 
-        result += [source_literal]
+        if not remove_code:
+            result += [source_literal]
 
         if hide_code:
             html = "</details>"

--- a/tests/examples_methods_syntax/bar_chart_sorted.py
+++ b/tests/examples_methods_syntax/bar_chart_sorted.py
@@ -1,0 +1,15 @@
+"""
+Sorted Bar Chart
+================
+This example shows a bar chart sorted by a calculated value.
+"""
+# category: bar charts
+import altair as alt
+from vega_datasets import data
+
+source = data.barley()
+
+alt.Chart(source).mark_bar().encode(
+    x='sum(yield):Q',
+    y=alt.Y('site:N').sort('-x')
+)


### PR DESCRIPTION
Following up on the discussion in https://github.com/altair-viz/altair/discussions/2599#discussioncomment-5396690 to make the method-based channel option syntax the default in the docs. This PR prefers that syntax throughout the narrative documentation and includes both the method-based and attribute-syntax for the gallery examples in a tabbed interface so that there are some examples for users prefer this syntax (and since we will preserve these snippets for testing purposes anyways). The only thing left to update is the interactivity section, which I can address after #2981 is merged.

Example of how the gallery looks now:

![image](https://user-images.githubusercontent.com/4560057/227093860-4964f396-e4e1-4885-9d02-73867f5467a5.png)


