### PR TITLE
Update README badges to reflect updated tool chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vega-Altair <a href="https://altair-viz.github.io/"><img align="right" src="https://altair-viz.github.io/_static/altair-logo-light.png" height="50"></img></a>
 
 [![github actions](https://github.com/altair-viz/altair/workflows/build/badge.svg)](https://github.com/altair-viz/altair/actions?query=workflow%3Abuild)
-[![code style black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![typedlib_mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://www.mypy-lang.org)
 [![JOSS Paper](https://joss.theoj.org/papers/10.21105/joss.01057/status.svg)](https://joss.theoj.org/papers/10.21105/joss.01057)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/altair)](https://pypi.org/project/altair)
 
@@ -108,6 +108,10 @@ you can post it on [StackOverflow](https://stackoverflow.com/questions/tagged/al
 For bugs and feature requests, please open a [Github Issue](https://github.com/altair-viz/altair/issues).
 
 ## Development
+
+[![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![pytest](https://img.shields.io/badge/logo-pytest-blue?logo=pytest&labelColor=5c5c5c&label=%20)](https://github.com/pytest-dev/pytest)
 
 You can find the instructions on how to install the package for development in [the documentation](https://altair-viz.github.io/getting_started/installation.html).
 


### PR DESCRIPTION
This PR removes the obsolete code style black badge and replaces it with a badge indicating that this is a type checked library using mypy

Moreover under the development section I've added three more badges indicating we use hatch, ruff and pytest for development.

Before:
![image](https://github.com/altair-viz/altair/assets/5186265/200603c4-d7e9-4676-8648-e4a9a4056ffd)

After:
![image](https://github.com/altair-viz/altair/assets/5186265/2fa598ee-168f-4774-b7a1-f30fcc27acd7)

---

Before:
![image](https://github.com/altair-viz/altair/assets/5186265/b17ada60-64fb-4a14-bead-f8127adbef01)

After:
![image](https://github.com/altair-viz/altair/assets/5186265/93b566e9-b17d-440a-ba13-120a0393ec7b)
