### PR TITLE
Make facet error more informative

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2766,7 +2766,10 @@ class _EncodingMixin:
             # Remove "ignore" statement once Undefined is no longer typed as Any
             if self.data is Undefined:  # type: ignore
                 raise ValueError(
-                    "Facet charts require data to be specified at the top level."
+                    "Facet charts require data to be specified at the top level. "
+                    "If you are trying to facet layered or concatenated charts, "
+                    "ensure that the same data variable is passed to each chart "
+                    "or specify the data inside the facet method instead."
                 )
             # ignore type as copy comes from another class
             self = self.copy(deep=False)  # type: ignore[attr-defined]


### PR DESCRIPTION
Currently if we charts use different data and are trying to be faceted, altair raises `ValueError: Facet charts require data to be specified at the top level.` I don't think it is immediately clear to everyone what this means, and this PR is an attempt to make the error message more instructive.

Not that there will still be situations like the below that raises the error although the same data is technically used, just respecified as a new variable.

```py
alt.layer(
    alt.Chart(data.movies.url).mark_rule().encode(x='IMDB_Rating:Q'),
    alt.Chart(data.movies.url).mark_rule().encode(x='IMDB_Rating:Q')
).facet(
    'Major_Genre:N'
)
```

I am not sure if altair should be capable of figuring out that this is the same as 

```py
source = data.movies.url
alt.layer(
    alt.Chart(source).mark_rule().encode(x='IMDB_Rating:Q'),
    alt.Chart(source).mark_rule().encode(x='IMDB_Rating:Q')
).facet(
    'Major_Genre:N'
)
```

and avoid the error, maybe those comparisons will be too complex for large data frames and non-portable across dataframe implementations (although many have some type of equality test built-in like pandas).