### PR TITLE
Integrate VegaFusion into JupyterChart

### DIFF
--- a/altair/jupyter/js/index.js
+++ b/altair/jupyter/js/index.js
@@ -1,5 +1,5 @@
-import embed from "https://esm.sh/vega-embed@6?deps=vega@5&deps=vega-lite@5.16.3";
-import debounce from "https://esm.sh/lodash-es@4.17.21/debounce";
+import vegaEmbed from "https://esm.sh/vega-embed@6?deps=vega@5&deps=vega-lite@5.16.3";
+import lodashDebounce from "https://esm.sh/lodash-es@4.17.21/debounce";
 
 export async function render({ model, el }) {
     let finalize;
@@ -33,7 +33,7 @@ export async function render({ model, el }) {
 
         let api;
         try {
-            api = await embed(el, spec);
+            api = await vegaEmbed(el, spec);
         } catch (error) {
             showError(error)
             return;
@@ -59,7 +59,7 @@ export async function render({ model, el }) {
                 model.set("_vl_selections", newSelections);
                 model.save_changes();
             };
-            api.view.addSignalListener(selectionName, debounce(selectionHandler, wait, debounceOpts));
+            api.view.addSignalListener(selectionName, lodashDebounce(selectionHandler, wait, debounceOpts));
 
             initialSelections[selectionName] = {
                 value: cleanJson(api.view.signal(selectionName) ?? {}),
@@ -76,7 +76,7 @@ export async function render({ model, el }) {
                 model.set("_params", newParams);
                 model.save_changes();
             };
-            api.view.addSignalListener(paramName, debounce(paramHandler, wait, debounceOpts));
+            api.view.addSignalListener(paramName, lodashDebounce(paramHandler, wait, debounceOpts));
 
             initialParams[paramName] = api.view.signal(paramName) ?? null
         }
@@ -103,7 +103,7 @@ export async function render({ model, el }) {
                     }]);
                     model.save_changes();
                 };
-                addDataListener(api.view, watch.name, watch.scope, debounce(dataHandler, wait, debounceOpts))
+                addDataListener(api.view, watch.name, watch.scope, lodashDebounce(dataHandler, wait, debounceOpts))
 
             } else if (watch.namespace === "signal") {
                 const signalHandler = (_, value) => {
@@ -116,7 +116,7 @@ export async function render({ model, el }) {
                     model.save_changes();
                 };
 
-                addSignalListener(api.view, watch.name, watch.scope, debounce(signalHandler, wait, debounceOpts))
+                addSignalListener(api.view, watch.name, watch.scope, lodashDebounce(signalHandler, wait, debounceOpts))
             }
         }
 

--- a/altair/jupyter/js/index.js
+++ b/altair/jupyter/js/index.js
@@ -1,6 +1,5 @@
 import embed from "https://esm.sh/vega-embed@6?deps=vega@5&deps=vega-lite@5.16.3";
 import debounce from "https://esm.sh/lodash-es@4.17.21/debounce";
