### PR TITLE
docs: Add example of reordering stacked bars

### DIFF
--- a/tests/examples_arguments_syntax/interactive_reorder_stacked_bars.py
+++ b/tests/examples_arguments_syntax/interactive_reorder_stacked_bars.py
@@ -1,0 +1,30 @@
+"""
+Reorder stacked bar segments
+============================
+This example uses a calculate transform
+to check the values of the "site" column
+vs the clicked values in the legend,
+and assigns a lower order (0)
+if there is a match.
+The use of "indexOf" checks for equality in an array,
+which here allows for mutliple segments to be reordered
+by holding down the shift key while clicking the legend.
+"""
+# category: interactive charts
+import altair as alt
+from vega_datasets import data
+
+
+selection = alt.selection_point(fields=['site'], bind='legend')
+
+alt.Chart(data.barley.url).mark_bar().transform_calculate(
+    site_order=f"if({selection.name}.site && indexof({selection.name}.site, datum.site) !== -1, 0, 1)"
+).encode(
+    x='sum(yield):Q',
+    y='variety:N',
+    color='site:N',
+    order='site_order:N',
+    opacity=alt.condition(selection, alt.value(0.9), alt.value(0.2))
+).add_params(
+    selection
+)

--- a/tests/examples_arguments_syntax/interactive_reorder_stacked_bars.py
+++ b/tests/examples_arguments_syntax/interactive_reorder_stacked_bars.py
@@ -7,17 +7,18 @@ vs the clicked values in the legend,
 and assigns a lower order (0)
 if there is a match.
 The use of "indexOf" checks for equality in an array,
-which here allows for mutliple segments to be reordered
+which here allows for multiple segments to be reordered
 by holding down the shift key while clicking the legend.
 """
 # category: interactive charts
 import altair as alt
 from vega_datasets import data
 
-
 selection = alt.selection_point(fields=['site'], bind='legend')
 
-alt.Chart(data.barley.url).mark_bar().transform_calculate(
+source = data.barley.url
+
+alt.Chart(source).mark_bar().transform_calculate(
     site_order=f"if({selection.name}.site && indexof({selection.name}.site, datum.site) !== -1, 0, 1)"
 ).encode(
     x='sum(yield):Q',


### PR DESCRIPTION
This example shows how to reorder bar segments via a click interaction in the legend. Credit to @dwootton who came up with the spec in [this very neat tweet](https://twitter.com/WoottonDylan/status/1646596161548046346) which I modified slightly to include opacity changes and to allow for sorting multiple segments.

https://github.com/altair-viz/altair/assets/4560057/f4e55602-7c4b-4bc7-a981-4bc3264b3929

