### PR TITLE
Add note about conda "all" installation and how to install without optional dependencies

### DIFF
--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -5,7 +5,7 @@
 Installation
 ============
 
-Altair can be installed, along with the example datasets in vega_datasets_, using:
+Altair can be installed, along with all its optional dependencies, using:
 
 .. code-block:: bash
 
@@ -15,12 +15,14 @@ If you are using the conda_ package manager, the equivalent is:
 
 .. code-block:: bash
 
-    conda install -c conda-forge altair vega_datasets
+    conda install -c conda-forge altair-all
 
-At this point, you should be able to open `Jupyter Notebook`_ or `JupyterLab`_
+At this point, you should be able to open any IDE compatible with Jupyter Notebooks,
 and execute any of the code from the :ref:`example-gallery`.
 For more information on how to display charts in various notebook environments
 and non-notebook IDEs, see :ref:`displaying-charts`.
+If you wish to install Altair with only the required dependencies,
+you can omit the ``[all]``/``-all`` suffix.
 
 Development Installation
 ========================


### PR DESCRIPTION
I created a new env on Linux and this is what is downloaded when installing `altair-all`:

```
The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    altair-5.2.0               |     pyhd8ed1ab_1         447 KB  conda-forge
    altair-all-5.2.0           |     pyhd8ed1ab_1           7 KB  conda-forge
    altair_tiles-0.3.0         |     pyhd8ed1ab_0          14 KB  conda-forge
    aws-c-auth-0.7.16          |       haed3651_8         101 KB  conda-forge
    aws-c-cal-0.6.10           |       ha9bf9b1_2          54 KB  conda-forge
    aws-c-common-0.9.14        |       hd590300_0         220 KB  conda-forge
    aws-c-compression-0.2.18   |       h4466546_2          19 KB  conda-forge
    aws-c-event-stream-0.4.2   |       he635cd5_6          52 KB  conda-forge
    aws-c-http-0.8.1           |       hbfc29b2_7         190 KB  conda-forge
    aws-c-io-0.14.6            |       h6b388c4_1         154 KB  conda-forge
    aws-c-mqtt-0.10.3          |       hffff1cc_2         159 KB  conda-forge
    aws-c-s3-0.5.2             |       h4893938_2         103 KB  conda-forge
    aws-c-sdkutils-0.1.15      |       h4466546_2          54 KB  conda-forge
    aws-checksums-0.1.18       |       h4466546_2          49 KB  conda-forge
    aws-crt-cpp-0.26.3         |       h137ae52_2         326 KB  conda-forge
    aws-sdk-cpp-1.11.267       |       he0cb598_3         3.5 MB  conda-forge
    libarrow-15.0.1            |   h6bfc85a_2_cpu         7.8 MB  conda-forge
    libarrow-acero-15.0.1      |   h59595ed_2_cpu         584 KB  conda-forge
    libarrow-dataset-15.0.1    |   h59595ed_2_cpu         571 KB  conda-forge
    libarrow-flight-15.0.1     |   hc6145d9_2_cpu         493 KB  conda-forge
    libarrow-flight-sql-15.0.1 |   h757c851_2_cpu         191 KB  conda-forge
    libarrow-gandiva-15.0.1    |   hb016d2e_2_cpu         876 KB  conda-forge
    libarrow-substrait-15.0.1  |   h757c851_2_cpu         509 KB  conda-forge
    libcurl-8.6.0              |       hca28451_0         382 KB  conda-forge
    libparquet-15.0.1          |   h352af49_2_cpu         1.1 MB  conda-forge
    libxml2-2.12.6             |       h232c23b_0         688 KB  conda-forge
    orc-2.0.0                  |       h1e5e2c1_0        1005 KB  conda-forge
    protobuf-4.25.3            |  py312h72fbbdf_0         382 KB  conda-forge
    pyarrow-15.0.1             |py312h176e3d2_2_cpu         4.3 MB  conda-forge
    referencing-0.34.0         |     pyhd8ed1ab_0          41 KB  conda-forge
    s2n-1.4.7                  |       h06160fa_0         331 KB  conda-forge
    ucx-1.15.0                 |       h11edf95_7         6.5 MB  conda-forge
    vegafusion-python-embed-1.6.5|  py312h4b3b743_0        15.5 MB  conda-forge
    vl-convert-python-1.3.0    |  py312h98912ed_0        20.5 MB  conda-forge
    ------------------------------------------------------------
                                           Total:        67.1 MB
```