### PR TITLE
Add code copy button to docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinxext.altairplot",
     "sphinxext.altairgallery",
     "sphinxext.schematable",
+    "sphinx_copybutton",
     # "sphinxext.rediraffe",
 ]
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,3 +6,4 @@ pillow
 pydata-sphinx-theme
 geopandas
 myst-parser
+sphinx_copybutton


### PR DESCRIPTION
This adds a copy button on hover for all code blocks in the docs. Easier than dragging and selecting text =)

![image](https://user-images.githubusercontent.com/4560057/227094550-3a2094ef-6cdf-4ac8-9089-69a1b53137c4.png)
