### PR TITLE
doc: add example interactive aggregation

### DIFF
--- a/tests/examples_arguments_syntax/interactive_aggregation.py
+++ b/tests/examples_arguments_syntax/interactive_aggregation.py
@@ -1,0 +1,39 @@
+"""
+Interactive Chart with Aggregation
+==================================
+This example shows an interactive chart where the range binder controls a
+threshold as rule where the datapoints on the left-side are aggregated and on the
+right-side are drawn as is. 
+The ability to slide back and fourth may help you understand how the visualization
+represents the aggregation. Example inspired by @dwootton.
+"""
+# category: interactive charts
+import altair as alt
+from vega_datasets import data
+
+source = data.movies()
+
+slider = alt.binding_range(min=1, max=10, step=1)
+threshold = alt.param(name='threshold', value=5, bind=slider)
+
+alt.layer(
+    alt.Chart(source).mark_circle().encode(
+        x=alt.X('IMDB_Rating:Q', title='IMDB Rating'),
+        y=alt.Y('Rotten_Tomatoes_Rating:Q', title='Rotten Tomatoes Rating')
+    ).transform_filter(
+        alt.datum['IMDB_Rating'] > threshold
+    ),
+
+    alt.Chart(source).mark_circle(color='yellowgreen').encode(
+        x=alt.X('IMDB_Rating:Q', bin=alt.Bin(maxbins=10)),
+        y=alt.Y('Rotten_Tomatoes_Rating:Q', bin=alt.Bin(maxbins=10)),
+        size=alt.Size('count()', scale=alt.Scale(domain=[0,160]))
+    ).transform_filter(
+        alt.datum['IMDB_Rating'] < threshold
+    ),
+
+    alt.Chart().mark_rule(color='gray').encode(
+        strokeWidth=alt.StrokeWidth(value=3),
+        x=alt.X(datum=alt.expr(threshold.name), type='quantitative')
+    )
+).add_params(threshold)

--- a/tests/examples_arguments_syntax/interactive_aggregation.py
+++ b/tests/examples_arguments_syntax/interactive_aggregation.py
@@ -11,7 +11,7 @@ represents the aggregation. Adapted from an example by @dwootton.
 import altair as alt
 from vega_datasets import data
 
-source = data.movies()
+source = data.movies.url
 
 slider = alt.binding_range(min=0, max=10, step=0.1)
 threshold = alt.param(name="threshold", value=5, bind=slider)
