### PR TITLE
fix: Support falling back to pandas when pyarrow is installed but too old

### DIFF
--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -93,5 +93,5 @@ def pyarrow_available() -> bool:
     try:
         import_pyarrow_interchange()
         return True
-    except ImportError:
+    except (ImportError, RuntimeError):
         return False


### PR DESCRIPTION
Closes #3385 by catching `RuntimeError` along with `ImportError` in `pyarrow_available`.

This was a regression introduced in https://github.com/altair-viz/altair/pull/3244 when the `ImportError` was swapped out for a `RuntimeError` without updating `pyarrow_available`.

@mattijn, could you give this a try to see if it takes care of the issue of an old pyarrow with pandas?