### PR TITLE
Refactor optional import logic and verify minimum versions

### DIFF
--- a/NOTES_FOR_MAINTAINERS.md
+++ b/NOTES_FOR_MAINTAINERS.md
@@ -49,6 +49,14 @@ of some docstrings.
 Major version updates (e.g. Vega-Lite 1.X->2.X) have required substantial
 rewrites, because the internal structure of the schema changed appreciably.
 
+### Updating vl-convert version bound
+When updating the version of Vega-Lite, it's important to ensure that 
+[vl-convert](https://github.com/vega/vl-convert) includes support for the new Vega-Lite version. 
+Check the [vl-convert releases](https://github.com/vega/vl-convert/releases) to find the minimum
+version of vl-convert that includes support for the desired version of Vega-Lite (and [open
+an issue](https://github.com/vega/vl-convert/issues) if this version hasn't been
+included in a released yet.). Update the vl-convert version check in `altair/utils/_importers.py` 
+with the new minimum required version of vl-convert.
 
 ## Releasing the Package
 

--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -1,0 +1,82 @@
+from types import ModuleType
+from packaging.version import Version
+
+
+def import_vegafusion() -> ModuleType:
+    min_vf_version = "1.4.0"
+    try:
+        import vegafusion as vf  # type: ignore
+
+        if Version(vf.__version__) < Version(min_vf_version):
+            raise ImportError(
+                f"The vegafusion package must be version {min_vf_version} or greater. "
+                f"Found version {vf.__version__}"
+            )
+        return vf
+    except ImportError as err:
+        raise ImportError(
+            'The "vegafusion" data transformer and chart.transformed_data feature requires\n'
+            f"version {min_vf_version} or greater of the 'vegafusion-python-embed' and 'vegafusion' packages.\n"
+            "These can be installed with pip using:\n"
+            f'    pip install "vegafusion[embed]>={min_vf_version}"\n'
+            "Or with conda using:\n"
+            f'    conda install -c conda-forge "vegafusion-python-embed>={min_vf_version}" '
+            f'"vegafusion>={min_vf_version}"\n\n'
+            f"ImportError: {err.args[0]}"
+        ) from err
+
+
+def import_vl_convert() -> ModuleType:
+    min_vlc_version = "0.12.0"
+    try:
+        import vl_convert as vlc
+
+        if Version(vlc.__version__) < Version(min_vlc_version):
+            raise ImportError(
+                f"The vl-convert-python package must be version {min_vlc_version} or greater. "
+                f"Found version {vlc.__version__}"
+            )
+        return vlc
+    except ImportError as err:
+        raise ImportError(
+            f"The vl-convert Vega-Lite compiler and image export feature requires\n"
+            f"version {min_vlc_version} or greater of the 'vl-convert-python' package. \n"
+            f"This can be installed with pip using:\n"
+            f'   pip install "vl-convert-python>={min_vlc_version}"\n'
+            "or conda:\n"
+            f'   conda install -c conda-forge "vl-convert-python>={min_vlc_version}"\n\n'
+            f"ImportError: {err.args[0]}"
+        ) from err
+
+
+def import_pyarrow_interchange() -> ModuleType:
+    min_pa_version = "11.0.0"
+    try:
+        import pyarrow as pa
+
+        if Version(pa.__version__) < Version(min_pa_version):
+            raise ImportError(
+                f"The pyarrow package must be version {min_pa_version} or greater. "
+                f"Found version {pa.__version__}"
+            )
+        import pyarrow.interchange as pi
+
+        return pi
+    except ImportError as err:
+        raise ImportError(
+            f"Usage of the DataFrame Interchange Protocol requires\n"
+            f"version {min_pa_version} or greater of the pyarrow package. \n"
+            f"This can be installed with pip using:\n"
+            f'   pip install "pyarrow>={min_pa_version}"\n'
+            "or conda:\n"
+            f'   conda install -c conda-forge "pyarrow>={min_pa_version}"\n\n'
+            f"ImportError: {err.args[0]}"
+        ) from err
+
+
+def pyarrow_available() -> bool:
+    try:
+        import_pyarrow_interchange()
+        return True
+    except ImportError:
+        return False

--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -1,63 +1,66 @@
 from types import ModuleType
 from packaging.version import Version
+from importlib.metadata import version as importlib_version
 
 
 def import_vegafusion() -> ModuleType:
-    min_vf_version = "1.4.0"
+    min_version = "1.4.0"
     try:
+        version = importlib_version("vegafusion")
+        if Version(version) < Version(min_version):
+            raise ImportError(
+                f"The vegafusion package must be version {min_version} or greater. "
+                f"Found version {version}"
+            )
         import vegafusion as vf  # type: ignore
 
-        if Version(vf.__version__) < Version(min_vf_version):
-            raise ImportError(
-                f"The vegafusion package must be version {min_vf_version} or greater. "
-                f"Found version {vf.__version__}"
-            )
         return vf
     except ImportError as err:
         raise ImportError(
             'The "vegafusion" data transformer and chart.transformed_data feature requires\n'
-            f"version {min_vf_version} or greater of the 'vegafusion-python-embed' and 'vegafusion' packages.\n"
+            f"version {min_version} or greater of the 'vegafusion-python-embed' and 'vegafusion' packages.\n"
             "These can be installed with pip using:\n"
-            f'    pip install "vegafusion[embed]>={min_vf_version}"\n'
+            f'    pip install "vegafusion[embed]>={min_version}"\n'
             "Or with conda using:\n"
-            f'    conda install -c conda-forge "vegafusion-python-embed>={min_vf_version}" '
-            f'"vegafusion>={min_vf_version}"\n\n'
+            f'    conda install -c conda-forge "vegafusion-python-embed>={min_version}" '
+            f'"vegafusion>={min_version}"\n\n'
             f"ImportError: {err.args[0]}"
         ) from err
 
 
 def import_vl_convert() -> ModuleType:
-    min_vlc_version = "0.12.0"
+    min_version = "0.12.0"
     try:
+        version = importlib_version("vl-convert-python")
+        if Version(version) < Version(min_version):
+            raise ImportError(
+                f"The vl-convert-python package must be version {min_version} or greater. "
+                f"Found version {version}"
+            )
         import vl_convert as vlc
 
-        if Version(vlc.__version__) < Version(min_vlc_version):
-            raise ImportError(
-                f"The vl-convert-python package must be version {min_vlc_version} or greater. "
-                f"Found version {vlc.__version__}"
-            )
         return vlc
     except ImportError as err:
         raise ImportError(
             f"The vl-convert Vega-Lite compiler and image export feature requires\n"
-            f"version {min_vlc_version} or greater of the 'vl-convert-python' package. \n"
+            f"version {min_version} or greater of the 'vl-convert-python' package. \n"
             f"This can be installed with pip using:\n"
-            f'   pip install "vl-convert-python>={min_vlc_version}"\n'
+            f'   pip install "vl-convert-python>={min_version}"\n'
             "or conda:\n"
-            f'   conda install -c conda-forge "vl-convert-python>={min_vlc_version}"\n\n'
+            f'   conda install -c conda-forge "vl-convert-python>={min_version}"\n\n'
             f"ImportError: {err.args[0]}"
         ) from err
 
 
 def import_pyarrow_interchange() -> ModuleType:
-    min_pa_version = "11.0.0"
+    min_version = "11.0.0"
     try:
-        import pyarrow as pa
+        version = importlib_version("pyarrow")
 
-        if Version(pa.__version__) < Version(min_pa_version):
+        if Version(version) < Version(min_version):
             raise ImportError(
-                f"The pyarrow package must be version {min_pa_version} or greater. "
-                f"Found version {pa.__version__}"
+                f"The pyarrow package must be version {min_version} or greater. "
+                f"Found version {version}"
             )
         import pyarrow.interchange as pi
 
@@ -65,11 +68,11 @@ def import_pyarrow_interchange() -> ModuleType:
     except ImportError as err:
         raise ImportError(
             f"Usage of the DataFrame Interchange Protocol requires\n"
-            f"version {min_pa_version} or greater of the pyarrow package. \n"
+            f"version {min_version} or greater of the pyarrow package. \n"
             f"This can be installed with pip using:\n"
-            f'   pip install "pyarrow>={min_pa_version}"\n'
+            f'   pip install "pyarrow>={min_version}"\n'
             "or conda:\n"
-            f'   conda install -c conda-forge "pyarrow>={min_pa_version}"\n\n'
+            f'   conda install -c conda-forge "pyarrow>={min_version}"\n\n'
             f"ImportError: {err.args[0]}"
         ) from err
 

--- a/altair/utils/_transformed_data.py
+++ b/altair/utils/_transformed_data.py
@@ -24,7 +24,7 @@ from altair import (
     FacetSpec,
     data_transformers,
 )
-from altair.utils._vegafusion_data import get_inline_tables
+from altair.utils._vegafusion_data import get_inline_tables, import_vegafusion
 from altair.utils.core import _DataFrameLike
 from altair.utils.schemapi import Undefined
 
@@ -91,16 +91,7 @@ def transformed_data(chart, row_limit=None, exclude=None):
         transformed data. Otherwise, returns a list of DataFrames of the
         transformed data
     """
-    try:
-        from vegafusion import runtime, get_local_tz  # type: ignore
-    except ImportError as err:
-        raise ImportError(
-            "transformed_data requires the vegafusion-python-embed and vegafusion packages\n"
-            "These can be installed with pip using:\n"
-            "    pip install vegafusion[embed]\n"
-            "Or with conda using:\n"
-            "    conda install -c conda-forge vegafusion-python-embed vegafusion"
-        ) from err
+    vf = import_vegafusion()
 
     if isinstance(chart, Chart):
         # Add mark if none is specified to satisfy Vega-Lite
@@ -133,7 +124,7 @@ def transformed_data(chart, row_limit=None, exclude=None):
             raise ValueError("Failed to locate all datasets")
 
     # Extract transformed datasets with VegaFusion
-    datasets, warnings = runtime.pre_transform_datasets(
+    datasets, warnings = vf.runtime.pre_transform_datasets(
         vega_spec,
         dataset_names,
         get_local_tz(),

--- a/altair/utils/_transformed_data.py
+++ b/altair/utils/_transformed_data.py
@@ -127,7 +127,6 @@ def transformed_data(chart, row_limit=None, exclude=None):
     datasets, warnings = vf.runtime.pre_transform_datasets(
         vega_spec,
         dataset_names,
-        get_local_tz(),
         row_limit=row_limit,
         inline_datasets=inline_datasets,
     )

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -6,6 +6,7 @@ from typing import Union, Dict, Set, MutableMapping
 
 from typing import TypedDict, Final
 
+from altair.utils._importers import import_vegafusion
 from altair.utils.core import _DataFrameLike
 from altair.utils.data import _DataType, _ToValuesReturnType, MaxRowsError
 from altair.vegalite.data import default_data_transformer
@@ -145,16 +146,7 @@ def compile_with_vegafusion(vegalite_spec: dict) -> dict:
     # Local import to avoid circular ImportError
     from altair import vegalite_compilers, data_transformers
 
-    try:
-        import vegafusion as vf  # type: ignore
-    except ImportError as e:
-        raise ImportError(
-            'The "vegafusion" data transformer requires the vegafusion-python-embed\n'
-            "and vegafusion packages. These can be installed with pip using:\n"
-            '    pip install "vegafusion[embed]"\n'
-            "Or with conda using:\n"
-            "    conda install -c conda-forge vegafusion-python-embed vegafusion"
-        ) from e
+    vf = import_vegafusion()
 
     # Compile Vega-Lite spec to Vega
     compiler = vegalite_compilers.get()

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -519,7 +519,7 @@ def parse_shorthand(
     >>> parse_shorthand('count()', data) == {'aggregate': 'count', 'type': 'quantitative'}
     True
     """
-    from altair.utils.data import pyarrow_available
+    from altair.utils._importers import pyarrow_available
 
     if not shorthand:
         return {}

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -3,15 +3,13 @@ import os
 import random
 import hashlib
 import warnings
-from importlib.metadata import version as importlib_version, PackageNotFoundError
 from typing import Union, MutableMapping, Optional, Dict, Sequence, TYPE_CHECKING, List
-from types import ModuleType
 
 import pandas as pd
 from toolz import curried
 from typing import TypeVar
-from packaging.version import Version
 
+from ._importers import import_pyarrow_interchange
 from .core import sanitize_dataframe, sanitize_arrow_table, _DataFrameLike
 from .core import sanitize_geo_interface
 from .deprecation import AltairDeprecationWarning
@@ -348,31 +346,3 @@ def curry(*args, **kwargs):
         stacklevel=1,
     )
     return curried.curry(*args, **kwargs)
-
-
-def import_pyarrow_interchange() -> ModuleType:
-    try:
-        pyarrow_version_str = importlib_version("pyarrow")
-    except PackageNotFoundError as err:
-        raise ImportError(
-            "Usage of the DataFrame Interchange Protocol requires the package"
-            + " 'pyarrow', but it is not installed."
-        ) from err
-    else:
-        if Version(pyarrow_version_str) < Version("11.0.0"):
-            raise ImportError(
-                "The installed version of 'pyarrow' does not meet the minimum requirement of version 11.0.0. "
-                "Please update 'pyarrow' to use the DataFrame Interchange Protocol."
-            )
-        else:
-            import pyarrow.interchange as pi
-
-            return pi
-
-
-def pyarrow_available() -> bool:
-    try:
-        import_pyarrow_interchange()
-        return True
-    except ImportError:
-        return False

--- a/altair/vegalite/v5/compiler.py
+++ b/altair/vegalite/v5/compiler.py
@@ -1,3 +1,4 @@
+from ...utils._importers import import_vl_convert
 from ...utils.compiler import VegaLiteCompilerRegistry
 
 from typing import Final
@@ -13,12 +14,7 @@ def vl_convert_compiler(vegalite_spec: dict) -> dict:
     """
     from . import SCHEMA_VERSION
 
-    try:
-        import vl_convert as vlc
-    except ImportError as err:
-        raise ImportError(
-            "The vl-convert Vega-Lite compiler requires the vl-convert-python package"
-        ) from err
+    vlc = import_vl_convert()
 
     # Compute vl-convert's vl_version string (of the form 'v5_8')
     # from SCHEMA_VERSION (of the form 'v5.8.0')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
     "types-jsonschema",
     "types-setuptools",
     "pyarrow>=11",
-    "vegafusion[embed]",
+    "vegafusion[embed]>=1.4.0",
     "anywidget"
 ]
 doc = [


### PR DESCRIPTION
This PR moves the optional import logic for pyarrow, vegafusion, and vl-convert to `util._importers` and checks for minimum supported versions of vegafusion (1.4.0) and vl-convert (0.12.0).