### PR TITLE
master -> main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ which you can find in `pyproject.toml` (`[project.optional-dependencies]/dev`)
 
 Once your local environment is up-to-date, you can create a new git branch
 which will contain your contribution
-(always create a new branch instead of making changes to the master branch):
+(always create a new branch instead of making changes to the main branch):
 
 ```cmd
 git switch -c <your-branch-name>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ alt.Chart(cars).mark_point().encode(
 )
 ```
 
-![Vega-Altair Visualization](https://raw.githubusercontent.com/altair-viz/altair/master/images/cars.png)
+![Vega-Altair Visualization](https://raw.githubusercontent.com/altair-viz/altair/main/images/cars.png)
 
 One of the unique features of Vega-Altair, inherited from Vega-Lite, is a declarative grammar of not just visualization, but _interaction_. 
 With a few modifications to the example above we can create a linked histogram that is filtered based on a selection of the scatter plot.
@@ -74,7 +74,7 @@ bars = alt.Chart(source).mark_bar().encode(
 points & bars
 ```
 
-![Vega-Altair Visualization Gif](https://raw.githubusercontent.com/altair-viz/altair/master/images/cars_scatter_bar.gif)
+![Vega-Altair Visualization Gif](https://raw.githubusercontent.com/altair-viz/altair/main/images/cars_scatter_bar.gif)
 
 ## Features
 * Carefully-designed, declarative Python API.
@@ -114,7 +114,7 @@ hatch run test
 ```
 
 For information on how to contribute your developments back to the Vega-Altair repository, see
-[`CONTRIBUTING.md`](https://github.com/altair-viz/altair/blob/master/CONTRIBUTING.md)
+[`CONTRIBUTING.md`](https://github.com/altair-viz/altair/blob/main/CONTRIBUTING.md)
 
 ## Citing Vega-Altair
 [![JOSS Paper](https://joss.theoj.org/papers/10.21105/joss.01057/status.svg)](https://joss.theoj.org/papers/10.21105/joss.01057)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@
 
 2. Make certain your branch is in sync with head:
  
-       git pull upstream master
+       git pull upstream main
 
 3. Do a clean doc build:
 
@@ -28,11 +28,11 @@
    - URLs in ``doc/conf.py``
    - versions in ``altair/vegalite/v5/display.py``
 
-7. Commit change and push to master:
+7. Commit change and push to main:
 
        git add . -u
        git commit -m "MAINT: bump version to 5.0.0"
-       git push upstream master
+       git push upstream main
 
 8. Tag the release:
 
@@ -69,11 +69,11 @@
        Backward-Incompatible Changes
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-14. Commit change and push to master:
+14. Commit change and push to main:
 
         git add . -u
         git commit -m "MAINT: bump version to 5.1.0dev"
-        git push upstream master
+        git push upstream main
 
 15. Double-check that a conda-forge pull request is generated from the updated
     pip package by the conda-forge bot (may take up to ~an hour):

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -27,7 +27,7 @@ Development Installation
 
 The `Altair source repository`_ is available on GitHub. Once you have cloned the
 repository and installed all the above dependencies, run the following command
-from the root of the repository to install the master version of Altair:
+from the root of the repository to install the main version of Altair:
 
 .. code-block:: bash
 
@@ -46,7 +46,7 @@ development version directly from GitHub using:
 
     pip install -e git+https://github.com/altair-viz/altair.git
 
-Please see `CONTRIBUTING.md <https://github.com/altair-viz/altair/blob/master/CONTRIBUTING.md>`_
+Please see `CONTRIBUTING.md <https://github.com/altair-viz/altair/blob/main/CONTRIBUTING.md>`_
 for details on how to contribute to the Altair project.
 
 .. _conda: https://docs.conda.io/

--- a/doc/user_guide/internals.rst
+++ b/doc/user_guide/internals.rst
@@ -110,7 +110,7 @@ Altair's python object structure and Vega-Lite's schema definition structure.
 One of the nice features of Altair is that this low-level object hierarchy is not
 constructed by hand, but rather *programmatically generated* from the Vega-Lite
 schema, using the ``generate_schema_wrapper.py`` script that you can find in
-`Altair's repository <https://github.com/altair-viz/altair/blob/master/tools/generate_schema_wrapper.py>`_.
+`Altair's repository <https://github.com/altair-viz/altair/blob/main/tools/generate_schema_wrapper.py>`_.
 This auto-generation of code propagates descriptions from the vega-lite schema
 into the Python class docstrings, from which the
 `API Reference <http://altair-viz.github.io/user_guide/API.html>`_


### PR DESCRIPTION
As discussed in https://github.com/altair-viz/altair/pull/3124, this PR starts the process of migrating from `master` to `main` as the Altair development branch.

In particular, this PR updates the project's documentation to refer to `main`.  After merging this PR, we can use the GitHub interface to rename `master` to `main` (See https://github.com/github/renaming), and all of the open PRs will be updated automatically. It looks like I don't have permission to do this, so I expect @mattijn will need to be the one to make that change.

Once the repo itself is migrated, we should each follow [these instructions](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#updating-a-local-clone-after-a-branch-name-changes) to update our local development environments to correspond.