### PR TITLE
Add Roadmap and CoC to the documentation

### DIFF
--- a/doc/about/code_of_conduct.rst
+++ b/doc/about/code_of_conduct.rst
@@ -1,0 +1,127 @@
+Code of Conduct
+===============
+
+Our Pledge
+----------
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+Our Standards
+-------------
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Enforcement Responsibilities
+----------------------------
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+Scope
+-----
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+Enforcement
+-----------
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+vegajs.conduct@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+Enforcement Guidelines
+----------------------
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+1. Correction
+~~~~~~~~~~~~~
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+2. Warning
+~~~~~~~~~~
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+3. Temporary Ban
+~~~~~~~~~~~~~~~~
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+4. Permanent Ban
+~~~~~~~~~~~~~~~~
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+Attribution
+-----------
+This Code of Conduct is adapted from the `Contributor Covenant <https://www.contributor-covenant.org>`_,
+version 2.1, available at
+`https://www.contributor-covenant.org/version/2/1/code_of_conduct.html <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>`_.
+
+Community Impact Guidelines were inspired by
+`Mozilla's code of conduct enforcement ladder <https://github.com/mozilla/diversity>`_.
+
+For answers to common questions about this code of conduct, see the FAQ at
+`https://www.contributor-covenant.org/faq <https://www.contributor-covenant.org/faq>`_. Translations are available at
+`https://www.contributor-covenant.org/translations <https://www.contributor-covenant.org/translations>`_.

--- a/doc/about/roadmap.rst
+++ b/doc/about/roadmap.rst
@@ -1,0 +1,14 @@
+.. _roadmap:
+
+Roadmap
+=======
+
+Vega-Altair roadmap...
+
+.. toctree::
+   :maxdepth: 1
+   :caption: About
+   :hidden:
+
+   self
+   code_of_conduct

--- a/doc/about/roadmap.rst
+++ b/doc/about/roadmap.rst
@@ -82,6 +82,7 @@ support for gridded datasets.
 
 Areas of focus:
 
