### PR TITLE
doc: histogram with gradient color

### DIFF
--- a/tests/examples_arguments_syntax/histogram_gradient_color.py
+++ b/tests/examples_arguments_syntax/histogram_gradient_color.py
@@ -2,7 +2,7 @@
 Histogram with Gradient Color
 -----------------------------
 This example shows how to make a histogram with gradient color. 
-The low-high IMDB rating is represented with the color scheme `redyellowgreen`.
+The low-high IMDB rating is represented with the color scheme `pinkyellowgreen`.
 """
 # category: distributions
 import altair as alt
@@ -18,6 +18,6 @@ alt.Chart(source).mark_bar().encode(
     alt.Y('count()'),
     alt.Color("IMDB_Rating:Q", 
         bin=alt.Bin(maxbins=20), 
-        scale=alt.Scale(scheme='redyellowgreen')
+        scale=alt.Scale(scheme='pinkyellowgreen')
     )
 )

--- a/tests/examples_arguments_syntax/histogram_gradient_color.py
+++ b/tests/examples_arguments_syntax/histogram_gradient_color.py
@@ -1,0 +1,23 @@
+"""
+Histogram with Gradient Color
+-----------------------------
+This example shows how to make a histogram with gradient color. 
+The low-high IMDB rating is represented with the color scheme `redyellowgreen`.
+"""
+# category: distributions
+import altair as alt
+from vega_datasets import data
+
+source = data.movies.url
+
+alt.Chart(source).mark_bar().encode(
+    alt.X("IMDB_Rating:Q", 
+        bin=alt.Bin(maxbins=20), 
+        scale=alt.Scale(domain=[1, 10])
+    ),
+    alt.Y('count()'),
+    alt.Color("IMDB_Rating:Q", 
+        bin=alt.Bin(maxbins=20), 
+        scale=alt.Scale(scheme='redyellowgreen')
+    )
+)

--- a/tests/examples_methods_syntax/histogram_gradient_color.py
+++ b/tests/examples_methods_syntax/histogram_gradient_color.py
@@ -2,7 +2,7 @@
 Histogram with Gradient Color
 -----------------------------
 This example shows how to make a histogram with gradient color.
-The low-high IMDB rating is represented with the color scheme `redyellowgreen`.
+The low-high IMDB rating is represented with the color scheme `pinkyellowgreen`.
 """
 # category: distributions
 import altair as alt
@@ -13,5 +13,5 @@ source = data.movies.url
 alt.Chart(source).mark_bar().encode(
     alt.X("IMDB_Rating:Q").bin(maxbins=20).scale(domain=[1, 10]),
     alt.Y('count()'),
-    alt.Color("IMDB_Rating:Q").bin(maxbins=20).scale(scheme='redyellowgreen')
+    alt.Color("IMDB_Rating:Q").bin(maxbins=20).scale(scheme='pinkyellowgreen')
 )

--- a/tests/examples_methods_syntax/histogram_gradient_color.py
+++ b/tests/examples_methods_syntax/histogram_gradient_color.py
@@ -1,0 +1,17 @@
+"""
+Histogram with Gradient Color
+-----------------------------
+This example shows how to make a histogram with gradient color.
+The low-high IMDB rating is represented with the color scheme `redyellowgreen`.
+"""
+# category: distributions
+import altair as alt
+from vega_datasets import data
+
+source = data.movies.url
+
+alt.Chart(source).mark_bar().encode(
+    alt.X("IMDB_Rating:Q").bin(maxbins=20).scale(domain=[1, 10]),
+    alt.Y('count()'),
+    alt.Color("IMDB_Rating:Q").bin(maxbins=20).scale(scheme='redyellowgreen')
+)


### PR DESCRIPTION
This PR adds an example of a histogram with a gradient color. Sometimes it is desirable to emphasise that higher/lower values are more/less favourable (here green/red).

<img width="486" alt="image" src="https://github.com/altair-viz/altair/assets/5186265/507d9a5c-c8b7-4cf8-b76b-fc56ecb56f27">
