### PR TITLE
chore: Remove CoC link in templates since it's displayed by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -29,6 +29,3 @@ body:
     attributes:
       label: Which version of Altair are you using?
       description: Use `alt.__version__` to find out
-  - type: markdown
-    attributes:
-      value: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/altair-viz/altair/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -31,4 +31,4 @@ body:
       description: Use `alt.__version__` to find out
   - type: markdown
     attributes:
-      value: By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md).
+      value: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/altair-viz/altair/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -23,4 +23,4 @@ body:
       label: Have you considered any alternative solutions?
   - type: markdown
     attributes:
-      value: By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md).
+      value: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/altair-viz/altair/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -21,6 +21,3 @@ body:
     id: alternative-solutions
     attributes:
       label: Have you considered any alternative solutions?
-  - type: markdown
-    attributes:
-      value: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/altair-viz/altair/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,3 @@ Please follow these guidelines when submitting your PR:
 - Include unit tests and documentation for new features
 - Ensure that the title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "feat: Add `embed_options` to charts").
     - Append `!` if the change is breaking (e.g. "fix!: Raise error when `embed_options` is `None`")
-- By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/altair-viz/altair/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,4 @@ Please follow these guidelines when submitting your PR:
 - Include unit tests and documentation for new features
 - Ensure that the title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "feat: Add `embed_options` to charts").
     - Append `!` if the change is breaking (e.g. "fix!: Raise error when `embed_options` is `None`")
+- By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/altair-viz/altair/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
I noticed that GH actually already displays a message about this under the "Submit" button, so no need to have it twice:

![image](https://github.com/altair-viz/altair/assets/4560057/9452fbc6-bc2d-4bf0-840a-bd151aba39aa)
