### PR TITLE
infer dtype pandas fallback

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -586,7 +586,15 @@ def parse_shorthand(
                 unescaped_field = attrs["field"].replace("\\", "")
                 if unescaped_field in dfi.column_names():
                     column = dfi.get_column_by_name(unescaped_field)
-                    attrs["type"] = infer_vegalite_type_for_dfi_column(column)
+                    try:
+                        attrs["type"] = infer_vegalite_type_for_dfi_column(column)
+                    except NotImplementedError:
+                        # Fall back to pandas-based inference
+                        if isinstance(data, pd.DataFrame):
+                            attrs["type"] = infer_vegalite_type(data[unescaped_field])
+                        else:
+                            raise
+
                     if isinstance(attrs["type"], tuple):
                         attrs["sort"] = attrs["type"][1]
                         attrs["type"] = attrs["type"][0]

--- a/tests/utils/test_core.py
+++ b/tests/utils/test_core.py
@@ -134,7 +134,8 @@ def test_parse_shorthand():
     )
 
 
-def test_parse_shorthand_with_data():
+@pytest.mark.parametrize("object_dtype", [False, True])
+def test_parse_shorthand_with_data(object_dtype):
     def check(s, data, **kwargs):
         assert parse_shorthand(s, data) == kwargs
 
@@ -146,6 +147,9 @@ def test_parse_shorthand_with_data():
             "t": pd.date_range("2018-01-01", periods=5, freq="D").tz_localize("UTC"),
         }
     )
+
+    if object_dtype:
+        data = data.astype("object")
 
     check("x", data, field="x", type="quantitative")
     check("y", data, field="y", type="nominal")


### PR DESCRIPTION
Closes https://github.com/altair-viz/altair/issues/3177.

This PR updates the `parse_shorthand` type inference logic to fall back to the pandas-based implementation (that which was always used in Altair 5.0) when the DataFrame Interchange approach raises a `NotImplementedError`.