@@ -27,7 +27,7 @@ alt.layer(
     alt.Chart(source).mark_circle().encode(
         x=alt.X("IMDB_Rating:Q", bin=alt.Bin(maxbins=10)),
         y=alt.Y("Rotten_Tomatoes_Rating:Q", bin=alt.Bin(maxbins=10)),
-        size=alt.Size("count()", scale=alt.Scale(domain=[0,160]))
+        size=alt.Size("count():Q", scale=alt.Scale(domain=[0,160]))
     ).transform_filter(
         alt.datum["IMDB_Rating"] < threshold
     ),

--- a/tests/examples_arguments_syntax/interactive_aggregation.py
+++ b/tests/examples_arguments_syntax/interactive_aggregation.py
@@ -21,7 +21,7 @@ alt.layer(
         x=alt.X("IMDB_Rating:Q", title="IMDB Rating"),
         y=alt.Y("Rotten_Tomatoes_Rating:Q", title="Rotten Tomatoes Rating")
     ).transform_filter(
-        alt.datum["IMDB_Rating"] > threshold
+        alt.datum["IMDB_Rating"] >= threshold
     ),
 
     alt.Chart(source).mark_circle().encode(
@@ -33,7 +33,7 @@ alt.layer(
     ),
 
     alt.Chart().mark_rule(color="gray").encode(
-        strokeWidth=alt.StrokeWidth(value=3),
+        strokeWidth=alt.StrokeWidth(value=6),
         x=alt.X(datum=alt.expr(threshold.name), type="quantitative")
     )
 ).add_params(threshold)

--- a/tests/examples_arguments_syntax/interactive_aggregation.py
+++ b/tests/examples_arguments_syntax/interactive_aggregation.py
@@ -5,7 +5,7 @@ This example shows an interactive chart where the range binder controls a
 threshold as rule where the datapoints on the left-side are aggregated and on the
 right-side are drawn as is. 
 The ability to slide back and fourth may help you understand how the visualization
-represents the aggregation. Example inspired by @dwootton.
+represents the aggregation. Adapted from an example by @dwootton.
 """
 # category: interactive charts
 import altair as alt
@@ -13,27 +13,27 @@ from vega_datasets import data
 
 source = data.movies()
 
-slider = alt.binding_range(min=1, max=10, step=1)
-threshold = alt.param(name='threshold', value=5, bind=slider)
+slider = alt.binding_range(min=0, max=10, step=0.1)
+threshold = alt.param(name="threshold", value=5, bind=slider)
 
 alt.layer(
     alt.Chart(source).mark_circle().encode(
-        x=alt.X('IMDB_Rating:Q', title='IMDB Rating'),
-        y=alt.Y('Rotten_Tomatoes_Rating:Q', title='Rotten Tomatoes Rating')
+        x=alt.X("IMDB_Rating:Q", title="IMDB Rating"),
+        y=alt.Y("Rotten_Tomatoes_Rating:Q", title="Rotten Tomatoes Rating")
     ).transform_filter(
-        alt.datum['IMDB_Rating'] > threshold
+        alt.datum["IMDB_Rating"] > threshold
     ),
 
-    alt.Chart(source).mark_circle(color='yellowgreen').encode(
-        x=alt.X('IMDB_Rating:Q', bin=alt.Bin(maxbins=10)),
-        y=alt.Y('Rotten_Tomatoes_Rating:Q', bin=alt.Bin(maxbins=10)),
-        size=alt.Size('count()', scale=alt.Scale(domain=[0,160]))
+    alt.Chart(source).mark_circle().encode(
+        x=alt.X("IMDB_Rating:Q", bin=alt.Bin(maxbins=10)),
+        y=alt.Y("Rotten_Tomatoes_Rating:Q", bin=alt.Bin(maxbins=10)),
+        size=alt.Size("count()", scale=alt.Scale(domain=[0,160]))
     ).transform_filter(
-        alt.datum['IMDB_Rating'] < threshold
+        alt.datum["IMDB_Rating"] < threshold
     ),
 
-    alt.Chart().mark_rule(color='gray').encode(
+    alt.Chart().mark_rule(color="gray").encode(
         strokeWidth=alt.StrokeWidth(value=3),
-        x=alt.X(datum=alt.expr(threshold.name), type='quantitative')
+        x=alt.X(datum=alt.expr(threshold.name), type="quantitative")
     )
 ).add_params(threshold)

--- a/tests/examples_methods_syntax/interactive_aggregation.py
+++ b/tests/examples_methods_syntax/interactive_aggregation.py
@@ -21,7 +21,7 @@ alt.layer(
         x=alt.X("IMDB_Rating:Q").title("IMDB Rating"),
         y=alt.Y("Rotten_Tomatoes_Rating:Q").title("Rotten Tomatoes Rating")
     ).transform_filter(
-        alt.datum["IMDB_Rating"] > threshold
+        alt.datum["IMDB_Rating"] >= threshold
     ),
 
     alt.Chart(source).mark_circle().encode(
@@ -33,7 +33,7 @@ alt.layer(
     ),
 
     alt.Chart().mark_rule(color="gray").encode(
-        strokeWidth=alt.StrokeWidth(value=3),
+        strokeWidth=alt.StrokeWidth(value=6),
         x=alt.X(datum=alt.expr(threshold.name), type="quantitative")
     )
 ).add_params(threshold)

--- a/tests/examples_methods_syntax/interactive_aggregation.py
+++ b/tests/examples_methods_syntax/interactive_aggregation.py
@@ -11,7 +11,7 @@ represents the aggregation. Adapted from an example by @dwootton.
 import altair as alt
 from vega_datasets import data
 
-source = data.movies()
+source = data.movies.url
 
 slider = alt.binding_range(min=0, max=10, step=0.1)
 threshold = alt.param(name="threshold", value=5, bind=slider)
@@ -27,7 +27,7 @@ alt.layer(
     alt.Chart(source).mark_circle().encode(
         x=alt.X("IMDB_Rating:Q").bin(maxbins=10),
         y=alt.Y("Rotten_Tomatoes_Rating:Q").bin(maxbins=10),
-        size=alt.Size("count()").scale(domain=[0,160])
+        size=alt.Size("count():Q").scale(domain=[0,160])
     ).transform_filter(
         alt.datum["IMDB_Rating"] < threshold
     ),

--- a/tests/examples_methods_syntax/interactive_aggregation.py
+++ b/tests/examples_methods_syntax/interactive_aggregation.py
@@ -1,0 +1,39 @@
+"""
+Interactive Chart with Aggregation
+==================================
+This example shows an interactive chart where the range binder controls a
+threshold as rule where the datapoints on the left-side are aggregated and on the
+right-side are drawn as is. 
+The ability to slide back and fourth may help you understand how the visualization
+represents the aggregation. Example inspired by @dwootton.
+"""
+# category: interactive charts
+import altair as alt
+from vega_datasets import data
+
+source = data.movies()
+
+slider = alt.binding_range(min=1, max=10, step=1)
+threshold = alt.param(name='threshold', value=5, bind=slider)
+
+alt.layer(
+    alt.Chart(source).mark_circle().encode(
+        x=alt.X('IMDB_Rating:Q').title('IMDB Rating'),
+        y=alt.Y('Rotten_Tomatoes_Rating:Q').title('Rotten Tomatoes Rating')
+    ).transform_filter(
+        alt.datum['IMDB_Rating'] > threshold
+    ),
+
+    alt.Chart(source).mark_circle(color='yellowgreen').encode(
+        x=alt.X('IMDB_Rating:Q').bin(maxbins=10),
+        y=alt.Y('Rotten_Tomatoes_Rating:Q').bin(maxbins=10),
+        size=alt.Size('count()').scale(domain=[0,160])
+    ).transform_filter(
+        alt.datum['IMDB_Rating'] < threshold
+    ),
+
+    alt.Chart().mark_rule(color='gray').encode(
+        strokeWidth=alt.StrokeWidth(value=3),
+        x=alt.X(datum=alt.expr(threshold.name), type='quantitative')
+    )
+).add_params(threshold)

--- a/tests/examples_methods_syntax/interactive_aggregation.py
+++ b/tests/examples_methods_syntax/interactive_aggregation.py
@@ -5,7 +5,7 @@ This example shows an interactive chart where the range binder controls a
 threshold as rule where the datapoints on the left-side are aggregated and on the
 right-side are drawn as is. 
 The ability to slide back and fourth may help you understand how the visualization
-represents the aggregation. Example inspired by @dwootton.
+represents the aggregation. Adapted from an example by @dwootton.
 """
 # category: interactive charts
 import altair as alt
@@ -13,27 +13,27 @@ from vega_datasets import data
 
 source = data.movies()
 
-slider = alt.binding_range(min=1, max=10, step=1)
-threshold = alt.param(name='threshold', value=5, bind=slider)
+slider = alt.binding_range(min=0, max=10, step=0.1)
+threshold = alt.param(name="threshold", value=5, bind=slider)
 
 alt.layer(
     alt.Chart(source).mark_circle().encode(
-        x=alt.X('IMDB_Rating:Q').title('IMDB Rating'),
-        y=alt.Y('Rotten_Tomatoes_Rating:Q').title('Rotten Tomatoes Rating')
+        x=alt.X("IMDB_Rating:Q").title("IMDB Rating"),
+        y=alt.Y("Rotten_Tomatoes_Rating:Q").title("Rotten Tomatoes Rating")
     ).transform_filter(
-        alt.datum['IMDB_Rating'] > threshold
+        alt.datum["IMDB_Rating"] > threshold
     ),
 
-    alt.Chart(source).mark_circle(color='yellowgreen').encode(
-        x=alt.X('IMDB_Rating:Q').bin(maxbins=10),
-        y=alt.Y('Rotten_Tomatoes_Rating:Q').bin(maxbins=10),
-        size=alt.Size('count()').scale(domain=[0,160])
+    alt.Chart(source).mark_circle().encode(
+        x=alt.X("IMDB_Rating:Q").bin(maxbins=10),
+        y=alt.Y("Rotten_Tomatoes_Rating:Q").bin(maxbins=10),
+        size=alt.Size("count()").scale(domain=[0,160])
     ).transform_filter(
-        alt.datum['IMDB_Rating'] < threshold
+        alt.datum["IMDB_Rating"] < threshold
     ),
 
-    alt.Chart().mark_rule(color='gray').encode(
+    alt.Chart().mark_rule(color="gray").encode(
         strokeWidth=alt.StrokeWidth(value=3),
-        x=alt.X(datum=alt.expr(threshold.name), type='quantitative')
+        x=alt.X(datum=alt.expr(threshold.name), type="quantitative")
     )
 ).add_params(threshold)


### PR DESCRIPTION
This PR adds a new example showing interactive aggregation. The example is heavily inspired by [this](https://twitter.com/InsightsMachine/status/1708898945135730727) example by @dwootton.

<img width="459" alt="image" src="https://github.com/altair-viz/altair/assets/5186265/d8c1f2d1-3b83-410a-a030-4c32ec3944b8">

@dwootton, I modified your example a little bit, could you review the introduced changes? I'm not sure if my changes make the goal of the chart more intuitive.