### PR TITLE
Add offline support to JupyterChart and "jupyter" renderer

### DIFF
--- a/altair/jupyter/js/index.js
+++ b/altair/jupyter/js/index.js
@@ -1,6 +1,11 @@
 import vegaEmbed from "https://esm.sh/vega-embed@6?deps=vega@5&deps=vega-lite@5.16.3";
 import lodashDebounce from "https://esm.sh/lodash-es@4.17.21/debounce";
 
+// Note: For offline support, the import lines above are removed and the remaining script
+// is bundled using vl-convert's javascript_bundle function. See the documentation of
+// the javascript_bundle function for details on the available imports and their names.
+// If an additional import is required in the future, it will need to be added to vl-convert
+// in order to preserve offline support.
 export async function render({ model, el }) {
     let finalize;
 

--- a/altair/jupyter/js/index.js
+++ b/altair/jupyter/js/index.js
@@ -1,5 +1,5 @@
-import embed from "https://esm.sh/vega-embed@6?deps=vega@5&deps=vega-lite@5.16.3";
-import debounce from "https://esm.sh/lodash-es@4.17.21/debounce";
+import vegaEmbed from "https://esm.sh/vega-embed@6?deps=vega@5&deps=vega-lite@5.16.3";
+import lodashDebounce from "https://esm.sh/lodash-es@4.17.21/debounce";
 
 export async function render({ model, el }) {
     let finalize;
@@ -22,7 +22,7 @@ export async function render({ model, el }) {
         let spec = model.get("spec");
         let api;
         try {
-            api = await embed(el, spec);
+            api = await vegaEmbed(el, spec);
         } catch (error) {
             showError(error)
             return;
@@ -45,7 +45,7 @@ export async function render({ model, el }) {
                 model.set("_vl_selections", newSelections);
                 model.save_changes();
             };
-            api.view.addSignalListener(selectionName, debounce(selectionHandler, wait, {maxWait}));
+            api.view.addSignalListener(selectionName, lodashDebounce(selectionHandler, wait, {maxWait}));
 
             initialSelections[selectionName] = {
                 value: cleanJson(api.view.signal(selectionName) ?? {}),
@@ -62,7 +62,7 @@ export async function render({ model, el }) {
                 model.set("_params", newParams);
                 model.save_changes();
             };
-            api.view.addSignalListener(paramName, debounce(paramHandler, wait, {maxWait}));
+            api.view.addSignalListener(paramName, lodashDebounce(paramHandler, wait, {maxWait}));
 
             initialParams[paramName] = api.view.signal(paramName) ?? null
         }

--- a/altair/jupyter/jupyter_chart.py
+++ b/altair/jupyter/jupyter_chart.py
@@ -112,6 +112,24 @@ class JupyterChart(anywidget.AnyWidget):
     # Internal param traitlets
     _params = traitlets.Dict().tag(sync=True)
 
+    @classmethod
+    def enable_offline(cls):
+        from altair.utils._importers import import_vl_convert, vl_version_for_vl_convert
+
+        vlc = import_vl_convert()
+
+        src_lines = (_here / "js" / "index.js").read_text().split("\n")
+
+        # Remove leading lines with only whitespace or imports
+        while src_lines and (
+            len(src_lines[0].strip()) == 0 or src_lines[0].startswith("import")
+        ):
+            src_lines.pop(0)
+
+        src = "\n".join(src_lines)
+        bundled_src = vlc.javascript_bundle(src, vl_version=vl_version_for_vl_convert())
+        cls._esm = bundled_src
+
     def __init__(self, chart: TopLevelSpec, debounce_wait: int = 10, **kwargs: Any):
         """
         Jupyter Widget for displaying and updating Altair Charts, and

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -86,9 +86,13 @@ def svg_renderer(spec: dict, **metadata) -> Dict[str, str]:
     )
 
 
-def jupyter_renderer(spec: dict):
+def jupyter_renderer(spec: dict, **metadata):
     """Render chart using the JupyterChart Jupyter Widget"""
     from altair import Chart, JupyterChart
+
+    # Configure offline mode
+    offline = metadata.get("offline", False)
+    JupyterChart.enable_offline(offline=offline)
 
     # Need to ignore attr-defined mypy rule because mypy doesn't see _repr_mimebundle_
     # conditionally defined in AnyWidget

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -92,7 +92,9 @@ def jupyter_renderer(spec: dict, **metadata):
 
     # Configure offline mode
     offline = metadata.get("offline", False)
-    JupyterChart.enable_offline(offline=offline)
+
+    # mypy doesn't see the enable_offline class method for some reason
+    JupyterChart.enable_offline(offline=offline)  # type: ignore[attr-defined]
 
     # Need to ignore attr-defined mypy rule because mypy doesn't see _repr_mimebundle_
     # conditionally defined in AnyWidget

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -9,6 +9,8 @@ Version 5.3.0 (unreleased month day, year)
 Enhancements
 ~~~~~~~~~~~~
 - Add "jupyter" renderer which uses JupyterChart for rendering (#3283). See :ref:`renderers` for more information.
+- Add offline support for JupyterChart and the new "jupyter" renderer. See :ref:`user-guide-jupyterchart-offline`
+  for more information.
 - Docs: Add :ref:`section on dashboards <display_dashboards>` which have support for Altair (#3299)
 - Support restrictive FIPS-compliant environment (#3291)
 

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -50,6 +50,11 @@ The most used built-in renderers are:
   object explicitly following the instructions in the :ref:`user-guide-jupyterchart`
   documentation.
 
+``alt.renderers.enable("jupyter", offline=True)``
+  *(added in version 5.3):* Same as the ``"jupyter"`` renderer above, but loads JavaScript
+  dependencies from the ``vl-convert-python`` package (rather than from an online CDN)
+  so that an internet connection is not required.
+
 In addition, Altair includes the following renderers:
 
 - ``"default"``, ``"colab"``, ``"kaggle"``, ``"zeppelin"``: identical to ``"html"``

--- a/doc/user_guide/jupyter_chart.rst
+++ b/doc/user_guide/jupyter_chart.rst
@@ -426,15 +426,33 @@ is used to combine the chart and HTML table in a column layout.
       Your browser does not support the video tag.
     </video>
 
+.. _user-guide-jupyterchart-offline:
+
+Offline Usage
+-------------
+By default, the ``JupyterChart`` widget loads its JavaScript dependencies dynamically from a CDN
+location, which requires an active internet connection. Starting in Altair 5.3, JupyterChart supports
+loading its JavaScript dependencies from the ``vl-convert-python`` package, which enables offline usage.
+
+Offline mode is enabled using the ``JupyterChart.enable_offline`` class method.
+
+.. code-block:: python
+
+    import altair as alt
+    alt.JupyterChart.enable_offline()
+
+This only needs to be called once, after which all displayed JupyterCharts will operate in offline mode.
+
+Offline mode can be disabled by passing ``offline=False`` to this same method.
+
+.. code-block:: python
+
+    import altair as alt
+    alt.JupyterChart.enable_offline(offline=False)
+
 Limitations
 -----------
 
 Setting Selections
 ~~~~~~~~~~~~~~~~~~
 It's not currently possible to set selection states from Python.
-
-Internet Connection Required
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The JupyterChart class currently loads its JavaScript dependencies dynamically from a CDN location.
-This keeps the ``altair`` package small, but it means that an internet connection is required
-to display JupyterChart instances. In the future, we would like to provide optional offline support.


### PR DESCRIPTION
This PR adds optional offline support for JupyterChart and the "jupyter" renderer.

## How to enable offline support
Offline support is enabled on JupyterChart directly by calling the `JupyterChart.enable_offline()` class method.

```python
alt.JupyterChart.enable_offline()
```

Offline support is enabled for the "jupyter" renderer by activating the renderer with the `offline` kwarg:

```python
alt.renderers.enable("jupyter", offline=True)
```

## How it works
In order to support offline usage, the AnyWidget documentation describes how to create JS bundles using bundlers like esbuild: https://anywidget.dev/en/bundling/#bundler-guides. This is the approach I used in the very first JupyterChart PR (https://github.com/altair-viz/altair/pull/3108).

There are two main downsides of this approach:
 - It complicates the development setup by requiring an additional build tool and build step
 - It increases the Altair package size by close to 1MB.

Because of these downsides, we opted to start with an online-only version in https://github.com/altair-viz/altair/pull/3119.

When vl-convert added support for HTML export, it added a `javascript_bundle` function that performs bundling (using [deno_emit](https://github.com/denoland/deno_emit)). Unlike a regular bundler that supports all JavaScript packages and downloads them from the internet during bundling, vl-convert's bundler only supports a couple of packages (`vegaEmbed` and `lodashDebounce` in particular) but these packages are vendored in the vl-convert executable so no internet connection is required to perform bundling.

The `JupyterChart.enable_offline` method calls vl-convert's `javascript_bundle` function to generate a bundle for the widget code that includes all dependencies, including the correct version of Vega-Lite. This takes around 1 second to run on my machine, which I think is well worth it to overcome both of the downsides above.

## Docs
I added documentation in both the JupyterChart and "jupyter" renderer sections


