### PR TITLE
Update to Vega-Lite 5.15.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,28 @@ git switch -c <your-branch-name>
 
 With this branch checked-out, make the desired changes to the package.
 
+### Updating the Vega-Lite version
+
+If your desired changes include updating the Vega-Lite that Altair uses
+you need to change the following section in ``tools/generate_schema_wrapper.py``
+to the desired version number
+
+```python
+SCHEMA_VERSION = {
+    "vega-lite": {"v5": "v5.15.0"},
+}
+```
+
+Then regenerate any automatically generated files
+as described in the next section.
+
+### Updating any automatically generated files
+
+A large part of Altair's code base is automatically generated.
+After you have made your manual changes,
+make sure to run the following to see if there are any changes
+to the automatically generated files: ``tools/generate_schema_wrapper.py``.
+
 ### Testing your Changes
 
 Before suggesting your contributing your changing to the main Altair repository,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,27 +53,13 @@ git switch -c <your-branch-name>
 
 With this branch checked-out, make the desired changes to the package.
 
-### Updating the Vega-Lite version
-
-If your desired changes include updating the Vega-Lite that Altair uses
-you need to change the following section in ``tools/generate_schema_wrapper.py``
-to the desired version number
-
-```python
-SCHEMA_VERSION = {
-    "vega-lite": {"v5": "v5.15.0"},
-}
-```
-
-Then regenerate any automatically generated files
-as described in the next section.
-
-### Updating any automatically generated files
-
 A large part of Altair's code base is automatically generated.
 After you have made your manual changes,
 make sure to run the following to see if there are any changes