+* Add support for Python array/tensor interchange protocol (through the `__dlpack__` interface)
 * Add support for creating charts from Xarray
   `DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
   objects (rendering large arrays may require the performance work described elsewhere).

--- a/doc/about/roadmap.rst
+++ b/doc/about/roadmap.rst
@@ -38,6 +38,7 @@ Areas of focus:
 
 * Standardize the API of methods that convert charts into other formats (``alt.Chart().to_<format>``).
 
+* Add type hints to the public API and most of the internals so that users can type check their Altair code with a static type checker such as mypy. This will also make it easier for other packages to integrate with Altair.
 Documentation
 -------------
 We want to continue to improve Vega-Altair's official documentation to be more

--- a/doc/about/roadmap.rst
+++ b/doc/about/roadmap.rst
@@ -3,7 +3,149 @@
 Roadmap
 =======
 
-Vega-Altair roadmap...
+This page contains the current roadmap for the Vega-Altair project. The roadmap is
+informed by the needs of the Vega-Altair community, and the priorities of the active
+project contributors. It's designed to communicate the direction of the project,
+but it's not a commitment that these items will be completed in a particular timeframe.
+If you would like to help contribute to any of these areas, or suggest new ones,
+please `start a discussion <https://github.com/altair-viz/altair/discussions>`_.
+
+Vega-Altair is deeply integrated with other components in the Vega ecosystem,
+and as such many items on the roadmap will require work in other projects.
+Abbreviations for these projects are included at the end of project descriptions
+where relevant:
+
+* *(VL)* — `Vega-Lite <https://vega.github.io/vega-lite/>`_
+* *(VG)* — `Vega <https://vega.github.io/vega/>`_
+* *(VF)* — `VegaFusion <https://vegafusion.io/>`_
+* *(VC)* — `VlConvert <https://github.com/vega/vl-convert>`_
+
+API Ergonomics
+--------------
+The primary job of the Vega-Altair library is to provide an ergonomic Python
+API for generating Vega-Lite JSON specifications, and there are several improvements
+here that we would like to investigate.
+
+Areas of focus:
+
+* Improve the syntax for creating condition expressions with two or more
+  predicates.
+
+* Explore the possibility of a new operator, ``*``, for modular compositing of sub components.
+  See this composition proposal
+  `queryverse/VegaLite.jl#411 <https://github.com/queryverse/VegaLite.jl/pull/411>`_ and
+  also https://aog.makie.org/stable/generated/penguins/#Tutorial.
+
+* Standardize the API of methods that convert charts into other formats (``alt.Chart().to_<format>``).
+
+Documentation
+-------------
+We want to continue to improve Vega-Altair's official documentation to be more
+useful for both beginning and experienced users.
+
+Areas of focus:
+
+* Incorporate a conceptual guide that includes best practices of effective
+  data communication.
+
+* Update and extend the tutorial section and replace outdated materials.
+
+* Add usage guide with best practices for publishing Vega-Altair charts in various
+  contexts including websites, research papers, embedded dashboards, and interactive
+  platforms.
+
+* Add guide on building domain specific visualization packages on top of Vega-Altair.
+  For example, Vega-Altair for soccer analytics.
+
+* Add documentation for the expression language that is available throughout the API.
+
+Ecosystem Integration
+---------------------
+We want Vega-Altair to be well integrated with the PyData ecosystem. It should
+work well with popular libraries and ecosystem standards.
+
+Areas of focus:
+
+* Provide integration with the broader Python DataFrame ecosystem (beyond pandas). Ensure
+  that all of Vega-Altair's features are available to any DataFrame library that implements the
+  `DataFrame Interchange Protocol <https://data-apis.org/dataframe-protocol/latest/index.html>`_.
+
+* Work with dashboard toolkit maintainers to ensure that Vega-Altair is well supported.
+  Write documentation for best practices for making Vega-Altair's interactive features
+  available in Python.
+
+Gridded Data Support
+--------------------
+Vega-Altair currently requires tidy tabular data as input, so it is not currently a natural
+choice for working with gridded data. We would like to extend the project to include native
+support for gridded datasets.
+
+Areas of focus:
+
+* Add support for creating charts from Xarray
+  `DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
+  objects (rendering large arrays may require the performance work described elsewhere).
+
+Increased Coverage of Statistical Charts
+----------------------------------------
+While Vega-Altair includes support for many types of statistical visualizations,
+there are a few important types that are not yet possible.
+
+Areas of focus:
+
+* Add support for 2D density visualizations
+  (`vega-lite#6043 <https://github.com/vega/vega-lite/issues/6043>`_) *(VL)*
+
+* Add Violin chart support
+  (`vega-lite#3442 <https://github.com/vega/vega-lite/issues/3442>`_) *(VL)*
+
+Map Tile Support
+----------------
+We want Vega-Altair to provide first-class support for displaying map tiles from
+xyz tile providers like OpenStreetMap. Early development is in progress in the
+`altair_tiles <https://github.com/altair-viz/altair_tiles>`_ repository.
+
+Scale/Performance Improvements
+------------------------------
+In the traditional Vega-Altair architecture, a chart's entire input dataset is serialized
+to JSON and transferred to the browser for data transformation and rendering. Rendering
+itself is then preformed by The Vega JavaScript library using the Canvas API (which is
+not GPU accelerated). This architecture has many advantages (e.g. chart specifications
+are fully self-contained and portable to Python-free rendering environments), but it
+is not well suited for creating charts of large datasets.
+
+Through a variety of enhancements, our goal is to allow all Vega-Altair charts to
+scale comfortably to over 1 million rows.
+
+Areas of focus:
+
+* Provide optional integration with VegaFusion to automatically
+  move data transformation steps from the browser to efficient multi-threaded implementations
+  in the Python kernel.
+* Utilize binary serialization of datasets in Apache Arrow IPC format between the Python kernel
+  and the browser. This will significant reduce serialization time for large unaggregated
+  visualizations such as scatter plots.
+* Support creating Vega-Altair charts that reference tables in external database systems, and convert
+  data transformation steps to SQL that can be evaluated by the database before the results are
+  transferred to the Python kernel *(VF)*.
+* Add support for GPU accelerated rendering. This will enable rendering of large unnagregated
+  visualizations at interactive speeds. For example, pan and zoom interactions on a large scatter
+  plot *(VG)*.
+
+Static Image Export
+-------------------
+Even though Vega-Altair charts are rendered by the Vega JavaScript library, it's important to
+provide reliable (and easy to install) support for exporting charts to static images. Image
+export was dramatically simplified in Vega-Altair 5.0 with the adoption of VlConvert,
+which has no external dependencies on a system web-browser or Node.js installation. Now that
+image export is easy to install and easy to use, we want to improve support for publication
+workflows.
+
+Areas of focus:
+
+* Support configurable pixel density in PNG image export *(VC)*.
+
+* Support exporting charts to vector PDF files with embedded text *(VC)*.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/about/roadmap.rst
+++ b/doc/about/roadmap.rst
@@ -110,7 +110,7 @@ Scale/Performance Improvements
 ------------------------------
 In the traditional Vega-Altair architecture, a chart's entire input dataset is serialized
 to JSON and transferred to the browser for data transformation and rendering. Rendering
