### PR TITLE
docs: add range bar chart

### DIFF
--- a/tests/examples_arguments_syntax/bar_chart_with_range.py
+++ b/tests/examples_arguments_syntax/bar_chart_with_range.py
@@ -1,0 +1,32 @@
+"""
+Bar Chart with Range
+====================
+This example shows a range bar chart where each bar displays information of a low and high value.
+"""
+# category: bar charts
+import altair as alt
+from vega_datasets import data
+
+source = data.seattle_weather()
+
+bar = alt.Chart(source).mark_bar(cornerRadius=10, height=10).encode(
+    x=alt.X('min(temp_min):Q', scale=alt.Scale(domain=[-15, 45], title='temperature (°C)')),
+    x2='max(temp_max):Q',
+    y=alt.Y('month(date):O', title=None) 
+)
+
+text_min = alt.Chart(source).mark_text(align='right', dx=-5).encode(
+    x='min(temp_min):Q',
+    y=alt.Y('month(date):O'),
+    text='min(temp_min):Q'
+)
+
+text_max = alt.Chart(source).mark_text(align='left', dx=5).encode(
+    x='max(temp_max):Q',
+    y=alt.Y('month(date):O'),
+    text='max(temp_max):Q'
+)
+
+(bar + text_min + text_max).properties(
+    title=alt.Title(text='Temperature variation by month', subtitle='Seatle weather, 2012-2015')
+)

--- a/tests/examples_arguments_syntax/bar_chart_with_range.py
+++ b/tests/examples_arguments_syntax/bar_chart_with_range.py
@@ -10,7 +10,7 @@ from vega_datasets import data
 source = data.seattle_weather()
 
 bar = alt.Chart(source).mark_bar(cornerRadius=10, height=10).encode(
-    x=alt.X('min(temp_min):Q', scale=alt.Scale(domain=[-15, 45], title='temperature (°C)')),
+    x=alt.X('min(temp_min):Q', scale=alt.Scale(domain=[-15, 45]), title='temperature (°C)'),
     x2='max(temp_max):Q',
     y=alt.Y('month(date):O', title=None) 
 )

--- a/tests/examples_arguments_syntax/bar_chart_with_range.py
+++ b/tests/examples_arguments_syntax/bar_chart_with_range.py
@@ -10,7 +10,7 @@ from vega_datasets import data
 source = data.seattle_weather()
 
 bar = alt.Chart(source).mark_bar(cornerRadius=10, height=10).encode(
-    x=alt.X('min(temp_min):Q', scale=alt.Scale(domain=[-15, 45]), title='temperature (°C)'),
+    x=alt.X('min(temp_min):Q', scale=alt.Scale(domain=[-15, 45]), title='Temperature (°C)'),
     x2='max(temp_max):Q',
     y=alt.Y('month(date):O', title=None) 
 )

--- a/tests/examples_methods_syntax/bar_chart_with_range.py
+++ b/tests/examples_methods_syntax/bar_chart_with_range.py
@@ -10,7 +10,7 @@ from vega_datasets import data
 source = data.seattle_weather()
 
 bar = alt.Chart(source).mark_bar(cornerRadius=10, height=10).encode(
-    x=alt.X('min(temp_min):Q').scale(domain=[-15, 45]).title('temperature (°C)'),
+    x=alt.X('min(temp_min):Q').scale(domain=[-15, 45]).title('Temperature (°C)'),
     x2='max(temp_max):Q',
     y=alt.Y('month(date):O').title(None) 
 )

--- a/tests/examples_methods_syntax/bar_chart_with_range.py
+++ b/tests/examples_methods_syntax/bar_chart_with_range.py
@@ -1,0 +1,32 @@
+"""
+Bar Chart with Range
+====================
+This example shows a range bar chart where each bar displays information of a low and high value.
+"""
+# category: bar charts
+import altair as alt
+from vega_datasets import data
+
+source = data.seattle_weather()
+
+bar = alt.Chart(source).mark_bar(cornerRadius=10, height=10).encode(
+    x=alt.X('min(temp_min):Q').scale(domain=[-15, 45]).title('temperature (°C)'),
+    x2='max(temp_max):Q',
+    y=alt.Y('month(date):O').title(None) 
+)
+
+text_min = alt.Chart(source).mark_text(align='right', dx=-5).encode(
+    x='min(temp_min):Q',
+    y=alt.Y('month(date):O'),
+    text='min(temp_min):Q'
+)
+
+text_max = alt.Chart(source).mark_text(align='left', dx=5).encode(
+    x='max(temp_max):Q',
+    y=alt.Y('month(date):O'),
+    text='max(temp_max):Q'
+)
+
+(bar + text_min + text_max).properties(
+    title=alt.Title(text='Temperature variation by month', subtitle='Seatle weather, 2012-2015')
+)


### PR DESCRIPTION
This example add an example to the bar chart category. It is a range bar chart where each bar displays information of a low and high value. In this example I used the temperature variation by month for Seattle (2012-2015).
<img width="332" alt="image" src="https://github.com/altair-viz/altair/assets/5186265/c4a66b48-b204-453f-a015-5973411be626">