-to the automatically generated files: ``tools/generate_schema_wrapper.py``.
+to the automatically generated files: `python tools/generate_schema_wrapper.py`.
+
+For information on how to update the Vega-Lite version that Altair uses,
+please read [the maintainers' notes](NOTES_FOR_MAINTAINERS.md).
 
 ### Testing your Changes
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,5 @@
-1. Create a new virtual environment following the instructions in `CONTRIBUTING.md`. 
-   Make sure to also install all dependencies for the documentation including `altair_saver`
-   and uninstall `vl-convert-python` (this is not needed for normal contributions to the repo, see `CONTRIBUTING.md` for details).
+1. Create a new virtual environment following the instructions in `CONTRIBUTING.md`.
+   Make sure to also install all dependencies for the documentation.
 
 2. Make certain your branch is in sync with head:
  

--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -29,7 +29,7 @@ def import_vegafusion() -> ModuleType:
 
 
 def import_vl_convert() -> ModuleType:
-    min_version = "0.13.0"
+    min_version = "0.14.0"
     try:
         version = importlib_version("vl-convert-python")
         if Version(version) < Version(min_version):

--- a/altair/vegalite/v5/schema/__init__.py
+++ b/altair/vegalite/v5/schema/__init__.py
@@ -1,5 +1,5 @@
 # ruff: noqa
 from .core import *
 from .channels import *
-SCHEMA_VERSION = 'v5.15.0'
-SCHEMA_URL = 'https://vega.github.io/schema/vega-lite/v5.15.0.json'
+SCHEMA_VERSION = 'v5.15.1'
+SCHEMA_URL = 'https://vega.github.io/schema/vega-lite/v5.15.1.json'

--- a/altair/vegalite/v5/schema/__init__.py
+++ b/altair/vegalite/v5/schema/__init__.py
@@ -1,5 +1,5 @@
 # ruff: noqa
 from .core import *
 from .channels import *
-SCHEMA_VERSION = 'v5.14.1'
-SCHEMA_URL = 'https://vega.github.io/schema/vega-lite/v5.14.1.json'
+SCHEMA_VERSION = 'v5.15.0'
+SCHEMA_URL = 'https://vega.github.io/schema/vega-lite/v5.15.0.json'

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -7057,6 +7057,13 @@ class IntervalSelectionConfig(VegaLiteSchema):
         **See also:** The `projection with encodings and fields section
         <https://vega.github.io/vega-lite/docs/selection.html#project>`__ in the
         documentation.
+    fields : List(:class:`FieldName`)
+        An array of field names whose values must match for a data tuple to fall within the
+        selection.
+
+        **See also:** The `projection with encodings and fields section
+        <https://vega.github.io/vega-lite/docs/selection.html#project>`__ in the
+        documentation.
     mark : :class:`BrushConfig`
         An interval selection also adds a rectangle mark to depict the extents of the
         interval. The ``mark`` property can be used to customize the appearance of the mark.
@@ -7121,10 +7128,11 @@ class IntervalSelectionConfig(VegaLiteSchema):
     """
     _schema = {'$ref': '#/definitions/IntervalSelectionConfig'}
 
-    def __init__(self, type=Undefined, clear=Undefined, encodings=Undefined, mark=Undefined,
-                 on=Undefined, resolve=Undefined, translate=Undefined, zoom=Undefined, **kwds):
+    def __init__(self, type=Undefined, clear=Undefined, encodings=Undefined, fields=Undefined,
+                 mark=Undefined, on=Undefined, resolve=Undefined, translate=Undefined, zoom=Undefined,
+                 **kwds):
         super(IntervalSelectionConfig, self).__init__(type=type, clear=clear, encodings=encodings,
-                                                      mark=mark, on=on, resolve=resolve,
+                                                      fields=fields, mark=mark, on=on, resolve=resolve,
                                                       translate=translate, zoom=zoom, **kwds)
 
 
@@ -7149,6 +7157,13 @@ class IntervalSelectionConfigWithoutType(VegaLiteSchema):
     encodings : List(:class:`SingleDefUnitChannel`)
         An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
+
+        **See also:** The `projection with encodings and fields section
+        <https://vega.github.io/vega-lite/docs/selection.html#project>`__ in the
+        documentation.
+    fields : List(:class:`FieldName`)
+        An array of field names whose values must match for a data tuple to fall within the
+        selection.
 
         **See also:** The `projection with encodings and fields section
         <https://vega.github.io/vega-lite/docs/selection.html#project>`__ in the
@@ -7217,11 +7232,12 @@ class IntervalSelectionConfigWithoutType(VegaLiteSchema):
     """
     _schema = {'$ref': '#/definitions/IntervalSelectionConfigWithoutType'}
 
-    def __init__(self, clear=Undefined, encodings=Undefined, mark=Undefined, on=Undefined,
-                 resolve=Undefined, translate=Undefined, zoom=Undefined, **kwds):
+    def __init__(self, clear=Undefined, encodings=Undefined, fields=Undefined, mark=Undefined,
+                 on=Undefined, resolve=Undefined, translate=Undefined, zoom=Undefined, **kwds):
         super(IntervalSelectionConfigWithoutType, self).__init__(clear=clear, encodings=encodings,
-                                                                 mark=mark, on=on, resolve=resolve,
-                                                                 translate=translate, zoom=zoom, **kwds)
+                                                                 fields=fields, mark=mark, on=on,
+                                                                 resolve=resolve, translate=translate,
+                                                                 zoom=zoom, **kwds)
 
 
 class JoinAggregateFieldDef(VegaLiteSchema):
