### PR TITLE
Open charts in the default browser with `open_editor` method

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1133,7 +1133,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         """
         import webbrowser
 
-        webbrowser.open(self.to_url(fullscreen = fullscreen))
+        webbrowser.open(self.to_url(fullscreen=fullscreen))
 
     def save(
         self,

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1104,7 +1104,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             **kwargs,
         )
 
-    def to_url(self, *, fullscreen: bool = False) -> str:
+    def to_url(self, *, open_browser: bool = True, fullscreen: bool = False) -> str:
         """Convert a chart to a URL that opens the chart specification in the Vega chart editor
         The chart specification (including any inline data) is encoded in the URL.
 
@@ -1112,6 +1112,8 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
         Parameters
         ----------
+        open_browser : bool
+            If True, the default browser will be launched to open the url. Default True
         fullscreen : bool
             If True, editor will open chart in fullscreen mode. Default False
         """
@@ -1119,9 +1121,14 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
         vlc = import_vl_convert()
         if _using_vegafusion():
-            return vlc.vega_to_url(self.to_dict(format="vega"), fullscreen=fullscreen)
+            url = vlc.vega_to_url(self.to_dict(format="vega"), fullscreen=fullscreen)
         else:
-            return vlc.vegalite_to_url(self.to_dict(), fullscreen=fullscreen)
+            url = vlc.vegalite_to_url(self.to_dict(), fullscreen=fullscreen)
+        if open_browser:
+            import webbrowser
+
+            webbrowser.open(url)
+        return url
 
     def save(
         self,

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1104,7 +1104,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             **kwargs,
         )
 
-    def to_url(self, *, open_browser: bool = True, fullscreen: bool = False) -> str:
+    def to_url(self, *, fullscreen: bool = False) -> str:
         """Convert a chart to a URL that opens the chart specification in the Vega chart editor
         The chart specification (including any inline data) is encoded in the URL.
 
@@ -1112,8 +1112,6 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
         Parameters
         ----------
