### PR TITLE
maint: change to ruff for formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: black-ruff-mypy
+    name: ruff-mypy
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -17,13 +17,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
-    - name: Check formatting with black
-      run: |
-        black --diff --color .
-        black --check .
     - name: Lint with ruff
       run: |        
-        ruff check .
+        ruff check .        
+    - name: Check formatting with ruff
+      run: |
+        ruff format --diff .
+        ruff format --check .
     - name: Lint with mypy
       run: |
         mypy altair tests

--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -54,11 +54,11 @@ def _get_variable(name):
     if ip is None:
         raise ValueError(
             "Magic command must be run within an IPython "
-            "environemnt, in which get_ipython() is defined."
+            "environment, in which get_ipython() is defined."
         )
     if name not in ip.user_ns:
         raise NameError(
-            "argument '{}' does not match the " "name of any defined variable".format(
+            "argument '{}' does not match the name of any defined variable".format(
                 name
             )
         )

--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -58,8 +58,9 @@ def _get_variable(name):
         )
     if name not in ip.user_ns:
         raise NameError(
-            "argument '{}' does not match the "
-            "name of any defined variable".format(name)
+            "argument '{}' does not match the " "name of any defined variable".format(
+                name
+            )
         )
     return ip.user_ns[name]
 

--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -58,9 +58,7 @@ def _get_variable(name):
         )
     if name not in ip.user_ns:
         raise NameError(
-            "argument '{}' does not match the name of any defined variable".format(
-                name
-            )
+            "argument '{}' does not match the name of any defined variable".format(name)
         )
     return ip.user_ns[name]
 

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -380,18 +380,21 @@ def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:  # noqa: C901
             # geopandas >=0.6.1 uses the dtype geometry. Continue here
             # otherwise it will give an error on np.issubdtype(dtype, np.integer)
             continue
-        elif dtype_name in {
-            "Int8",
-            "Int16",
-            "Int32",
-            "Int64",
-            "UInt8",
-            "UInt16",
-            "UInt32",
-            "UInt64",
-            "Float32",
-            "Float64",
-        }:  # nullable integer datatypes (since 24.0) and nullable float datatypes (since 1.2.0)
+        elif (
+            dtype_name
+            in {
+                "Int8",
+                "Int16",
+                "Int32",
+                "Int64",
+                "UInt8",
+                "UInt16",
+                "UInt32",
+                "UInt64",
+                "Float32",
+                "Float64",
+            }
+        ):  # nullable integer datatypes (since 24.0) and nullable float datatypes (since 1.2.0)
             # https://pandas.pydata.org/pandas-docs/version/0.25/whatsnew/v0.24.0.html#optional-integer-na-support
             col = df[col_name].astype(object)
             df[col_name] = col.where(col.notnull(), None)

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -1079,7 +1079,7 @@ class SchemaBase:
         cls,
         json_string: str,
         validate: bool = True,
