### PR TITLE
Update to Vega-Lite 5.16.3

### DIFF
--- a/NOTES_FOR_MAINTAINERS.md
+++ b/NOTES_FOR_MAINTAINERS.md
@@ -49,7 +49,7 @@ of some docstrings.
 Major version updates (e.g. Vega-Lite 1.X->2.X) have required substantial
 rewrites, because the internal structure of the schema changed appreciably.
 
-## Updating the Vega-Lite in JupyterChart
+### Updating the Vega-Lite in JupyterChart
 To update the Vega-Lite version used in JupyterChart, update the version in the 
 esm.sh URL in `altair/jupyter/js/index.js`.
 

--- a/NOTES_FOR_MAINTAINERS.md
+++ b/NOTES_FOR_MAINTAINERS.md
@@ -11,7 +11,7 @@ All the files within these directories are created automatically by running
 the following script from the root of the repository:
 
 ```bash
-$ python tools/generate_schema_wrapper.py
+$ hatch run python tools/generate_schema_wrapper.py
 ```
 
 This script does a couple things:

--- a/NOTES_FOR_MAINTAINERS.md
+++ b/NOTES_FOR_MAINTAINERS.md
@@ -50,9 +50,11 @@ Major version updates (e.g. Vega-Lite 1.X->2.X) have required substantial
 rewrites, because the internal structure of the schema changed appreciably.
 
 ## Updating the Vega-Lite in JupyterChart
-To update the Vega-Lite version used in JupyterChart, update the version in the esm.sh URL in `altair/jupyter/js/index.js`.
+To update the Vega-Lite version used in JupyterChart, update the version in the 
+esm.sh URL in `altair/jupyter/js/index.js`.
 
-For example, to update to Vega-Lite 5.15.1, Vega 5 and Vega-Embed 6, the URL should be:
+For example, to update to Vega-Lite 5.15.1, Vega 5 and Vega-Embed 6, the URL 
+should be:
 
 ```javascript
 import embed from "https://esm.sh/vega-embed@6?deps=vega@5&deps=vega-lite@5.15.1";

--- a/altair/jupyter/js/index.js
+++ b/altair/jupyter/js/index.js
@@ -1,4 +1,4 @@
-import embed from "https://esm.sh/vega-embed@6?deps=vega@5&deps=vega-lite@5.15.1";
+import embed from "https://esm.sh/vega-embed@6?deps=vega@5&deps=vega-lite@5.16.3";
 import debounce from "https://esm.sh/lodash-es@4.17.21/debounce";
 
 export async function render({ model, el }) {

--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -29,7 +29,7 @@ def import_vegafusion() -> ModuleType:
 
 
 def import_vl_convert() -> ModuleType:
-    min_version = "1.0.1"
+    min_version = "1.1.0"
     try:
         version = importlib_version("vl-convert-python")
         if Version(version) < Version(min_version):

--- a/altair/vegalite/v5/schema/__init__.py
+++ b/altair/vegalite/v5/schema/__init__.py
@@ -3,6 +3,6 @@
 from .core import *
 from .channels import *  # type: ignore[assignment]
 
-SCHEMA_VERSION = "v5.15.1"
+SCHEMA_VERSION = "v5.16.3"
 
-SCHEMA_URL = "https://vega.github.io/schema/vega-lite/v5.15.1.json"
+SCHEMA_URL = "https://vega.github.io/schema/vega-lite/v5.16.3.json"

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -11418,7 +11418,7 @@ class DomainUnionWith(VegaLiteSchema):
     Parameters
     ----------
 
-    unionWith : Sequence[:class:`DateTime`, Dict], Sequence[bool], Sequence[float], Sequence[str]
+    unionWith : Sequence[:class:`DateTime`, Dict, bool, float, str]
         Customized domain values to be union with the field's values or explicitly defined
         domain. Should be an array of valid scale domain values.
     """
@@ -11428,13 +11428,7 @@ class DomainUnionWith(VegaLiteSchema):
     def __init__(
         self,
         unionWith: Union[
-            Union[
-                Sequence[Union["DateTime", dict]],
-                Sequence[bool],
-                Sequence[float],
-                Sequence[str],
-            ],
-            UndefinedType,
+            Sequence[Union[Union["DateTime", dict], bool, float, str]], UndefinedType
         ] = Undefined,
         **kwds,
     ):
@@ -17884,8 +17878,8 @@ class IntervalSelectionConfig(VegaLiteSchema):
         include a start and end event to trigger continuous panning. Discrete panning (e.g.,
         pressing the left/right arrow keys) will be supported in future versions.
 
-        **Default value:** ``true``, which corresponds to ``[mousedown, window:mouseup] >
-        window:mousemove!``. This default allows users to clicks and drags within an
+        **Default value:** ``true``, which corresponds to ``[pointerdown, window:pointerup]
+        > window:pointermove!``. This default allows users to clicks and drags within an
         interval selection to reposition it.
 
         **See also:** `translate examples
