### PR TITLE
Do not display search keyboard shortcut on home page

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -70,9 +70,16 @@ properly displayed on mobile devices and not restricted to 20% */
   vertical-align: text-bottom;
   margin-right: 3px;
 }
-  
+
 .full-width-plot {
   width: 100%;
+}
+
+/* This hides the Ctrl + K from the search box on the start page
+ * to make it less distracting on the home page.
+ * The shortcut still shows up when clicking the search box */
+.search-button-field > .search-button__kbd-shortcut {
+    display: none;
 }
 
 /* Configurations for the start page

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -82,6 +82,11 @@ properly displayed on mobile devices and not restricted to 20% */
     display: none;
 }
 
+/* Use old light blue color for banner since it goes better with the Altair logo */
+.bd-header-announcement {
+    background-color: #daebf1 !important;
+}
+
 /* Configurations for the start page
 ------------------------------------ */
 .lead {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ doc = [
     "jinja2",
     "numpydoc",
     "pillow>=9,<10",
-    "pydata-sphinx-theme",
+    "pydata-sphinx-theme>=0.14.1",
     "geopandas",
     "myst-parser",
     "sphinx_copybutton",


### PR DESCRIPTION
There are a few style changes in the latest pydata sphinx theme. The Altair docs home page looks like this:

![image](https://github.com/altair-viz/altair/assets/4560057/37a631c5-1dbf-4e24-910d-5b7a3a5dc7f2)

After the changes in the latest pydata version it will look like this:

![image](https://github.com/altair-viz/altair/assets/4560057/b12015ed-1a9a-4724-b0a2-30e8a9f95b6b)

I like the centered navigation titles, but think the different color banner goes less well with the altair logo (although I don't feel strongly about this), and I definitely don't like that a keyboard shortcut is being displayed in the search box by default. After this PR, the home page looks like this:

![image](https://github.com/altair-viz/altair/assets/4560057/1064a705-d165-4479-a071-c4cd29c17f7c)

Once you click the search box, the keyboard shortcut still shows up:

![image](https://github.com/altair-viz/altair/assets/4560057/b9aa1bd3-023b-44cc-95dd-05f484892b4f)


I tried changing back the header color also, but couldn't quite figure out how to do it and want to avoid putting too much time into changing CSS rules. I tried something like this

```css
/* with and without ":after" */
.bd-header-announcement:after {
    background-color: #daebf1 !important;
}
```
