### PR TITLE
maint: GitHub action include `python-version` 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.10", "3.11", "3.12"]
         jsonschema-version: ["3.0", "latest"]
     name: py ${{ matrix.python-version }} js ${{ matrix.jsonschema-version }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ publish-clean-build = [
 
 [tool.black]
 line-length = 88
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 include = '\.pyi?$'
 extend-exclude = '''
 /(


### PR DESCRIPTION
Python 3.12 was released recently, this PR updates our GitHub action to also test against python 3.12. This PR is currently failing because pyarrow does not yet publish builds for python 3.12, see https://github.com/apache/arrow/issues/37880. 

By including `python-version` 3.12 I dropped 3.9 to avoid the number of tests that are run in parallel. So it becomes `python-version: ["3.8", "3.10", "3.11", "3.12"]`, not sure if that is a good idea. 