-        open_browser : bool
-            If True, the default browser will be launched to open the url. Default True
         fullscreen : bool
             If True, editor will open chart in fullscreen mode. Default False
         """
@@ -1121,14 +1119,21 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
         vlc = import_vl_convert()
         if _using_vegafusion():
-            url = vlc.vega_to_url(self.to_dict(format="vega"), fullscreen=fullscreen)
+            return vlc.vega_to_url(self.to_dict(format="vega"), fullscreen=fullscreen)
         else:
-            url = vlc.vegalite_to_url(self.to_dict(), fullscreen=fullscreen)
-        if open_browser:
-            import webbrowser
+            return vlc.vegalite_to_url(self.to_dict(), fullscreen=fullscreen)
 
-            webbrowser.open(url)
-        return url
+    def open_editor(self, *, fullscreen: bool = False) -> None:
+        """Opens the chart specification in the Vega chart editor using the default browser.
+
+        Parameters
+        ----------
+        fullscreen : bool
+            If True, editor will open chart in fullscreen mode. Default False
+        """
+        import webbrowser
+
+        webbrowser.open(self.to_url(fullscreen = fullscreen))
 
     def save(
         self,

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -13,6 +13,7 @@ Enhancements
   for more information.
 - Docs: Add :ref:`section on dashboards <display_dashboards>` which have support for Altair (#3299)
 - Support restrictive FIPS-compliant environment (#3291)
+- Support opening charts in the Vega editor with ``chart.open_editor()`` (#3358)
 
 Bug Fixes
 ~~~~~~~~~

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -381,7 +381,7 @@ def test_save_html(basic_chart, inline):
 
 
 def test_to_url(basic_chart):
-    share_url = basic_chart.to_url(open_browser=False)
+    share_url = basic_chart.to_url()
     expected_vegalite_encoding = "N4Igxg9gdgZglgcxALlANzgUwO4tJKAFzigFcJSBnAdTgBNCALFAZgAY2AacaYsiygAlMiRoVYcAvpO50AhoTl4QUOQFtMKEPMUBaAOwA2ABwAWFi1NyTcgEb7TtuabAswc-XTZhMczLdNDAEYQGRA1OQAnAGtlQgBPAAdNZBAnSNDuTChIOhIkVBAAD2V4TAAbOi0lbgTkrSgINRI5csyQeNKsSq1bEFqklJAAR1I5IjhFYjRNaW4AEkowRkwIrTFCRMpkAHodmYQ5ADoEScZSWyO4CB2llYj9zEPdcsnMfYBWI6DDI5YjgBWlGg-W0CjklEwhEoyh0cgMJnMlmsxjsDicLjcHi8Pj8AWCKAA2qAlKkAIKgvrIABMxhkJK0ACFKSgPh96SBSSAAMIs5DmDlcgAifIAnEFBVoAKJ84wSzgM1IAMT5HxYktSAHE+UFRRqQIJZfp9QBJVXUyQAXWkQA"
 
     assert (
@@ -390,7 +390,7 @@ def test_to_url(basic_chart):
     )
 
     # Check fullscreen
-    fullscreen_share_url = basic_chart.to_url(open_browser=False, fullscreen=True)
+    fullscreen_share_url = basic_chart.to_url(fullscreen=True)
     assert (
         fullscreen_share_url
         == f"https://vega.github.io/editor/#/url/vega-lite/{expected_vegalite_encoding}/view"

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -381,7 +381,7 @@ def test_save_html(basic_chart, inline):
 
 
 def test_to_url(basic_chart):
-    share_url = basic_chart.to_url()
+    share_url = basic_chart.to_url(open_browser=False)
     expected_vegalite_encoding = "N4Igxg9gdgZglgcxALlANzgUwO4tJKAFzigFcJSBnAdTgBNCALFAZgAY2AacaYsiygAlMiRoVYcAvpO50AhoTl4QUOQFtMKEPMUBaAOwA2ABwAWFi1NyTcgEb7TtuabAswc-XTZhMczLdNDAEYQGRA1OQAnAGtlQgBPAAdNZBAnSNDuTChIOhIkVBAAD2V4TAAbOi0lbgTkrSgINRI5csyQeNKsSq1bEFqklJAAR1I5IjhFYjRNaW4AEkowRkwIrTFCRMpkAHodmYQ5ADoEScZSWyO4CB2llYj9zEPdcsnMfYBWI6DDI5YjgBWlGg-W0CjklEwhEoyh0cgMJnMlmsxjsDicLjcHi8Pj8AWCKAA2qAlKkAIKgvrIABMxhkJK0ACFKSgPh96SBSSAAMIs5DmDlcgAifIAnEFBVoAKJ84wSzgM1IAMT5HxYktSAHE+UFRRqQIJZfp9QBJVXUyQAXWkQA"
 
     assert (
@@ -390,7 +390,7 @@ def test_to_url(basic_chart):
     )
 
     # Check fullscreen
-    fullscreen_share_url = basic_chart.to_url(fullscreen=True)
+    fullscreen_share_url = basic_chart.to_url(open_browser=False, fullscreen=True)
     assert (
         fullscreen_share_url
         == f"https://vega.github.io/editor/#/url/vega-lite/{expected_vegalite_encoding}/view"


### PR DESCRIPTION
I have been working more in VS Code instead of JupyterLab lately and really come to appreciate the `to_url()` method added in https://github.com/altair-viz/altair/pull/3252 (thanks @jonmmease!). VS Code can't correctly handle the Vega-Lite actions menu https://github.com/altair-viz/altair/issues/2875 and there seems to be little hope of fixing this https://github.com/microsoft/vscode-jupyter/issues/13261.

However, after trying to troubleshoot a few altair specs in the Vega-Lite window, I find myself copying the url over and over again after small edits to the altair spec (for me VS Code only sometimes figures out that the url is a link that can be clicked; maybe related to the length of the spec). It would be convenient if the Vega-Lite spec of the charts could automatically open in the default browser, which is what this PR tries to implement (also mentioned in https://github.com/altair-viz/altair/pull/3252#issuecomment-1793758530).

I put the browser launch as the default when using `to_url()`, since I imagine that the most common scenario is to quickly go between the local editor and the online Vega-Editor to troubleshoot a spec. I find this convenient, but if it is considered too aggressive, then I'm happy to change it.

Tagging everyone who was involved in the previous PR discussion: @jonmmease @NickCrews @mattijn @binste 