@@ -18073,8 +18067,8 @@ class IntervalSelectionConfigWithoutType(VegaLiteSchema):
         include a start and end event to trigger continuous panning. Discrete panning (e.g.,
         pressing the left/right arrow keys) will be supported in future versions.
 
-        **Default value:** ``true``, which corresponds to ``[mousedown, window:mouseup] >
-        window:mousemove!``. This default allows users to clicks and drags within an
+        **Default value:** ``true``, which corresponds to ``[pointerdown, window:pointerup]
+        > window:pointermove!``. This default allows users to clicks and drags within an
         interval selection to reposition it.
 
         **See also:** `translate examples

--- a/altair/vegalite/v5/schema/vega-lite-schema.json
+++ b/altair/vegalite/v5/schema/vega-lite-schema.json
@@ -8330,33 +8330,24 @@
       "additionalProperties": false,
       "properties": {
         "unionWith": {
-          "anyOf": [
-            {
-              "items": {
+          "description": "Customized domain values to be union with the field's values or explicitly defined domain. Should be an array of valid scale domain values.",
+          "items": {
+            "anyOf": [
+              {
                 "type": "number"
               },
-              "type": "array"
-            },
-            {
-              "items": {
+              {
                 "type": "string"
               },
-              "type": "array"
-            },
-            {
-              "items": {
+              {
                 "type": "boolean"
               },
-              "type": "array"
-            },
-            {
-              "items": {
+              {
                 "$ref": "#/definitions/DateTime"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Customized domain values to be union with the field's values or explicitly defined domain. Should be an array of valid scale domain values."
+              }
+            ]
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -12499,7 +12490,7 @@
           "description": "With layered and multi-view displays, a strategy that determines how selections' data queries are resolved when applied in a filter transform, conditional encoding rule, or scale domain.\n\nOne of:\n- `\"global\"` -- only one brush exists for the entire SPLOM. When the user begins to drag, any previous brushes are cleared, and a new one is constructed.\n- `\"union\"` -- each cell contains its own brush, and points are highlighted if they lie within _any_ of these individual brushes.\n- `\"intersect\"` -- each cell contains its own brush, and points are highlighted only if they fall within _all_ of these individual brushes.\n\n__Default value:__ `global`.\n\n__See also:__ [`resolve` examples](https://vega.github.io/vega-lite/docs/selection.html#resolve) in the documentation."
         },
         "translate": {
-          "description": "When truthy, allows a user to interactively move an interval selection back-and-forth. Can be `true`, `false` (to disable panning), or a [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) which must include a start and end event to trigger continuous panning. Discrete panning (e.g., pressing the left/right arrow keys) will be supported in future versions.\n\n__Default value:__ `true`, which corresponds to `[mousedown, window:mouseup] > window:mousemove!`. This default allows users to clicks and drags within an interval selection to reposition it.\n\n__See also:__ [`translate` examples](https://vega.github.io/vega-lite/docs/selection.html#translate) in the documentation.",
+          "description": "When truthy, allows a user to interactively move an interval selection back-and-forth. Can be `true`, `false` (to disable panning), or a [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) which must include a start and end event to trigger continuous panning. Discrete panning (e.g., pressing the left/right arrow keys) will be supported in future versions.\n\n__Default value:__ `true`, which corresponds to `[pointerdown, window:pointerup] > window:pointermove!`. This default allows users to clicks and drags within an interval selection to reposition it.\n\n__See also:__ [`translate` examples](https://vega.github.io/vega-lite/docs/selection.html#translate) in the documentation.",
           "type": [
             "string",
             "boolean"
@@ -12574,7 +12565,7 @@
           "description": "With layered and multi-view displays, a strategy that determines how selections' data queries are resolved when applied in a filter transform, conditional encoding rule, or scale domain.\n\nOne of:\n- `\"global\"` -- only one brush exists for the entire SPLOM. When the user begins to drag, any previous brushes are cleared, and a new one is constructed.\n- `\"union\"` -- each cell contains its own brush, and points are highlighted if they lie within _any_ of these individual brushes.\n- `\"intersect\"` -- each cell contains its own brush, and points are highlighted only if they fall within _all_ of these individual brushes.\n\n__Default value:__ `global`.\n\n__See also:__ [`resolve` examples](https://vega.github.io/vega-lite/docs/selection.html#resolve) in the documentation."
         },
         "translate": {
-          "description": "When truthy, allows a user to interactively move an interval selection back-and-forth. Can be `true`, `false` (to disable panning), or a [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) which must include a start and end event to trigger continuous panning. Discrete panning (e.g., pressing the left/right arrow keys) will be supported in future versions.\n\n__Default value:__ `true`, which corresponds to `[mousedown, window:mouseup] > window:mousemove!`. This default allows users to clicks and drags within an interval selection to reposition it.\n\n__See also:__ [`translate` examples](https://vega.github.io/vega-lite/docs/selection.html#translate) in the documentation.",
+          "description": "When truthy, allows a user to interactively move an interval selection back-and-forth. Can be `true`, `false` (to disable panning), or a [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) which must include a start and end event to trigger continuous panning. Discrete panning (e.g., pressing the left/right arrow keys) will be supported in future versions.\n\n__Default value:__ `true`, which corresponds to `[pointerdown, window:pointerup] > window:pointermove!`. This default allows users to clicks and drags within an interval selection to reposition it.\n\n__See also:__ [`translate` examples](https://vega.github.io/vega-lite/docs/selection.html#translate) in the documentation.",
           "type": [
             "string",
             "boolean"

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -6,7 +6,7 @@ Release Notes
 Version 5.2.0 (unreleased month date, year)
 -------------------------------------------
 - Update Vega-Lite from version 5.15.1 to version 5.16.3;
-  see `Vega-Lite 5.16.3 Release Notes <https://github.com/vega/vega-lite/releases/tag/v5.16.3>`_.
+  see `Vega-Lite Release Notes <https://github.com/vega/vega-lite/releases>`_.
 
 Enhancements
 ~~~~~~~~~~~~

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -5,6 +5,8 @@ Release Notes
 
 Version 5.2.0 (unreleased month date, year)
 -------------------------------------------
+- Update Vega-Lite from version 5.15.1 to version 5.16.3;
+  see `Vega-Lite 5.16.3 Release Notes <https://github.com/vega/vega-lite/releases/tag/v5.16.3>`_.
 
 Enhancements
 ~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     "pytest-cov",
     "m2r",
     "vega_datasets",
-    "vl-convert-python>=1.0.1",
+    "vl-convert-python>=1.1.0",
     "mypy",
     "pandas-stubs",
     "types-jsonschema",

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -383,12 +383,12 @@ def test_save_html(basic_chart, inline):
 def test_to_url(basic_chart):
     share_url = basic_chart.to_url()
     expected_vegalite_encoding = (
-        "N4Igxg9gdgZglgcxALlANzgUwO4tJKAFzigFcJSBnAdTgBNCALFAZgAY2AacaYsiygAlMiRoVYcAvpO50AhoTl4QU"
-        "OQFtMKEPMUBaMACY5LTAA4AnACM55ugFY6ARgBspgOz2zh03Wfs5bCwsIDIganIATgDWyoQAngAOmsgg1hEh3JhQk"
-        "HQkSKggAB7K8JgANnRaStzxSVpQEGokcmUZIHElWBValiA1ickgAI6kckRwisRomtLcACSUYIyY4VpihAmUyAD029"
-        "MIcgB0CBOMpJaHcBDbi8vhe5gHumUTmHt2h44fjocAVpTQPraBRySiYQiUZQ6OT6IwmCzWWwOFzuTymby+fyBYLIA"
-        "DaoCUKQAgkDesgDKYZAStAAhUkoOx2KkgQkgADC9OQABYWMzWQARTnmRx8rQAUU5phFnGpKQAYpy7LyZSytABxTmO"
-        "cyilKCSVuHUgACSioMkgAutIgA"
+        "N4Igxg9gdgZglgcxALlANzgUwO4tJKAFzigFcJSBnAdTgBNCALFAZgAY2AacaYsiygAlMiRoVYcAvpO5"
+        "0AhoTl4QUOQFtMKEPMUBaMACY5LTAA4AnACM55ugFY6ARgBspgOz2zh03Wfs5bCwsIDIganIATgDWyoQ"
+        "AngAOmsgg1hEh3JhQkHQkSKggAB7K8JgANnRaStzxSVpQEGokcmUZIHElWBValiA1ickgAI6kckRwisR"
+        "omtLcACSUYIyY4VpihAmUyAD029MIcgB0CBOMpJaHcBDbi8vhe5gHumUTmHt2hy6HLIcAVpTQPraBRyS"
+        "iYQiUZQ6OT6IwmCzWWwOFzuTymby+fyBYLIADaoCUKQAgkDesgDKYZAStAAhUkoOx2KkgQkgADC9OQABY"
+        "WMzWQARTnmRx8rQAUU5phFnGpKQAYpy7LyZSytABxTmOcyilKCSVuHUgACSioMkgAutIgA"
     )
 
     assert (

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -30,7 +30,7 @@ from schemapi.utils import (  # noqa: E402
     indent_docstring,
 )
 
-SCHEMA_VERSION: Final = "v5.15.1"
+SCHEMA_VERSION: Final = "v5.16.3"
 
 reLink = re.compile(r"(?<=\[)([^\]]+)(?=\]\([^\)]+\))", re.M)
 reSpecial = re.compile(r"[*_]{2,3}|`", re.M)


### PR DESCRIPTION
Updates Altair to Vega-Lite 5.16.3.  Not much in the way of notable API changes, so I don't think there are any documentation updates required