### PR TITLE
Add VegaFusion data transformer with mime renderer, save, and to_dict/to_json integration

### DIFF
--- a/altair/utils/_transformed_data.py
+++ b/altair/utils/_transformed_data.py
@@ -82,7 +82,7 @@ def transformed_data(chart, row_limit=None, exclude=None):
 
     # Compile to Vega and extract inline DataFrames
     with data_transformers.enable("vegafusion"):
-        vega_spec = chart.to_dict(format="vega")
+        vega_spec = chart.to_dict(format="vega", context={"pre_transform": False})
         inline_datasets = get_inline_tables(vega_spec)
 
     # Build mapping from mark names to vega datasets

--- a/altair/utils/_transformed_data.py
+++ b/altair/utils/_transformed_data.py
@@ -9,6 +9,7 @@ from altair import (
     ConcatChart,
     data_transformers,
 )
+from altair.utils._vegafusion_data import get_inline_tables
 from altair.utils.core import _DataFrameLike
 from altair.utils.schemapi import Undefined
 
@@ -57,7 +58,7 @@ def transformed_data(chart, row_limit=None, exclude=None):
         transformed data
     """
     try:
-        from vegafusion import runtime, get_local_tz, get_inline_datasets_for_spec  # type: ignore
+        from vegafusion import runtime, get_local_tz  # type: ignore
     except ImportError as err:
         raise ImportError(
             "transformed_data requires the vegafusion-python-embed and vegafusion packages\n"
@@ -80,9 +81,9 @@ def transformed_data(chart, row_limit=None, exclude=None):
     chart_names = name_views(chart, 0, exclude=exclude)
 
     # Compile to Vega and extract inline DataFrames
-    with data_transformers.enable("vegafusion-inline"):
+    with data_transformers.enable("vegafusion"):
         vega_spec = chart.to_dict(format="vega")
-        inline_datasets = get_inline_datasets_for_spec(vega_spec)
+        inline_datasets = get_inline_tables(vega_spec)
 
     # Build mapping from mark names to vega datasets
     facet_mapping = get_facet_mapping(vega_spec)

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -143,7 +143,7 @@ def compile_with_vegafusion(vegalite_spec: dict) -> dict:
     from altair import vegalite_compilers, data_transformers
 
     try:
-        import vegafusion as vf
+        import vegafusion as vf  # type: ignore
     except ImportError as e:
         raise ImportError(
             'The "vegafusion" data transformer requires the vegafusion-python-embed\n'
@@ -154,7 +154,11 @@ def compile_with_vegafusion(vegalite_spec: dict) -> dict:
         ) from e
 
     # Compile Vega-Lite spec to Vega
-    vega_spec = vegalite_compilers.get()(vegalite_spec)
+    compiler = vegalite_compilers.get()
+    if compiler is None:
+        raise ValueError("No active vega-lite compiler plugin found")
+
+    vega_spec = compiler(vegalite_spec)
 
     # Retrieve dict of inline tables referenced by the spec
     inline_tables = get_inline_tables(vega_spec)

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -1,0 +1,189 @@
+from typing import TypedDict, Union, Dict, Set, MutableMapping, Final
+
+from toolz import curried
+import uuid
+from weakref import WeakValueDictionary
+
+from altair.utils.core import _DataFrameLike
+from altair.utils.data import _DataType, _ToValuesReturnType, MaxRowsError
+from altair.vegalite.data import default_data_transformer
+
+# Temporary storage for dataframes that have been extracted
+# from charts by the vegafusion data transformer. Use a WeakValueDictionary
+# rather than a dict so that the Python interpreter is free to garbage
+# collect the stored DataFrames.
+extracted_inline_tables: MutableMapping[str, _DataFrameLike] = WeakValueDictionary()
+
+# Special URL prefix that VegaFusion uses to denote that a
+# dataset in a Vega spec corresponds to an entry in the `inline_datasets`
+# kwarg of vf.runtime.pre_transform_spec().
+VEGAFUSION_PREFIX: Final = "table://"
+
+
+class _ToVegaFusionReturnUrlDict(TypedDict):
+    url: str
+
+
+@curried.curry
+def vegafusion_data_transformer(
+    data: _DataType, max_rows: int = 100000
+) -> Union[_ToVegaFusionReturnUrlDict, _ToValuesReturnType]:
+    """VegaFusion Data Transformer"""
+    if hasattr(data, "__geo_interface__"):
+        # Use default transformer for geo interface objects
+        # # (e.g. a geopandas GeoDataFrame)
+        return default_data_transformer(data)
+    elif hasattr(data, "__dataframe__"):
+        table_name = f"table_{uuid.uuid4()}".replace("-", "_")
+        extracted_inline_tables[table_name] = data
+        return {"url": VEGAFUSION_PREFIX + table_name}
+    else:
+        # Use default transformer if we don't recognize data type
+        return default_data_transformer(data)
+
+
+def get_inline_table_names(vega_spec: dict) -> Set[str]:
+    """Get a set of the inline datasets names in the provided Vega spec
+
+    Inline datasets are encoded as URLs that start with the table://
+    prefix.
+
+    Parameters
+    ----------
+    vega_spec: dict
+        A Vega specification dict
+
+    Returns
+    -------
+    set of str
+        Set of the names of the inline datasets that are referenced
+        in the specification.
+
+    Examples
+    --------
+    >>> spec = {
+    ...     "data": [
+    ...         {
+    ...             "name": "foo",
+    ...             "url": "https://path/to/file.csv"
+    ...         },
+    ...         {
+    ...             "name": "bar",
+    ...             "url": "table://inline_dataset_123"
+    ...         }
+    ...     ]
+    ... }
+    >>> get_inline_table_names(spec)
+    {'inline_dataset_123'}
+    """
+    table_names = set()
+
+    # Process datasets
+    for data in vega_spec.get("data", []):
+        url = data.get("url", "")
+        if url.startswith(VEGAFUSION_PREFIX):
+            name = url[len(VEGAFUSION_PREFIX) :]
+            table_names.add(name)
+
+    # Recursively process child marks, which may have their own datasets
+    for mark in vega_spec.get("marks", []):
+        table_names.update(get_inline_table_names(mark))
+
+    return table_names
+
+
+def get_inline_tables(vega_spec: dict) -> Dict[str, _DataFrameLike]:
+    """Get the inline tables referenced by a Vega specification
+
+    Note: This function should only be called on a Vega spec that corresponds
+    to a chart that was processed by the vegafusion_data_transformer.
+    Furthermore, this function may only be called once per spec because
+    the returned dataframes are deleted from internal storage.
+
+    Parameters
+    ----------
+    vega_spec: dict
+        A Vega specification dict
+
+    Returns
+    -------
+    dict from str to dataframe
+        dict from inline dataset name to dataframe object
+    """
+    table_names = get_inline_table_names(vega_spec)
+    tables = {}
+    for table_name in table_names:
+        try:
+            tables[table_name] = extracted_inline_tables.pop(table_name)
+        except KeyError:
+            # named dataset that was provided by the user
+            pass
+    return tables
+
+
+def compile_with_vegafusion(vegalite_spec: dict) -> dict:
+    """Compile a Vega-Lite spec to Vega and pre-transform with VegaFusion
+
+    Note: This function should only be called on a Vega-Lite spec
+    that was generated with the "vegafusion" data transformer enabled.
+    In particular, this spec may contain references to extract datasets
+    using table:// prefixed URLs.
+
+    Parameters
+    ----------
+    vegalite_spec: dict
+        A Vega-Lite spec that was generated from an Altair chart with
+        the "vegafusion" data transformer enabled
+
+    Returns
+    -------
+    dict
+        A Vega spec that has been pre-transformed by VegaFusion
+    """
+    from altair import vegalite_compilers, data_transformers
+
+    try:
+        import vegafusion as vf
+    except ImportError as e:
+        raise ImportError(
+            'The "vegafusion" data transformer requires the vegafusion-python-embed\n'
+            "and vegafusion packages. These can be installed with pip using:\n"
+            '    pip install "vegafusion[embed]"\n'
+            "Or with conda using:\n"
+            "    conda install -c conda-forge vegafusion-python-embed vegafusion"
+        ) from e
+
+    # Compile Vega-Lite spec to Vega
+    vega_spec = vegalite_compilers.get()(vegalite_spec)
+
+    # Retrieve dict of inline tables referenced by the spec
+    inline_tables = get_inline_tables(vega_spec)
+
+    # Pre-evaluate transforms in vega spec with vegafusion
+    row_limit = data_transformers.options.get("max_rows", None)
+    transformed_vega_spec, warnings = vf.runtime.pre_transform_spec(
+        vega_spec,
+        vf.get_local_tz(),
+        inline_datasets=inline_tables,
+        row_limit=row_limit,
+    )
+
+    # Check from row limit warning and convert to MaxRowsError
+    for warning in warnings:
+        if warning.get("type") == "RowLimitExceeded":
+            raise MaxRowsError(
+                "The number of dataset rows after filtering and aggregation exceeds\n"
+                f"the current limit of {row_limit}. Try adding an aggregation to reduce\n"
+                "the size of the dataset that must be loaded into the browser. Or, disable\n"
+                "the limit by calling alt.data_transformers.disable_max_rows(). Note that\n"
+                "disabling this limit may cause the browser to freeze or crash."
+            )
+
+    return transformed_vega_spec
+
+
+def using_vegafusion() -> bool:
+    """Check whether the vegafusion data transfomer is enabled"""
+    from altair.vegalite.v5.data import data_transformers
+
+    return data_transformers.active == "vegafusion"

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -3,12 +3,12 @@ from toolz import curried
 import uuid
 from weakref import WeakValueDictionary
 
-from typing import Union, Dict, Set, MutableMapping, Final
+from typing import Union, Dict, Set, MutableMapping
 
 if sys.version_info >= (3, 8):
-    from typing import TypedDict
+    from typing import TypedDict, Final
 else:
-    from typing_extensions import TypedDict
+    from typing_extensions import TypedDict, Final
 
 from altair.utils.core import _DataFrameLike
 from altair.utils.data import _DataType, _ToValuesReturnType, MaxRowsError

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -146,6 +146,7 @@ def compile_with_vegafusion(vegalite_spec: dict) -> dict:
     dict
         A Vega spec that has been pre-transformed by VegaFusion
     """