-import cloneDeep from "https://esm.sh/lodash-es@4.17.21/cloneDeep";
 
 export async function render({ model, el }) {
     let finalize;
@@ -22,7 +21,7 @@ export async function render({ model, el }) {
 
         model.set("local_tz", Intl.DateTimeFormat().resolvedOptions().timeZone);
 
-        let spec = cloneDeep(model.get("spec"));
+        let spec = structuredClone(model.get("spec"));
         if (spec == null) {
             // Remove any existing chart and return
             while (el.firstChild) {

--- a/altair/jupyter/js/index.js
+++ b/altair/jupyter/js/index.js
@@ -19,7 +19,18 @@ export async function render({ model, el }) {
           finalize();
         }
 
+        model.set("local_tz", Intl.DateTimeFormat().resolvedOptions().timeZone);
+
         let spec = model.get("spec");
+        if (spec == null) {
+            // Remove any existing chart and return
+            while (el.firstChild) {
+                el.removeChild(el.lastChild);
+            }
+            model.save_changes();
+            return;
+        }
+
         let api;
         try {
             api = await embed(el, spec);

--- a/altair/jupyter/js/index.js
+++ b/altair/jupyter/js/index.js
@@ -44,7 +44,10 @@ export async function render({ model, el }) {
 
         // Debounce config
         const wait = model.get("debounce_wait") ?? 10;
-        const maxWait = wait;
+        const debounceOpts = {leading: false, trailing: true};
+        if (model.get("max_wait") ?? true) {
+            debounceOpts["maxWait"] = wait;
+        }
 
         const initialSelections = {};
         for (const selectionName of Object.keys(model.get("_vl_selections"))) {
@@ -57,7 +60,7 @@ export async function render({ model, el }) {
                 model.set("_vl_selections", newSelections);
                 model.save_changes();
             };
-            api.view.addSignalListener(selectionName, debounce(selectionHandler, wait, {maxWait}));
+            api.view.addSignalListener(selectionName, debounce(selectionHandler, wait, debounceOpts));
 
             initialSelections[selectionName] = {
                 value: cleanJson(api.view.signal(selectionName) ?? {}),
@@ -74,7 +77,7 @@ export async function render({ model, el }) {
                 model.set("_params", newParams);
                 model.save_changes();
             };
-            api.view.addSignalListener(paramName, debounce(paramHandler, wait, {maxWait}));
+            api.view.addSignalListener(paramName, debounce(paramHandler, wait, debounceOpts));
 
             initialParams[paramName] = api.view.signal(paramName) ?? null
         }
@@ -101,7 +104,7 @@ export async function render({ model, el }) {
                     }]);
                     model.save_changes();
                 };
-                addDataListener(api.view, watch.name, watch.scope, debounce(dataHandler, wait, maxWait))
+                addDataListener(api.view, watch.name, watch.scope, debounce(dataHandler, wait, debounceOpts))
 
             } else if (watch.namespace === "signal") {
                 const signalHandler = (_, value) => {
@@ -114,7 +117,7 @@ export async function render({ model, el }) {
                     model.save_changes();
                 };
 
-                addSignalListener(api.view, watch.name, watch.scope, debounce(signalHandler, wait, maxWait))
+                addSignalListener(api.view, watch.name, watch.scope, debounce(signalHandler, wait, debounceOpts))
             }
         }
 
@@ -133,6 +136,7 @@ export async function render({ model, el }) {
 
     model.on('change:spec', reembed);
     model.on('change:debounce_wait', reembed);
+    model.on('change:max_wait', reembed);
     await reembed();
 }
 

--- a/altair/jupyter/jupyter_chart.py
+++ b/altair/jupyter/jupyter_chart.py
@@ -107,6 +107,7 @@ class JupyterChart(anywidget.AnyWidget):
     chart = traitlets.Instance(TopLevelSpec, allow_none=True)
     spec = traitlets.Dict(allow_none=True).tag(sync=True)
     debounce_wait = traitlets.Float(default_value=10).tag(sync=True)
+    max_wait = traitlets.Bool(default_value=True).tag(sync=True)
     local_tz = traitlets.Unicode(default_value=None, allow_none=True).tag(sync=True)
 
     # Internal selection traitlets
@@ -122,7 +123,13 @@ class JupyterChart(anywidget.AnyWidget):
     _js_to_py_updates = traitlets.List().tag(sync=True)
     _py_to_js_updates = traitlets.List().tag(sync=True)
 
-    def __init__(self, chart: TopLevelSpec, debounce_wait: int = 10, **kwargs: Any):
+    def __init__(
+        self,
+        chart: TopLevelSpec,
+        debounce_wait: int = 10,
+        max_wait: bool = True,
+        **kwargs: Any,
+    ):
         """
         Jupyter Widget for displaying and updating Altair Charts, and
         retrieving selection and parameter values
@@ -132,11 +139,18 @@ class JupyterChart(anywidget.AnyWidget):
         chart: Chart
             Altair Chart instance
         debounce_wait: int
-             Debouncing wait time in milliseconds
+             Debouncing wait time in milliseconds. Updates will be sent from the client to the kernel
+             after debounce_wait milliseconds of no chart interactions.
+        max_wait: bool
+             If True (default), updates will be sent from the client to the kernel every debounce_wait
+             milliseconds even if there are ongoing chart interactions. If False, updates will not be
+             sent until chart interactions have completed.
         """
         self.params = Params({})
         self.selections = Selections({})
-        super().__init__(chart=chart, debounce_wait=debounce_wait, **kwargs)
+        super().__init__(
+            chart=chart, debounce_wait=debounce_wait, max_wait=max_wait, **kwargs
+        )
 
     @traitlets.observe("chart")
     def _on_change_chart(self, change):

--- a/altair/jupyter/jupyter_chart.py
+++ b/altair/jupyter/jupyter_chart.py
@@ -23,9 +23,7 @@ class Params(traitlets.HasTraits):
         super().__init__()
 
         for key, value in trait_values.items():
-            if isinstance(value, int):
-                traitlet_type = traitlets.Int()
-            elif isinstance(value, float):
+            if isinstance(value, (int, float)):
                 traitlet_type = traitlets.Float()
             elif isinstance(value, str):
                 traitlet_type = traitlets.Unicode()

--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -4,7 +4,7 @@ from importlib.metadata import version as importlib_version
 
 
 def import_vegafusion() -> ModuleType:
-    min_version = "1.4.0"
+    min_version = "1.5.0"
     try:
         version = importlib_version("vegafusion")
         if Version(version) < Version(min_version):

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -2,12 +2,23 @@ from toolz import curried
 import uuid
 from weakref import WeakValueDictionary
 
-from typing import Union, Dict, Set, MutableMapping, TypedDict, Final, Any
+from typing import (
+    Union,
+    Dict,
+    Set,
+    MutableMapping,
+    TypedDict,
+    Final,
+    TYPE_CHECKING,
+)
 
 from altair.utils._importers import import_vegafusion
 from altair.utils.core import DataFrameLike
 from altair.utils.data import DataType, ToValuesReturnType, MaxRowsError
 from altair.vegalite.data import default_data_transformer
+
+if TYPE_CHECKING:
+    from vegafusion.runtime import ChartState  # type: ignore
 
 # Temporary storage for dataframes that have been extracted
 # from charts by the vegafusion data transformer. Use a WeakValueDictionary
@@ -122,7 +133,9 @@ def get_inline_tables(vega_spec: dict) -> Dict[str, DataFrameLike]:
     return tables
 
 
-def compile_to_vegafusion_chart_state(vegalite_spec: dict, local_tz: str) -> Any:
+def compile_to_vegafusion_chart_state(
+    vegalite_spec: dict, local_tz: str
+) -> "ChartState":
     """Compile a Vega-Lite spec to a VegaFusion ChartState
 
     Note: This function should only be called on a Vega-Lite spec
@@ -223,7 +236,7 @@ def compile_with_vegafusion(vegalite_spec: dict) -> dict:
     return transformed_vega_spec
 
 
-def handle_row_limit_exceeded(row_limit, warnings):
+def handle_row_limit_exceeded(row_limit: int, warnings: list):
     for warning in warnings:
         if warning.get("type") == "RowLimitExceeded":
             raise MaxRowsError(

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -2,9 +2,7 @@ from toolz import curried
 import uuid
 from weakref import WeakValueDictionary
 
-from typing import Union, Dict, Set, MutableMapping
-
-from typing import TypedDict, Final
+from typing import Union, Dict, Set, MutableMapping, TypedDict, Final, Any
 
 from altair.utils._importers import import_vegafusion
 from altair.utils.core import DataFrameLike
@@ -124,6 +122,58 @@ def get_inline_tables(vega_spec: dict) -> Dict[str, DataFrameLike]:
     return tables
 
 
+def compile_to_vegafusion_chart_state(vegalite_spec: dict, local_tz: str) -> Any:
+    """Compile a Vega-Lite spec to a VegaFusion ChartState
+
+    Note: This function should only be called on a Vega-Lite spec
+    that was generated with the "vegafusion" data transformer enabled.
+    In particular, this spec may contain references to extract datasets
+    using table:// prefixed URLs.
+
+    Parameters
+    ----------
+    vegalite_spec: dict
+        A Vega-Lite spec that was generated from an Altair chart with
+        the "vegafusion" data transformer enabled
+    local_tz: str
+        Local timezone name (e.g. 'America/New_York')
+
+    Returns
+    -------
+    ChartState
+        A VegaFusion ChartState object
+    """
+    # Local import to avoid circular ImportError
+    from altair import vegalite_compilers, data_transformers
+
+    vf = import_vegafusion()
+
+    # Compile Vega-Lite spec to Vega
+    compiler = vegalite_compilers.get()
+    if compiler is None:
+        raise ValueError("No active vega-lite compiler plugin found")
+
+    vega_spec = compiler(vegalite_spec)
+
+    # Retrieve dict of inline tables referenced by the spec
+    inline_tables = get_inline_tables(vega_spec)
+
+    # Pre-evaluate transforms in vega spec with vegafusion
+    row_limit = data_transformers.options.get("max_rows", None)
+
+    chart_state = vf.runtime.new_chart_state(
+        vega_spec,
+        local_tz=local_tz,
+        inline_datasets=inline_tables,
+        row_limit=row_limit,
+    )
+
+    # Check from row limit warning and convert to MaxRowsError
+    handle_row_limit_exceeded(row_limit, chart_state.get_warnings())
+
+    return chart_state
+
+
 def compile_with_vegafusion(vegalite_spec: dict) -> dict:
     """Compile a Vega-Lite spec to Vega and pre-transform with VegaFusion
 
@@ -168,6 +218,12 @@ def compile_with_vegafusion(vegalite_spec: dict) -> dict:
     )
 
     # Check from row limit warning and convert to MaxRowsError
+    handle_row_limit_exceeded(row_limit, warnings)
+
+    return transformed_vega_spec
+
+
+def handle_row_limit_exceeded(row_limit, warnings):
     for warning in warnings:
         if warning.get("type") == "RowLimitExceeded":
             raise MaxRowsError(
@@ -177,8 +233,6 @@ def compile_with_vegafusion(vegalite_spec: dict) -> dict:
                 "the limit by calling alt.data_transformers.disable_max_rows(). Note that\n"
                 "disabling this limit may cause the browser to freeze or crash."
             )
-
-    return transformed_vega_spec
 
 
 def using_vegafusion() -> bool:

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -72,9 +72,11 @@ def spec_to_mimebundle(
 
     # Default to the embed options set by alt.renderers.set_embed_options
     if embed_options is None:
-        embed_options = renderers.options.get("embed_options", {})
+        final_embed_options = renderers.options.get("embed_options", {})
+    else:
+        final_embed_options = embed_options
 
-    embed_options = preprocess_embed_options(embed_options)
+    embed_options = preprocess_embed_options(final_embed_options)
 
     if format in ["png", "svg", "pdf", "vega"]:
         format = cast(Literal["png", "svg", "pdf", "vega"], format)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
     "types-jsonschema",
     "types-setuptools",
     "pyarrow>=11",
-    "vegafusion[embed]>=1.4.0",
+    "vegafusion[embed]>=1.5.0",
     "anywidget",
     "geopandas",
 ]

--- a/tests/test_jupyter_chart.py
+++ b/tests/test_jupyter_chart.py
@@ -30,6 +30,9 @@ def test_chart_with_no_interactivity(transformer):
         widget = alt.JupyterChart(chart)
 
         if transformer == "vegafusion":
+            # With the "vegafusion" transformer, the spec is not computed until the front-end
+            # sets the local_tz. Assign this property manually to simulate this.
+            widget.local_tz = "UTC"
             assert widget.spec == chart.to_dict(format="vega")
         else:
             assert widget.spec == chart.to_dict()
@@ -59,6 +62,7 @@ def test_interval_selection_example(transformer):
         widget = alt.JupyterChart(chart)
 
         if transformer == "vegafusion":
+            widget.local_tz = "UTC"
             assert widget.spec == chart.to_dict(format="vega")
         else:
             assert widget.spec == chart.to_dict()
@@ -126,6 +130,7 @@ def test_index_selection_example(transformer):
         widget = alt.JupyterChart(chart)
 
         if transformer == "vegafusion":
+            widget.local_tz = "UTC"
             assert widget.spec == chart.to_dict(format="vega")
         else:
             assert widget.spec == chart.to_dict()
@@ -185,6 +190,7 @@ def test_point_selection(transformer):
         widget = alt.JupyterChart(chart)
 
         if transformer == "vegafusion":
+            widget.local_tz = "UTC"
             assert widget.spec == chart.to_dict(format="vega")
         else:
             assert widget.spec == chart.to_dict()


### PR DESCRIPTION
## Overview
This PR updates JupyterChart to improve the integration with VegaFusion so that interactive data transformations can be performed in the Python kernel rather than the browser. This brings the capabilities of the dedicated [VegaFusion Widget Renderer](https://vegafusion.io/widget_renderer.html) to JupyterChart.

## Benefits
Let's start with an example of interactive crossfiltering on a 2 million row flights dataset.

```python
import altair as alt
import pandas as pd
from vega_datasets import data

alt.data_transformers.enable("vegafusion")

# Load data
source = pd.concat([data.flights_2k()] * 1000, axis=0)
# source = pd.concat([data.flights_2k()] * 10, axis=0)
print(f"{len(source)} rows")

# Build crossfiltered chart
brush = alt.selection_interval(encodings=['x'])

# Define the base chart, with the common parts of the
# background and highlights
base = alt.Chart(width=160, height=130).mark_bar().encode(
    x=alt.X(alt.repeat('column')).bin(maxbins=20),
    y='count()'
)

# gray background with selection
background = base.encode(
    color=alt.value('#ddd')
).add_params(brush)

# blue highlights on the transformed data
highlight = base.transform_filter(brush)

# layer the two charts & repeat
chart = alt.layer(
    background,
    highlight,
    data=source
).transform_calculate(
    "time",
    "hours(datum.date)"
).repeat(column=["distance", "delay", "time"])

alt.jupyter.JupyterChart(chart)
```

https://github.com/altair-viz/altair/assets/15064365/e9c59c89-31cb-4f89-b35d-3126082f303c

With this PR, the full dataset is never sent to the browser. Each time a selection is changed, a signal is sent from the widget to the Python kernel and the filtering and aggregation are performed in Python by VegaFusion, and the result is pushed back to the browser.

## How it's enabled
As before, VegaFusion is enabled in Altair globally using `alt.data_transformers.enable("vegafusion")`. When enabled, JupyterChart will automatically take advantage of VegaFusion. When not enabled, JupyterChart will continue to function as before. VegaFusion is still an optional dependency.

## How it works
This PR takes advantage of the ChartState construct added to VegaFusion 1.5.0 (See https://github.com/hex-inc/vegafusion/pull/426). The ChartState performs the initial spec transformation and provides a watch plan which specifies the signals and datasets that must be sent from the vega renderer back to the ChartState in order to preserve chart interactivity.

The ChartState is also responsible for holding references to inline datasets. So unlike VegaFusion's VegaFusionWidget approach, source dataframes do not need to be written to disk 🎉 

## Note on local_tz
One subtlety is that the ChartState requires the browser's local timezone in order to perform its data transformations. Because of this, I added a `local_tz` traitlet that is set by the widget to the browser's local timezone. The Python side adds a callback on this traitlet and builds the ChartState onces it is available in Python.

## Selection / Param access
When VegaFusion is enabled, it's still possible to access the Chart's selections and value parameters.

## Future of VegaFusionWidget
If these updates are accepted into JupyterChart, I plan on deprecating VegaFusionWidget (and the entire `vegafusion-jupyter` Python package).

I'll update the Altair docs in a follow-on PR to remove mention of VegaFusionWidget and explain the functionality of JupyterChart when VegaFusion is enabled.

