### PR TITLE
[ENH] Add Support for pd.Index, pd.Series, range to array type

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -958,7 +958,7 @@ class SchemaBase:
                 }
             )
             kwds = {
-                k: v.to_list() if isinstance(v, pd.Series) else v
+                k: v.to_list() if isinstance(v, (pd.Series, pd.Index)) else v
                 for k, v in kwds.items()
                 if k not in list(ignore) + ["shorthand"]
             }

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -958,7 +958,9 @@ class SchemaBase:
                 }
             )
             kwds = {
-                k: v for k, v in kwds.items() if k not in list(ignore) + ["shorthand"]
+                k: v.to_list() if isinstance(v, pd.Series) else v
+                for k, v in kwds.items()
+                if k not in list(ignore) + ["shorthand"]
             }
             if "mark" in kwds and isinstance(kwds["mark"], str):
                 kwds["mark"] = {"type": kwds["mark"]}

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -957,11 +957,15 @@ class SchemaBase:
                     if kwds.get(k, Undefined) is Undefined
                 }
             )
-            kwds = {
-                k: v.to_list() if isinstance(v, (pd.Series, pd.Index)) else v
-                for k, v in kwds.items()
-                if k not in list(ignore) + ["shorthand"]
-            }
+            for k, v in list(kwds.items()):
+                if k not in (list(ignore) + ["shorthand"]):
+                    if isinstance(v, (pd.Series, pd.Index)):
+                        kwds[k] = v.to_list()
+                    elif isinstance(v, range):
+                        kwds[k] = list(v)
+                else:
+                    kwds.pop(k, None)
+
             if "mark" in kwds and isinstance(kwds["mark"], str):
                 kwds["mark"] = {"type": kwds["mark"]}
             result = _todict(

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -955,11 +955,15 @@ class SchemaBase:
                     if kwds.get(k, Undefined) is Undefined
                 }
             )
-            kwds = {
-                k: v.to_list() if isinstance(v, (pd.Series, pd.Index)) else v
-                for k, v in kwds.items()
-                if k not in list(ignore) + ["shorthand"]
-            }
+            for k, v in list(kwds.items()):
+                if k not in (list(ignore) + ["shorthand"]):
+                    if isinstance(v, (pd.Series, pd.Index)):
+                        kwds[k] = v.to_list()
+                    elif isinstance(v, range):
+                        kwds[k] = list(v)
+                else:
+                    kwds.pop(k, None)
+
             if "mark" in kwds and isinstance(kwds["mark"], str):
                 kwds["mark"] = {"type": kwds["mark"]}
             result = _todict(

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -956,7 +956,7 @@ class SchemaBase:
                 }
             )
             kwds = {
-                k: v.to_list() if isinstance(v, pd.Series) else v
+                k: v.to_list() if isinstance(v, (pd.Series, pd.Index)) else v
                 for k, v in kwds.items()
                 if k not in list(ignore) + ["shorthand"]
             }

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -956,7 +956,9 @@ class SchemaBase:
                 }
             )
             kwds = {
-                k: v for k, v in kwds.items() if k not in list(ignore) + ["shorthand"]
+                k: v.to_list() if isinstance(v, pd.Series) else v
+                for k, v in kwds.items()
+                if k not in list(ignore) + ["shorthand"]
             }
             if "mark" in kwds and isinstance(kwds["mark"], str):
                 kwds["mark"] = {"type": kwds["mark"]}


### PR DESCRIPTION
try to deal with #2808 and #2877
add 
```
            for k, v in list(kwds.items()):
                if k not in (list(ignore) + ["shorthand"]):
                    if isinstance(v, (pd.Series, pd.Index)):
                        kwds[k] = v.to_list()
                    elif isinstance(v, range):
                        kwds[k] = list(v)
                else:
                    kwds.pop(k, None)
```
to convert to array type if it's pd.Series, pd.Index or range.
Not sure if it's right approach to convert inside to_dict() but not before (maybe in _todict?)

It can work on some test cases mentioned:
```
import altair as alt
from vega_datasets import data
import random
import pandas as pd
import numpy as np

n = 100
df = pd.DataFrame({"Category": [np.random.choice(["A","B","C","D"]) for i in range(n)],      
                   "Variable": [np.random.normal(0, 10) for i in range(n)]})

grouped = df.loc[:,['Category', 'Variable']] \
    .groupby(['Category']) \
    .median() \
    .sort_values(by='Variable').index

chart = alt.Chart(df).mark_boxplot().encode(
    x=alt.X("Category",sort=grouped),
    y='Variable'
)

chart
```
```
import altair as alt
import pandas as pd
from vega_datasets import data

barley = data.barley()

barley['variety'] = pd.Categorical(
    barley['variety'],
    ordered=True,
    categories=[
        'Manchuria',
         'No. 457',
         'No. 462',
         'No. 475',
         'Glabron',
         'Svansota',
         'Velvet',
         'Trebi',
         'Wisconsin No. 38',
         'Peatland'
    ]
)

chart = alt.Chart(barley).mark_bar().encode(
    x=alt.X('variety', sort=barley['variety'].cat.categories),  # This line needs manual conversion
    y=alt.Y('sum(yield)'),
    color='site:N'
)

chart
```

