### PR TITLE
Add governance page to the website

### DIFF
--- a/doc/about/governance.rst
+++ b/doc/about/governance.rst
@@ -1,0 +1,16 @@
+Governance
+==========
+Vega-Altair's governance structure is based on GitHub's
+`Minimum Viable Governance <https://github.com/github/MVG>`_ (MVG) template.
+
+Organizational Governance
+-------------------------
+The Altair-Viz organization is governed by the documents that reside in the
+`governance/org-docs <https://github.com/altair-viz/altair/tree/main/governance/org-docs>`_ directory of the
+Vega-Altair GitHub repository.
+
+Project Governance
+------------------
+The Vega-Altair library is governed by the documents that reside in the
+`governance/project-docs <https://github.com/altair-viz/altair/tree/main/governance/project-docs>`_ directory of
+the Vega-Altair GitHub repository.

--- a/doc/about/roadmap.rst
+++ b/doc/about/roadmap.rst
@@ -163,3 +163,4 @@ Areas of focus:
 
    self
    code_of_conduct
+   governance


### PR DESCRIPTION
Adds a brief governance page to the About section of the website that includes links to the `org-docs` and `project-docs` directories.