### PR TITLE
Perform type inference fallback on ValueError

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -588,7 +588,7 @@ def parse_shorthand(
                     column = dfi.get_column_by_name(unescaped_field)
                     try:
                         attrs["type"] = infer_vegalite_type_for_dfi_column(column)
-                    except (NotImplementedError, AttributeError):
+                    except (NotImplementedError, AttributeError, ValueError):
                         # Fall back to pandas-based inference.
                         # Note: The AttributeError catch is a workaround for
                         # https://github.com/pandas-dev/pandas/issues/55332


### PR DESCRIPTION
Follow on to https://github.com/altair-viz/altair/pull/3210 that adds `ValueError` to the list of exceptions that we catch and then fall back to the pandas implementation of encoding type inference.

This is to future proof for the pandas update in https://github.com/pandas-dev/pandas/pull/55338.