### PR TITLE
Add `all` dependency group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install .[all, dev]
           # pip install "selenium<4.3.0"
           # pip install altair_saver
       - name: Install specific jsonschema

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[all, dev]
+          pip install ".[all, dev]"
           # pip install "selenium<4.3.0"
           # pip install altair_saver
       - name: Install specific jsonschema

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev]
+        pip install .[all, dev]
     - name: Lint with ruff
       run: |        
         ruff check .        

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[all, dev]
+        pip install ".[all, dev]"
     - name: Lint with ruff
       run: |        
         ruff check .        

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,11 @@ every time you open a new Python interpreter
 
 ```cmd
 cd altair/ 
-python -m pip install -e .[dev]
+python -m pip install -e ".[all, dev]"
 ```
 
-'[dev]' indicates that pip should also install the development requirements
-which you can find in `pyproject.toml` (`[project.optional-dependencies]/dev`)
+'[all, dev]' indicates that pip should also install the optional and development requirements
+which you can find in `pyproject.toml` (`[project.optional-dependencies]/all` and `[project.optional-dependencies]/dev`)
 
 ### Creating a Branch
 

--- a/NOTES_FOR_MAINTAINERS.md
+++ b/NOTES_FOR_MAINTAINERS.md
@@ -69,6 +69,9 @@ an issue](https://github.com/vega/vl-convert/issues) if this version hasn't been
 included in a released yet.). Update the vl-convert version check in `altair/utils/_importers.py` 
 with the new minimum required version of vl-convert.
 
+Also, the version bound of the `vl-convert-python` package should be updated in the 
+`[project.optional-dependencies]/all` dependency group in `pyproject.toml`.
+
 ## Releasing the Package
 
 To cut a new release of Altair, follow the steps outlined in

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -9,7 +9,7 @@ Altair can be installed, along with the example datasets in vega_datasets_, usin
 
 .. code-block:: bash
 
-    pip install altair vega_datasets
+    pip install "altair[all]"
 
 If you are using the conda_ package manager, the equivalent is:
 
@@ -33,11 +33,11 @@ from the root of the repository to install the main version of Altair:
 
     pip install -e .
 
-To install development dependencies as well, run
+To install optional and development dependencies as well, run
 
 .. code-block:: bash
 
-    pip install -e .[dev]
+    pip install -e ".[all, dev]"
 
 If you do not wish to clone the source repository, you can install the
 development version directly from GitHub using:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,7 @@ all = [
     "vl-convert-python>=1.1.0",
     "pyarrow>=11",
     "vegafusion[embed]>=1.5.0",
-    "anywidget>=0.9.0",
-    "altair_tiles>=0.2.0"
+    "anywidget>=0.9.0"
 ]
 dev = [
     "hatch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ include = ["/altair"]
 artifacts = ["altair/jupyter/js/index.js"]
 
 [tool.hatch.envs.default]
-features = ["dev"]
+features = ["all", "dev"]
 
 [tool.hatch.envs.default.scripts]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,14 @@ Documentation = "https://altair-viz.github.io"
 Source = "https://github.com/altair-viz/altair"
 
 [project.optional-dependencies]
+all = [
+    "vega_datasets>=0.9.0",
+    "vl-convert-python>=1.1.0",
+    "pyarrow>=11",
+    "vegafusion[embed]>=1.5.0",
+    "anywidget>=0.9.0",
+    "altair_tiles>=0.2.0"
+]
 dev = [
     "hatch",
     "ruff>=0.3.0",
@@ -64,15 +72,10 @@ dev = [
     "pytest",
     "pytest-cov",
     "m2r",
-    "vega_datasets",
-    "vl-convert-python>=1.1.0",
     "mypy",
     "pandas-stubs",
     "types-jsonschema",
     "types-setuptools",
-    "pyarrow>=11",
-    "vegafusion[embed]>=1.5.0",
-    "anywidget",
     "geopandas",
 ]
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ all = [
     "pyarrow>=11",
     "vegafusion[embed]>=1.5.0",
     "anywidget>=0.9.0",
-    "altair_tiles>=0.2.0"
+    "altair_tiles>=0.3.0"
 ]
 dev = [
     "hatch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ all = [
     "vl-convert-python>=1.1.0",
     "pyarrow>=11",
     "vegafusion[embed]>=1.5.0",
-    "anywidget>=0.9.0"
+    "anywidget>=0.9.0",
+    "altair_tiles>=0.2.0"
 ]
 dev = [
     "hatch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ test-coverage = "python -m pytest --pyargs --doctest-modules --cov=altair --cov-
 test-coverage-html = "python -m pytest --pyargs --doctest-modules --cov=altair --cov-report html altair"
 
 [tool.hatch.envs.doc]
-features = ["dev", "doc"]
+features = ["all", "dev", "doc"]
 
 [tool.hatch.envs.doc.scripts]
 clean = "rm -rf doc/_build"


### PR DESCRIPTION
Closes #2818 and part of #3309

This PR adds a new `all` dependency group that contains the primary optional dependencies that we'd like most users of Altair to have installed by default. 

Rather than duplicate dependencies across `all` and our existing `dev` group, I removed the optional runtime dependencies from `dev` and updated the development instructions to install both groups with `pip install ".[all, dev]"`.

I updated the documentation to recommend installing the `altair` package with `pip install "altair[all]"`.