### PR TITLE
Add "jupyter" renderer based on JupyterChart

### DIFF
--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -86,7 +86,7 @@ def svg_renderer(spec: dict, **metadata) -> Dict[str, str]:
     )
 
 
-def render_jupyter(spec):
+def jupyter_renderer(spec: dict):
     """Render chart using the JupyterChart Jupyter Widget"""
     from altair import Chart, JupyterChart
 
@@ -112,7 +112,7 @@ renderers.register("nteract", mimetype_renderer)
 renderers.register("json", json_renderer)
 renderers.register("png", png_renderer)
 renderers.register("svg", svg_renderer)
-renderers.register("jupyter", render_jupyter)
+renderers.register("jupyter", jupyter_renderer)
 renderers.enable("default")
 
 

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -86,6 +86,13 @@ def svg_renderer(spec: dict, **metadata) -> Dict[str, str]:
     )
 
 
+def render_jupyter(spec):
+    """Render chart using the JupyterChart Jupyter Widget"""
+    from altair import Chart, JupyterChart
+
+    return JupyterChart(chart=Chart.from_dict(spec))._repr_mimebundle_()
+
+
 html_renderer = HTMLRenderer(
     mode="vega-lite",
     template="universal",
@@ -105,6 +112,7 @@ renderers.register("nteract", mimetype_renderer)
 renderers.register("json", json_renderer)
 renderers.register("png", png_renderer)
 renderers.register("svg", svg_renderer)
+renderers.register("jupyter", render_jupyter)
 renderers.enable("default")
 
 

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -90,7 +90,9 @@ def jupyter_renderer(spec: dict):
     """Render chart using the JupyterChart Jupyter Widget"""
     from altair import Chart, JupyterChart
 
-    return JupyterChart(chart=Chart.from_dict(spec))._repr_mimebundle_()
+    # Need to ignore attr-defined mypy rule because mypy doesn't see _repr_mimebundle_
+    # conditionally defined in AnyWidget
+    return JupyterChart(chart=Chart.from_dict(spec))._repr_mimebundle_()  # type: ignore[attr-defined]
 
 
 html_renderer = HTMLRenderer(

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -8,7 +8,7 @@ Version 5.3.0 (unreleased month day, year)
 
 Enhancements
 ~~~~~~~~~~~~
-- Add "jupyter" renderer which uses JupyterChart for rendering (#3283)
+- Add "jupyter" renderer which uses JupyterChart for rendering (#3283). See :ref:`renderers` for more information.
 
 Bug Fixes
 ~~~~~~~~~

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -8,6 +8,8 @@ Version 5.3.0 (unreleased month day, year)
 
 Enhancements
 ~~~~~~~~~~~~
+- Add "jupyter" renderer which uses JupyterChart for rendering (#3283)
+
 Bug Fixes
 ~~~~~~~~~
 Backward-Incompatible Changes

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -41,10 +41,14 @@ The most used built-in renderers are:
   with the `Jupyter Notebook`_, or with tools like nbviewer_ and nbconvert_.
 
 ``alt.renderers.enable("jupyter")``
-  *(added in version 5.3.0):* Output the chart using :ref:`user-guide-jupyterchart`. This renderer
+  *(added in version 5.3):* Output the chart using :ref:`user-guide-jupyterchart`. This renderer
   is compatible with environments that support third-party Jupyter Widgets including
   JupyterLab_, `Jupyter Notebook`_, `VSCode-Python`_, and `Colab`_.
-  It requires a web connection in order to load relevant Javascript libraries.
+  It requires a web connection in order to load relevant Javascript libraries.  Note that,
+  although this renderer uses ``JupyterChart``, it does not provide the
+  ability to access value and selection params in Python. To do so, create a ``JupyterChart``
+  object explicitly following the instructions in the :ref:`user-guide-jupyterchart`
+  documentation.
 
 In addition, Altair includes the following renderers:
 

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -40,6 +40,12 @@ The most used built-in renderers are:
   newer versions of JupyterLab_, nteract_, and `VSCode-Python`_, but does not work
   with the `Jupyter Notebook`_, or with tools like nbviewer_ and nbconvert_.
 
+``alt.renderers.enable("jupyter")``
+  *(added in version 5.3.0):* Output the chart using :ref:`user-guide-jupyterchart`. This renderer
+  is compatible with environments that support third-party Jupyter Widgets including
+  JupyterLab_, `Jupyter Notebook`_, `VSCode-Python`_, and `Colab`_.
+  It requires a web connection in order to load relevant Javascript libraries.
+
 In addition, Altair includes the following renderers:
 
 - ``"default"``, ``"colab"``, ``"kaggle"``, ``"zeppelin"``: identical to ``"html"``

--- a/doc/user_guide/jupyter_chart.rst
+++ b/doc/user_guide/jupyter_chart.rst
@@ -1,7 +1,7 @@
 .. _user-guide-jupyterchart:
 
-JupyterChart Interactivity
-==========================
+JupyterChart
+============
 The ``JupyterChart`` class, introduced in Vega-Altair 5.1, makes it possible to update charts
 after they have been displayed and access the state of :ref:`user-guide-interactions` from Python.
 


### PR DESCRIPTION
This PR adds a new "jupyter" renderer that performs rendering using JupyterChart. Enable with:

```python
import altair as alt
alt.renderers.enable("jupyter")
...
chart
```

In combination with https://github.com/altair-viz/altair/pull/3281, this will make it possible to enable VegaFusion's serverside data transformation on interactive charts without needing to manually wrap charts with JupyterChart.

cc @joelostblom 