@@ -21862,7 +21878,8 @@ class EventType(WindowEventType):
 
     enum('click', 'dblclick', 'dragenter', 'dragleave', 'dragover', 'keydown', 'keypress',
     'keyup', 'mousedown', 'mousemove', 'mouseout', 'mouseover', 'mouseup', 'mousewheel',
-    'timer', 'touchend', 'touchmove', 'touchstart', 'wheel')
+    'pointerdown', 'pointermove', 'pointerout', 'pointerover', 'pointerup', 'timer', 'touchend',
+    'touchmove', 'touchstart', 'wheel')
     """
     _schema = {'$ref': '#/definitions/EventType'}
 

--- a/altair/vegalite/v5/schema/vega-lite-schema.json
+++ b/altair/vegalite/v5/schema/vega-lite-schema.json
@@ -8791,6 +8791,11 @@
         "mouseover",
         "mouseup",
         "mousewheel",
+        "pointerdown",
+        "pointermove",
+        "pointerout",
+        "pointerover",
+        "pointerup",
         "timer",
         "touchend",
         "touchmove",
@@ -12467,6 +12472,13 @@
           },
           "type": "array"
         },
+        "fields": {
+          "description": "An array of field names whose values must match for a data tuple to fall within the selection.\n\n__See also:__ The [projection with `encodings` and `fields` section](https://vega.github.io/vega-lite/docs/selection.html#project) in the documentation.",
+          "items": {
+            "$ref": "#/definitions/FieldName"
+          },
+          "type": "array"
+        },
         "mark": {
           "$ref": "#/definitions/BrushConfig",
           "description": "An interval selection also adds a rectangle mark to depict the extents of the interval. The `mark` property can be used to customize the appearance of the mark.\n\n__See also:__ [`mark` examples](https://vega.github.io/vega-lite/docs/selection.html#mark) in the documentation."
@@ -12532,6 +12544,13 @@
           "description": "An array of encoding channels. The corresponding data field values must match for a data tuple to fall within the selection.\n\n__See also:__ The [projection with `encodings` and `fields` section](https://vega.github.io/vega-lite/docs/selection.html#project) in the documentation.",
           "items": {
             "$ref": "#/definitions/SingleDefUnitChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "description": "An array of field names whose values must match for a data tuple to fall within the selection.\n\n__See also:__ The [projection with `encodings` and `fields` section](https://vega.github.io/vega-lite/docs/selection.html#project) in the documentation.",
+          "items": {
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -18,7 +18,7 @@ Backward-Incompatible Changes
 Version 5.1.2 (released Oct 4, 2023)
 ----------------------------------------
 
-- Update Vega-Lite from version 5.14.1 to version 5.16.0;
+- Update Vega-Lite from version 5.14.1 to version 5.15.1;
   see `Vega-Lite Release Notes <https://github.com/vega/vega-lite/releases>`_.
 
 Bug Fixes

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -24,6 +24,7 @@ Version 5.1.2 (released Oct 4, 2023)
 Bug Fixes
 ~~~~~~~~~
 - Remove usage of deprecated Pandas parameter ``convert_dtypes`` (#3191)
+- Fix encoding type inference for boolean columns when pyarrow is installed (#3210)
 
 Version 5.1.1 (released August 30, 2023)
 ----------------------------------------

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -15,6 +15,15 @@ Bug Fixes
 Backward-Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Version 5.1.2 (released Oct 4, 2023)
+----------------------------------------
+
+- Update Vega-Lite from version 5.14.1 to version 5.16.0;
+  see `Vega-Lite Release Notes <https://github.com/vega/vega-lite/releases>`_.
+
+Bug Fixes
+~~~~~~~~~
+- Remove usage of deprecated Pandas parameter ``convert_dtypes`` (#3191)
 
 Version 5.1.1 (released August 30, 2023)
 ----------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
     "pytest-cov",
     "m2r",
     "vega_datasets",
-    "vl-convert-python>=0.13.0",
+    "vl-convert-python>=0.14.0",
     "mypy",
     "pandas-stubs",
     "types-jsonschema",

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -29,7 +29,7 @@ from schemapi.utils import (  # noqa: E402
     resolve_references,
 )
 
-SCHEMA_VERSION: Final = "v5.15.0"
+SCHEMA_VERSION: Final = "v5.15.1"
 
 reLink = re.compile(r"(?<=\[)([^\]]+)(?=\]\([^\)]+\))", re.M)
 reSpecial = re.compile(r"[*_]{2,3}|`", re.M)

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -30,7 +30,7 @@ from schemapi.utils import (  # noqa: E402
 
 # Map of version name to github branch name.
 SCHEMA_VERSION = {
-    "vega-lite": {"v5": "v5.14.1"},
+    "vega-lite": {"v5": "v5.15.0"},
 }
 
 reLink = re.compile(r"(?<=\[)([^\]]+)(?=\]\([^\)]+\))", re.M)


### PR DESCRIPTION
@mattijn @binste @jonmmease @ChristopherDavisUCI Would you be OK if we make a 5.1.2 (this seems to small for 5.2?) early next week to update VL once https://github.com/vega/vega-lite/pull/9106 is merged and to include https://github.com/altair-viz/altair/pull/3191? It would be helpful for a class I'm teaching mid-next week. I can try to make the release since I'm the one who needs it, but if anyone has time to help if needed it is of course appreciated (the release instructions seem straightforward so hopefully I don't set anything on fire).

I put up this PR as a draft to make sure I am doing the correct thing when updating VL; I will flag for review when there is an actual VL 5.16 release. I bumped the version number in `tools/generate_schema_wrapper.py` and then ran `python tools/generate_schema_wrapper.py`, and then `hatch test`. Is that all?