+    # Local import to avoid circular ImportError
     from altair import vegalite_compilers, data_transformers
 
     try:
@@ -194,6 +195,7 @@ def compile_with_vegafusion(vegalite_spec: dict) -> dict:
 
 def using_vegafusion() -> bool:
     """Check whether the vegafusion data transfomer is enabled"""
-    from altair.vegalite.v5.data import data_transformers
+    # Local import to avoid circular ImportError
+    from altair import data_transformers
 
     return data_transformers.active == "vegafusion"

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -23,7 +23,7 @@ extracted_inline_tables: MutableMapping[str, _DataFrameLike] = WeakValueDictiona
 # Special URL prefix that VegaFusion uses to denote that a
 # dataset in a Vega spec corresponds to an entry in the `inline_datasets`
 # kwarg of vf.runtime.pre_transform_spec().
-VEGAFUSION_PREFIX: Final = "table://"
+VEGAFUSION_PREFIX: Final = "vegafusion+dataset://"
 
 
 class _ToVegaFusionReturnUrlDict(TypedDict):

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -1,8 +1,14 @@
-from typing import TypedDict, Union, Dict, Set, MutableMapping, Final
-
+import sys
 from toolz import curried
 import uuid
 from weakref import WeakValueDictionary
+
+from typing import Union, Dict, Set, MutableMapping, Final
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 from altair.utils.core import _DataFrameLike
 from altair.utils.data import _DataType, _ToValuesReturnType, MaxRowsError

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -163,6 +163,7 @@ def default_renderer_base(
     how to render the custom VegaLite MIME type listed above.
     """
     from altair.vegalite.v5.display import VEGA_MIME_TYPE, VEGALITE_MIME_TYPE
+
     assert isinstance(spec, dict)
     bundle: Dict[str, Union[str, dict]] = {}
     metadata: Dict[str, Dict[str, Any]] = {}

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -4,6 +4,7 @@ import textwrap
 from typing import Callable, Dict, Optional, Tuple, Any, Union
 import uuid
 
+from ._vegafusion_data import compile_with_vegafusion, using_vegafusion
 from .plugin_registry import PluginRegistry, PluginEnabler
 from .mimebundle import spec_to_mimebundle
 from .schemapi import validate_jsonschema
@@ -161,9 +162,18 @@ def default_renderer_base(
     This renderer works with modern frontends (JupyterLab, nteract) that know
     how to render the custom VegaLite MIME type listed above.
     """
+    from altair.vegalite.v5.display import VEGA_MIME_TYPE, VEGALITE_MIME_TYPE
     assert isinstance(spec, dict)
     bundle: Dict[str, Union[str, dict]] = {}
     metadata: Dict[str, Dict[str, Any]] = {}
+
+    if using_vegafusion():
+        spec = compile_with_vegafusion(spec)
+
+        # Swap mimetype from Vega-Lite to Vega.
+        # If mimetype was JSON, leave it alone
+        if mime_type == VEGALITE_MIME_TYPE:
+            mime_type = VEGA_MIME_TYPE
 
     bundle[mime_type] = spec
     bundle["text/plain"] = str_repr

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -162,6 +162,7 @@ def default_renderer_base(
     This renderer works with modern frontends (JupyterLab, nteract) that know
     how to render the custom VegaLite MIME type listed above.
     """
+    # Local import to avoid circular ImportError
     from altair.vegalite.v5.display import VEGA_MIME_TYPE, VEGALITE_MIME_TYPE
 
     assert isinstance(spec, dict)

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -44,6 +44,7 @@ def spec_to_mimebundle(
     ----
     The png, svg, pdf, and vega outputs require the altair_saver package
     """
+    # Local import to avoid circular ImportError
     from altair.utils.display import compile_with_vegafusion, using_vegafusion
 
     if mode != "vega-lite":

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -45,6 +45,7 @@ def spec_to_mimebundle(
     The png, svg, pdf, and vega outputs require the altair_saver package
     """
     from altair.utils.display import compile_with_vegafusion, using_vegafusion
+
     if mode != "vega-lite":
         raise ValueError("mode must be 'vega-lite'")
 

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -124,13 +124,13 @@ def _spec_to_mimebundle_with_engine(spec, format, mode, **kwargs):
             if mode == "vega":
                 png = vlc.vega_to_png(
                     spec,
-                    scale=kwargs.get("scale_factor", 1.0),
+                    scale=kwargs.get("scale_factor", 1),
                 )
             else:
                 png = vlc.vegalite_to_png(
                     spec,
                     vl_version=vl_version,
-                    scale=kwargs.get("scale_factor", 1.0),
+                    scale=kwargs.get("scale_factor", 1),
                 )
             return {"image/png": png}
         else:

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -44,8 +44,13 @@ def spec_to_mimebundle(
     ----
     The png, svg, pdf, and vega outputs require the altair_saver package
     """
+    from altair.utils.display import compile_with_vegafusion, using_vegafusion
     if mode != "vega-lite":
         raise ValueError("mode must be 'vega-lite'")
+
+    if using_vegafusion():
+        spec = compile_with_vegafusion(spec)
+        mode = "vega"
 
     if format in ["png", "svg", "pdf", "vega"]:
         return _spec_to_mimebundle_with_engine(
@@ -82,7 +87,7 @@ def _spec_to_mimebundle_with_engine(spec, format, mode, **kwargs):
         a dictionary representing a vega-lite plot spec
     format : string {'png', 'svg', 'pdf', 'vega'}
         the format of the mimebundle to be returned
-    mode : string {'vega-lite'}
+    mode : string {'vega-lite', 'vega'}
         The rendering mode.
     engine: string {'vl-convert', 'altair_saver'}
         the conversion engine to use
@@ -102,17 +107,29 @@ def _spec_to_mimebundle_with_engine(spec, format, mode, **kwargs):
         # from SCHEMA_VERSION (of the form 'v5.2.0')
         vl_version = "_".join(SCHEMA_VERSION.split(".")[:2])
         if format == "vega":
-            vg = vlc.vegalite_to_vega(spec, vl_version=vl_version)
+            if mode == "vega":
+                vg = spec
+            else:
+                vg = vlc.vegalite_to_vega(spec, vl_version=vl_version)
             return {"application/vnd.vega.v5+json": vg}
         elif format == "svg":
-            svg = vlc.vegalite_to_svg(spec, vl_version=vl_version)
+            if mode == "vega":
+                svg = vlc.vega_to_svg(spec)
+            else:
+                svg = vlc.vegalite_to_svg(spec, vl_version=vl_version)
             return {"image/svg+xml": svg}
         elif format == "png":
-            png = vlc.vegalite_to_png(
-                spec,
-                vl_version=vl_version,
-                scale=kwargs.get("scale_factor", 1.0),
-            )
+            if mode == "vega":
+                png = vlc.vega_to_png(
+                    spec,
+                    scale=kwargs.get("scale_factor", 1.0),
+                )
+            else:
+                png = vlc.vegalite_to_png(
+                    spec,
+                    vl_version=vl_version,
+                    scale=kwargs.get("scale_factor", 1.0),
+                )
             return {"image/png": png}
         else:
             # This should be validated above

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -153,7 +153,7 @@ def save(
             mimebundle = spec_to_mimebundle(
                 spec=spec,
                 format=format,
-                mode=mode,
+                mode=inner_mode,
                 vega_version=vega_version,
                 vegalite_version=vegalite_version,
                 vegaembed_version=vegaembed_version,

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -124,7 +124,7 @@ def save(
     format = set_inspect_format_argument(format, fp, inline)
 
     def perform_save():
-        spec = chart.to_dict()
+        spec = chart.to_dict(context={"pre_transform": False})
 
         inner_mode = set_inspect_mode_argument(
             mode, embed_options, spec, vegalite_version

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -115,6 +115,7 @@ def save(
         additional kwargs passed to spec_to_mimebundle.
     """
     from altair.utils._vegafusion_data import using_vegafusion
+
     if json_kwds is None:
         json_kwds = {}
 
@@ -126,7 +127,9 @@ def save(
     def perform_save():
         spec = chart.to_dict()
 
-        inner_mode = set_inspect_mode_argument(mode, embed_options, spec, vegalite_version)
+        inner_mode = set_inspect_mode_argument(
+            mode, embed_options, spec, vegalite_version
+        )
 
         if format == "json":
             json_spec = json.dumps(spec, **json_kwds)

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -4,6 +4,7 @@ import warnings
 
 from .mimebundle import spec_to_mimebundle
 from ..vegalite.v5.data import data_transformers
+from altair.utils._vegafusion_data import using_vegafusion
 
 
 def write_file_or_filename(fp, content, mode="w", encoding=None):
@@ -114,8 +115,6 @@ def save(
     **kwargs :
         additional kwargs passed to spec_to_mimebundle.
     """
-    from altair.utils._vegafusion_data import using_vegafusion
-
     if json_kwds is None:
         json_kwds = {}
 

--- a/altair/vegalite/data.py
+++ b/altair/vegalite/data.py
@@ -27,7 +27,7 @@ class DataTransformerRegistry(_DataTransformerRegistry):
     def disable_max_rows(self) -> PluginEnabler:
         """Disable the MaxRowsError."""
         options = self.options
-        if self.active == "default":
+        if self.active in ("default", "vegafusion"):
             options = options.copy()
             options["max_rows"] = None
         return self.enable(**options)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -901,7 +901,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         # but due to how Altair is set up this should hold.
         # Too complex to type hint right now
         vegalite_spec = super(TopLevelMixin, copy).to_dict(  # type: ignore[misc]
-            validate=validate, ignore=ignore, context=context
+            validate=validate, ignore=ignore, context=dict(context, pre_transform=False)
         )
 
         # TODO: following entries are added after validation. Should they be validated?

--- a/altair/vegalite/v5/data.py
+++ b/altair/vegalite/v5/data.py
@@ -13,6 +13,8 @@ from ..data import (
     DataTransformerRegistry,
 )
 
+from ...utils._vegafusion_data import vegafusion_data_transformer
+
 if sys.version_info >= (3, 8):
     from typing import Final
 else:
@@ -31,6 +33,7 @@ data_transformers = DataTransformerRegistry(entry_point_group=ENTRY_POINT_GROUP)
 data_transformers.register("default", default_data_transformer)
 data_transformers.register("json", to_json)
 data_transformers.register("csv", to_csv)
+data_transformers.register("vegafusion", vegafusion_data_transformer)
 data_transformers.enable("default")
 
 
@@ -45,4 +48,5 @@ __all__ = (
     "to_json",
     "to_values",
     "data_transformers",
+    "vegafusion_data_transformer",
 )

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -32,6 +32,9 @@ VEGAEMBED_VERSION: Final = "6"
 # The MIME type for Vega-Lite 5.x releases.
 VEGALITE_MIME_TYPE: Final = "application/vnd.vegalite.v5+json"
 
+# The MIME type for Vega 5.x releases.
+VEGA_MIME_TYPE: Final = "application/vnd.vega.v5+json"
+
 # The entry point group that can be used by other packages to declare other
 # renderers that will be auto-detected. Explicit registration is also
 # allowed by the PluginRegistery API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
     "vega_datasets",
     # following is rejected by PyPI
     "altair_viewer @ git+https://github.com/altair-viz/altair_viewer.git",
-    "vl-convert-python",
+    "vl-convert-python==0.10.3",
     "mypy",
     "pandas-stubs",
     "types-jsonschema",

--- a/tests/utils/test_mimebundle.py
+++ b/tests/utils/test_mimebundle.py
@@ -221,3 +221,26 @@ def test_spec_to_json_mimebundle():
         format="json",
     )
     assert bundle == {"application/json": vegalite_spec}
+
+
+def test_vegafusion_spec_to_vega_mime_bundle(vegalite_spec):
+    with alt.data_transformers.enable("vegafusion"):
+        bundle = spec_to_mimebundle(
+            spec=vegalite_spec,
+            mode="vega-lite",
+            format="vega",
+        )
+        # Returned bundle will be vega
+        vega_spec = bundle["application/vnd.vega.v5+json"]
+        assert vega_spec["$schema"] == "https://vega.github.io/schema/vega/v5.json"
+
+        # Check data_0 is there
+        data_0 = vega_spec["data"][1]
+        assert data_0["name"] == "data_0"
+
+        # Check that the bin transform has been applied
+        row0 = data_0["values"][0]
+        assert row0 == {"a": "A", "b": 28, "b_end": 28.0, "b_start": 0.0}
+
+        # And no transforms remain
+        assert len(data_0.get("transform", [])) == 0

--- a/tests/utils/test_mimebundle.py
+++ b/tests/utils/test_mimebundle.py
@@ -1,6 +1,7 @@
 import pytest
 
 import altair as alt
+from altair import VEGA_VERSION
 from altair.utils.mimebundle import spec_to_mimebundle
 
 try:
@@ -232,7 +233,7 @@ def test_vegafusion_spec_to_vega_mime_bundle(vegalite_spec):
         )
         # Returned bundle will be vega
         vega_spec = bundle["application/vnd.vega.v5+json"]
-        assert vega_spec["$schema"] == "https://vega.github.io/schema/vega/v5.json"
+        assert vega_spec["$schema"] == f"https://vega.github.io/schema/vega/v{VEGA_VERSION}.json"
 
         # Check data_0 is there
         data_0 = vega_spec["data"][1]

--- a/tests/utils/test_mimebundle.py
+++ b/tests/utils/test_mimebundle.py
@@ -224,6 +224,24 @@ def test_spec_to_json_mimebundle():
     assert bundle == {"application/json": vegalite_spec}
 
 
+def check_pre_transformed_vega_spec(vega_spec):
+    assert (
+        vega_spec["$schema"]
+        == f"https://vega.github.io/schema/vega/v{VEGA_VERSION}.json"
+    )
+
+    # Check data_0 is there
+    data_0 = vega_spec["data"][1]
+    assert data_0["name"] == "data_0"
+
+    # Check that the bin transform has been applied
+    row0 = data_0["values"][0]
+    assert row0 == {"a": "A", "b": 28, "b_end": 28.0, "b_start": 0.0}
+
+    # And no transforms remain
+    assert len(data_0.get("transform", [])) == 0
+
+
 def test_vegafusion_spec_to_vega_mime_bundle(vegalite_spec):
     with alt.data_transformers.enable("vegafusion"):
         bundle = spec_to_mimebundle(
@@ -233,18 +251,12 @@ def test_vegafusion_spec_to_vega_mime_bundle(vegalite_spec):
         )
         # Returned bundle will be vega
         vega_spec = bundle["application/vnd.vega.v5+json"]
-        assert (
-            vega_spec["$schema"]
-            == f"https://vega.github.io/schema/vega/v{VEGA_VERSION}.json"
-        )
+        check_pre_transformed_vega_spec(vega_spec)
 
-        # Check data_0 is there
-        data_0 = vega_spec["data"][1]
-        assert data_0["name"] == "data_0"
 
-        # Check that the bin transform has been applied
-        row0 = data_0["values"][0]
-        assert row0 == {"a": "A", "b": 28, "b_end": 28.0, "b_start": 0.0}
-
-        # And no transforms remain
-        assert len(data_0.get("transform", [])) == 0
+def test_vegafusion_chart_to_vega_mime_bundle(vegalite_spec):
+    chart = alt.Chart.from_dict(vegalite_spec)
+    with alt.data_transformers.enable("vegafusion"), alt.renderers.enable("json"):
+        bundle = chart._repr_mimebundle_()
+        vega_spec = bundle[0]["application/json"]
+        check_pre_transformed_vega_spec(vega_spec)

--- a/tests/utils/test_mimebundle.py
+++ b/tests/utils/test_mimebundle.py
@@ -233,7 +233,10 @@ def test_vegafusion_spec_to_vega_mime_bundle(vegalite_spec):
         )
         # Returned bundle will be vega
         vega_spec = bundle["application/vnd.vega.v5+json"]
-        assert vega_spec["$schema"] == f"https://vega.github.io/schema/vega/v{VEGA_VERSION}.json"
+        assert (
+            vega_spec["$schema"]
+            == f"https://vega.github.io/schema/vega/v{VEGA_VERSION}.json"
+        )
 
         # Check data_0 is there
         data_0 = vega_spec["data"][1]


### PR DESCRIPTION
## Overview
Following on from the discussion in https://github.com/altair-viz/altair/discussions/3054, this PR introduces a new data transformer named "vegafusion".  When activated, we use [VegaFusion](https://vegafusion.io/) to pre-evaluate data transformations before displaying charts with mime renderers, and before saving charts with `Chart.save`.

## The Data Transformer
The "vegafusion" data transformer replaces DataFrames in Vega-Lite specs with URLs of the form "table://{uuid}". These DataFrames are stashed in a local `WeakValueDictionary`, with the UUID as the key. The `table://` URL is a VegaFusion convention used to mean that the associated data will be provided using the `inline_datasets` argument to the `pre_transform_spec` function.

## Mimerenderer and Save
A function is defined in `_vegafusion_data.py` called `compile_with_vegafusion` that inputs a Vega-Lite spec containing these `table://` URLs, compiles it to a Vega spec, then invokes VegaFusion's `pre_transform_spec` function. The stashed DataFrames that correspond to the `table://` URLs are extracted from the `WeakValueDictionary` and passed to `pre_transform_spec` as the `inline_datasets` argument.  `compile_with_vegafusion` then returns the pre-transformed Vega spec as a dictionary.

When the "vegafusion" data transformer is enabled, the `default_renderer_base()` function calls `compile_with_vegafusion()` before returning a Vega mime bundle.  Similarly, the `spec_to_mimebundle` function has been updated to call `compile_with_vegafusion()` when the "vegafusion" data transformer is enabled. This way, saved charts have their transforms pre-evaluated before saving.

## Transformed Data
This PR also updates the `chart.transformed_data` functionality added in #3081 and #3084 to rely on the new "vegafusion" data transformere rather than the "vegafusion-inline" transformer that is provided by the `vegafusion` Python package. ("vegafusion-inline" will be deprecated in `vegafusion` once this is released).

## MaxRowsError
VegaFusion still has a notion of a maximum number of rows. But unlike the regular row limit, VegaFusion's row limit is applied after all supported data transformations have been applied. So you may hit it in the case of a large scatter chart.  I decided to reuse the existing infrastructure for setting and disabling max_rows (e.g. `alt.data_transformers.disable_max_rows()`). When this post-transformed limit is exceeded, we raise the same `MaxRowsError` exception, but with a message that explains that the limit is applied after data transformations.

This is open for discussion, but I set the "vegafusion" data transformer's row limit to 100k.  This is partly justified by the fact that VegaFusion will remove unused data columns. But also, practically speaking I haven't run into issues at this scale. One case where a high default limit is helpful is for creating fine-grained heatmaps (e.g. 300x300 get's you to 90k).

## Testing
I added a test for the `spec_to_mimebundle` updates, but still need to find a place to test the renderer path.

## Follow-up
After this PR, I want to work on how to document this. We can talk more about it, but I'm thinking of adding a section to the top of the "Large Datasets" section that recommends enabling this data transformer as the first step.  And perhaps also updating the default MaxRowsError with instructions on how to enable it.

