### PR TITLE
Fix encoding type inference for boolean columns when pyarrow is installed

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -588,8 +588,10 @@ def parse_shorthand(
                     column = dfi.get_column_by_name(unescaped_field)
                     try:
                         attrs["type"] = infer_vegalite_type_for_dfi_column(column)
-                    except NotImplementedError:
-                        # Fall back to pandas-based inference
+                    except (NotImplementedError, AttributeError):
+                        # Fall back to pandas-based inference.
+                        # Note: The AttributeError catch is a workaround for
+                        # https://github.com/pandas-dev/pandas/issues/55332
                         if isinstance(data, pd.DataFrame):
                             attrs["type"] = infer_vegalite_type(data[unescaped_field])
                         else:

--- a/tests/utils/test_core.py
+++ b/tests/utils/test_core.py
@@ -143,6 +143,7 @@ def test_parse_shorthand_with_data(object_dtype):
         {
             "x": [1, 2, 3, 4, 5],
             "y": ["A", "B", "C", "D", "E"],
+            "b": pd.Series([True, False, True, False, None], dtype="boolean"),
             "z": pd.date_range("2018-01-01", periods=5, freq="D"),
             "t": pd.date_range("2018-01-01", periods=5, freq="D").tz_localize("UTC"),
         }
@@ -153,6 +154,7 @@ def test_parse_shorthand_with_data(object_dtype):
 
     check("x", data, field="x", type="quantitative")
     check("y", data, field="y", type="nominal")
+    check("b", data, field="b", type="nominal")
     check("z", data, field="z", type="temporal")
     check("t", data, field="t", type="temporal")
     check("count(x)", data, field="x", aggregate="count", type="quantitative")


### PR DESCRIPTION
Closes #3205 by working around https://github.com/pandas-dev/pandas/issues/55332