### PR TITLE
Use import_vl_convert in _spec_to_mimebundle_with_engine for better error message

### DIFF
--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -1,4 +1,5 @@
 from .html import spec_to_html
+from ._importers import import_vl_convert
 import struct
 
 
@@ -103,7 +104,7 @@ def _spec_to_mimebundle_with_engine(spec, format, mode, **kwargs):
     normalized_engine = _validate_normalize_engine(engine, format)
 
     if normalized_engine == "vlconvert":
-        import vl_convert as vlc
+        vlc = import_vl_convert()
         from ..vegalite import SCHEMA_VERSION
 
         # Compute VlConvert's vl_version string (of the form 'v5_2')

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -171,7 +171,7 @@ def _validate_normalize_engine(engine, format):
     """
     # Try to import vl_convert
     try:
-        import vl_convert as vlc
+        vlc = import_vl_convert()
     except ImportError:
         vlc = None
 

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -27,7 +27,8 @@ Bug Fixes
 Backward-Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - Drop support for Python 3.7 which is end-of-life (#3100)
-- Increase minimum required Pandas version to 0.25 (#3130)
+- Hard dependencies: Increase minimum required pandas version to 0.25 (#3130)
+- Soft dependencies: Increase minimum required vl-convert-python version to 0.13.0 and increase minimum required vegafusion version to 1.4.0 (#3163, #3160)
 
 Version 5.0.1 (released May 26, 2023)
 -------------------------------------


### PR DESCRIPTION
Updates `_spec_to_mimebundle_with_engine` to use `import_vl_convert` to import vl-convert so that we get a good minimum version constraint error message (rather than a ppi param does not exist error).