### PR TITLE
Fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ doc = [
     "sphinxext_altair",
     "jinja2",
     "numpydoc",
-    "pillow",
+    "pillow>=9,<10",
     "pydata-sphinx-theme",
     "geopandas",
     "myst-parser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
     "vega_datasets",
     # following is rejected by PyPI
     "altair_viewer @ git+https://github.com/altair-viz/altair_viewer.git",
-    "vl-convert-python",
+    "vl-convert-python==0.10.3",
     "mypy",
     "pandas-stubs",
     "types-jsonschema",


### PR DESCRIPTION
Pin vl-convert-python and pillow to fix CI.

vl-convert-python pin is to avoid a regression in 0.11 that still hasn't been fixed yet (https://github.com/vega/vl-convert/issues/78)

I haven't looked into the details on pillow, but the update from v9 to v10 broke the documentation build.

```
Extension error (sphinxext.altairgallery):
Handler <function main at 0x7f4a4a87fbe0> for event 'builder-inited' threw an exception (exception: module 'PIL.Image' has no attribute 'ANTIALIAS')
-> saving /home/runner/work/altair/altair/doc/_images/histogram_heatmap.png
```