-        **kwargs: Any
+        **kwargs: Any,
         # Type hints for this method would get rather complicated
         # if we want to provide a more specific return type
     ) -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,7 @@ Source = "https://github.com/altair-viz/altair"
 [project.optional-dependencies]
 dev = [
     "hatch",
-    "ruff",
-    "black<24",
+    "ruff>=0.1.3",
     "ipython",
     "pytest",
     "pytest-cov",
@@ -104,8 +103,8 @@ features = ["dev"]
 
 [tool.hatch.envs.default.scripts]
 test = [
-    "black --diff --color --check .",
     "ruff check .",
+    "ruff format --diff --check .",
     "mypy altair tests",
     "python -m pytest --pyargs --doctest-modules tests altair",
 ]
@@ -146,27 +145,21 @@ publish-clean-build = [
     "(cd doc && bash sync_website.sh)",
 ]
 
-[tool.black]
-line-length = 88
-target-version = ["py38", "py39", "py310", "py311"]
-include = '\.pyi?$'
-extend-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.mypy_cache
-  | build
-  | dist
-  | doc
-  | tests/examples_arguments_syntax
-  | tests/examples_methods_syntax
-  | altair/vegalite/v\d*/schema
-)/
-'''
-
 [tool.ruff]
 target-version = "py38"
 line-length = 88
+indent-width = 4
+exclude = [
+    ".git",
+    "build",
+    "__pycache__",
+    "tests/examples_arguments_syntax",
+    "tests/examples_methods_syntax",
+    "tests/test_transformed_data.py",    
+    "altair/vegalite/v?/schema",
+]
+
+[tool.ruff.lint]
 select = [
     # flake8-bugbear
     "B",
@@ -181,15 +174,11 @@ select = [
     # flake8-tidy-imports
     "TID",
 ]
-ignore = [
-    # E203, E266, W503 not yet supported by ruff,
-    # see https://github.com/charliermarsh/ruff/issues/2402
+ignore = [  
     # Whitespace before ':'
-    # "E203",
+    "E203",
     # Too many leading '#' for block comment
-    # "E266",
-    # Line break occurred before a binary operator
-    # "W503",
+    "E266",
     # Line too long
     "E501",
     # Relative imports are banned
@@ -198,14 +187,12 @@ ignore = [
     # python>=3.10 only
     "B905",
 ]
-exclude = [
-    ".git",
-    "build",
-    "__pycache__",
-    "tests/examples_arguments_syntax",
-    "tests/examples_methods_syntax",
-    "altair/vegalite/v?/schema",
-]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "lf"
 
 [tool.ruff.mccabe]
 max-complexity = 18

--- a/sphinxext/utils.py
+++ b/sphinxext/utils.py
@@ -122,8 +122,9 @@ def get_docstring_and_rest(filename):
 
     if not isinstance(node, ast.Module):
         raise TypeError(
-            "This function only supports modules. "
-            "You provided {}".format(node.__class__.__name__)
+            "This function only supports modules. " "You provided {}".format(
+                node.__class__.__name__
+            )
         )
     try:
         # In python 3.7 module knows its docstring.

--- a/sphinxext/utils.py
+++ b/sphinxext/utils.py
@@ -122,7 +122,7 @@ def get_docstring_and_rest(filename):
 
     if not isinstance(node, ast.Module):
         raise TypeError(
-            "This function only supports modules. " "You provided {}".format(
+            "This function only supports modules. You provided {}".format(
                 node.__class__.__name__
             )
         )

--- a/tests/test_magics.py
+++ b/tests/test_magics.py
@@ -31,9 +31,7 @@ if IPYTHON_AVAILABLE:
 import pandas as pd
 table = pd.DataFrame.from_records({})
 the_data = table
-""".format(
-            DATA_RECORDS
-        )
+""".format(DATA_RECORDS)
     )
 
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -1077,7 +1077,7 @@ class SchemaBase:
         cls,
         json_string: str,
         validate: bool = True,
-        **kwargs: Any
+        **kwargs: Any,
         # Type hints for this method would get rather complicated
         # if we want to provide a more specific return type
     ) -> Any:

--- a/tools/update_init_file.py
+++ b/tools/update_init_file.py
@@ -4,11 +4,10 @@ based on the updated Altair schema.
 """
 import inspect
 import sys
+import subprocess
 from pathlib import Path
 from os.path import abspath, dirname, join
 from typing import TypeVar, Type, cast, List, Any, Optional, Iterable, Union
-
-import black
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -58,11 +57,22 @@ def update__all__variable() -> None:
         + lines[last_definition_line + 1 :]
     )
     # Format file content with black
-    new_file_content = black.format_str("\n".join(new_lines), mode=black.Mode())
+    new_file_content = ruff_format_str("\n".join(new_lines))
 
     # Write new version of altair/__init__.py
     with open(init_path, "w") as f:
         f.write(new_file_content)
+
+
+def ruff_format_str(code: str) -> str:
+    r = subprocess.run(
+        # Name of the file does not seem to matter but ruff requires one
+        ["ruff", "format", "--stdin-filename", "placeholder.py"],
+        input=code.encode(),
+        check=True,
+        capture_output=True,
+    )
+    return r.stdout.decode()
 
 
 def _is_relevant_attribute(attr_name: str) -> bool:


### PR DESCRIPTION
Close https://github.com/altair-viz/altair/issues/3241.

With this PR we switch from black to ruff for formatting and so we can reduce our dependencies by 1 (thank you `black`, you were awesome). There are a few minimal formatting changes with associated with this PR. 
I excluded `tests/test_transformed_data.py` for now as I didn't like the introduced reformatting there.