### PR TITLE
Unpin vl-convert-python in dev/ci dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
     "vega_datasets",
     # following is rejected by PyPI
     "altair_viewer @ git+https://github.com/altair-viz/altair_viewer.git",
-    "vl-convert-python==0.10.3",
+    "vl-convert-python>=0.11.2",
     "mypy",
     "pandas-stubs",
     "types-jsonschema",


### PR DESCRIPTION
vl-convert-python was pinned to 0.10.3 in https://github.com/altair-viz/altair/pull/3095 due to https://github.com/vega/vl-convert/issues/78.

This was fixed in vl-convert-python 0.11.2, so replacing the pin with 0.11.2 as the lower version bound.