-itself is then preformed by The Vega JavaScript library using the Canvas API (which is
+itself is then performed by The Vega JavaScript library using the Canvas API (which is
 not GPU accelerated). This architecture has many advantages (e.g. chart specifications
 are fully self-contained and portable to Python-free rendering environments), but it
 is not well suited for creating charts of large datasets.

--- a/doc/about/roadmap.rst
+++ b/doc/about/roadmap.rst
@@ -38,7 +38,10 @@ Areas of focus:
 
 * Standardize the API of methods that convert charts into other formats (``alt.Chart().to_<format>``).
 
-* Add type hints to the public API and most of the internals so that users can type check their Altair code with a static type checker such as mypy. This will also make it easier for other packages to integrate with Altair.
+* Add type hints to the public API and most of the internals so that users can type check their Altair
+  code with a static type  checker such as mypy. This will also make it easier for other packages to
+  integrate with Altair.
+
 Documentation
 -------------
 We want to continue to improve Vega-Altair's official documentation to be more
@@ -84,6 +87,7 @@ support for gridded datasets.
 Areas of focus:
 
 * Add support for Python array/tensor interchange protocol (through the ``__dlpack__`` interface)
+
 * Add support for creating charts from Xarray
   `DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
   objects (rendering large arrays may require the performance work described elsewhere).
@@ -124,12 +128,15 @@ Areas of focus:
 * Provide optional integration with VegaFusion to automatically
   move data transformation steps from the browser to efficient multi-threaded implementations
   in the Python kernel.
+
 * Utilize binary serialization of datasets in Apache Arrow IPC format between the Python kernel
   and the browser. This will significant reduce serialization time for large unaggregated
   visualizations such as scatter plots.
+
 * Support creating Vega-Altair charts that reference tables in external database systems, and convert
   data transformation steps to SQL that can be evaluated by the database before the results are
   transferred to the Python kernel *(VF)*.
+
 * Add support for GPU accelerated rendering. This will enable rendering of large unnagregated
   visualizations at interactive speeds. For example, pan and zoom interactions on a large scatter
   plot *(VG)*.

--- a/doc/about/roadmap.rst
+++ b/doc/about/roadmap.rst
@@ -82,7 +82,7 @@ support for gridded datasets.
 
 Areas of focus:
 
-* Add support for Python array/tensor interchange protocol (through the `__dlpack__` interface)
+* Add support for Python array/tensor interchange protocol (through the ``__dlpack__`` interface)
 * Add support for creating charts from Xarray
   `DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
   objects (rendering large arrays may require the performance work described elsewhere).

--- a/doc/getting_started/overview.rst
+++ b/doc/getting_started/overview.rst
@@ -51,4 +51,5 @@ This documentation serves as the main reference for learning about Altair. Addit
    installation
    starting
    getting_help
+   resources
    project_philosophy

--- a/doc/getting_started/resources.rst
+++ b/doc/getting_started/resources.rst
@@ -1,4 +1,4 @@
-.. _ecosystem:
+.. _resources:
 
 Resources
 =========

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -59,7 +59,6 @@ Vega-Altair: Declarative Visualization in Python
    User Guide <user_guide/data>
    Examples <gallery/index>
    API <user_guide/api>
-   user_guide/ecosystem
    releases/changes
 
 .. _GitHub: http://github.com/altair-viz/altair

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,6 +60,7 @@ Vega-Altair: Declarative Visualization in Python
    Examples <gallery/index>
    API <user_guide/api>
    releases/changes
+   About <about/roadmap>
 
 .. _GitHub: http://github.com/altair-viz/altair
 .. _Git Issues: http://github.com/altair-viz/altair/issues


### PR DESCRIPTION
This PR adds a new top-level "About" section to the documentation and includes subsections for:
 - Roadmap
 - Code of Conduct

The Roadmap is drawn from the discussion in https://github.com/altair-viz/altair/discussions/3125. Please review and, for maintainers, feel free to commit to this branch if there are things you'd like to add.

Note, to make space for the About section (the sphinx theme only displays 6 top-level sections by default), I moved the top-level Resources page into the Getting Started section.