### PR TITLE
Fix a few doc build warnings

### DIFF
--- a/doc/user_guide/marks/errorband.rst
+++ b/doc/user_guide/marks/errorband.rst
@@ -163,9 +163,9 @@ Here is an example of a ``errorband`` with the ``color`` encoding channel set to
     alt.Chart(source).mark_errorband(extent="ci", borders=True).encode(
         x="year(Year)",
         y=alt.Y("Miles_per_Gallon:Q")
-            .scale(zero=False),
+            .scale(zero=False)
             .title("Miles per Gallon (95% CIs)"),
-        color=alt.value("black"),
+        color=alt.value("black")
     )
 
 

--- a/tests/examples_arguments_syntax/trellis_stacked_bar_chart.py
+++ b/tests/examples_arguments_syntax/trellis_stacked_bar_chart.py
@@ -10,7 +10,7 @@ from vega_datasets import data
 source = data.barley()
 
 alt.Chart(source).mark_bar().encode(
-    column='year',
+    column='year:O',
     x='yield',
     y='variety',
     color='site'

--- a/tests/examples_arguments_syntax/us_employment.py
+++ b/tests/examples_arguments_syntax/us_employment.py
@@ -50,7 +50,6 @@ text = alt.Chart(presidents).mark_text(
     size=11
 ).encode(
     x='start:T',
-    x2='end:T',
     text='president',
     color=alt.value('#000000')
 )

--- a/tests/examples_methods_syntax/us_employment.py
+++ b/tests/examples_methods_syntax/us_employment.py
@@ -50,7 +50,6 @@ text = alt.Chart(presidents).mark_text(
     size=11
 ).encode(
     x='start:T',
-    x2='end:T',
     text='president',
     color=alt.value('#000000')
 )


### PR DESCRIPTION
Fixes https://github.com/altair-viz/altair/pull/2983#issuecomment-1489157621 and a few more build warnings:


Fixes:

```text
-> saving /home/joel/proj/altair/doc/_images/us_employment.png
WARN x2 dropped as it is incompatible with "text".

-> saving /home/joel/proj/altair/doc/_images/trellis_stacked_bar_chart.png
WARN column encoding should be discrete (ordinal / nominal / binned).
```

Not sure how to fix:

```text
-> saving /home/joel/proj/altair/doc/_images/ridgeline_plot.png
WARN row encoding should be discrete (ordinal / nominal / binned).
WARN Channel x2 is required for "binned" bin.
```

Ok to leave as is:

```diff
# Cause by .interactive which still is useful to zoom the x-axis
saving /home/joel/proj/altair/doc/_images/streamgraph.png
WARN Cannot project a selection on encoding channel "y" as it uses an aggregate function ("sum").
# Similar issue with inteactive
saving /home/joel/proj/altair/doc/_images/ranged_dot_plot.png
WARN Scale bindings are currently only supported for scales with unbinned, continuous domains.

# Caused by redundant encoding; harmless
saving /home/joel/proj/altair/doc/_images/bar_chart_with_labels.png
WARN text dropped as it is incompatible with "bar".
# Same
saving /home/joel/proj/altair/doc/_images/line_with_last_value_labeled.png
WARN text dropped as it is incompatible with "circle".
```

