### PR TITLE
ci: Remove references to archived altair_viewer and altair_saver in ci, docs, and tests. Uninstall anywidget and vl-convert-python during one test run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,17 +16,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      # - name: Set Up Chromedriver
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get --only-upgrade install google-chrome-stable
-      #     sudo apt-get -yqq install chromium-chromedriver
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install ".[all, dev]"
-          # pip install "selenium<4.3.0"
-          # pip install altair_saver
       - name: Install specific jsonschema
         # Only have to execute this if we don't want the latest jsonschema version
         if: ${{ matrix.jsonschema-version != 'latest' }}
@@ -39,7 +32,7 @@ jobs:
         # Also see https://github.com/vega/altair/pull/3114
         if: ${{ matrix.python-version == '3.8' }}
         run: |
-          pip uninstall -y pyarrow vegafusion vegafusion-python-embed
+          pip uninstall -y pyarrow vegafusion vegafusion-python-embed vl-convert-python anywidget
       - name: Maybe install lowest supported pandas version
         # We install the lowest supported pandas version for one job to test that
         # it still works. Downgrade to the oldest versions of pandas and numpy that include
@@ -72,18 +65,6 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --doctest-modules tests
-      # - name: Selected tests without vl-convert-python
-      #   run: |
-      #     pip uninstall vl-convert-python --yes
-      #     pytest -m save_engine --doctest-modules tests
-      # - name: Selected tests without vl-convert-python and altair_saver
-      #   run: |
-      #     pip uninstall altair_saver --yes
-      #     pytest -m save_engine --doctest-modules tests
-      - name: Selected tests with vl-convert-python and without altair_saver
-        run: |
-          # pip install vl-convert-python
-          pytest -m save_engine --doctest-modules tests
       - name: Validate Vega-Lite schema
         run: |
           # We install all 'format' dependencies of jsonschema as check-jsonschema

--- a/altair/__init__.py
+++ b/altair/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "AggregatedFieldDef",
     "Align",
     "AllSortString",
+    "AltairDeprecationWarning",
     "Angle",
     "AngleDatum",
     "AngleValue",

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -38,13 +38,6 @@ class RendererRegistry(PluginRegistry[RendererType]):
             for more information.
             """
         ),
-        "altair_viewer": textwrap.dedent(
-            """
-            To use the 'altair_viewer' renderer, you must install the altair_viewer
-            package; see http://github.com/altair-viz/altair_viewer/
-            for more information.
-            """
-        ),
     }
 
     def set_embed_options(

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -1,10 +1,8 @@
 from typing import Literal, Optional, Union, cast, Tuple
 
-from .deprecation import AltairDeprecationWarning
 from .html import spec_to_html
 from ._importers import import_vl_convert, vl_version_for_vl_convert
 import struct
-import warnings
 
 
 def spec_to_mimebundle(

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -15,7 +15,7 @@ def spec_to_mimebundle(
     vegaembed_version: Optional[str] = None,
     vegalite_version: Optional[str] = None,
     embed_options: Optional[dict] = None,
-    engine: Optional[Literal["vl-convert", "altair_saver"]] = None,
+    engine: Optional[Literal["vl-convert"]] = None,
     **kwargs,
 ) -> Union[dict, Tuple[dict, dict]]:
     """Convert a vega-lite specification to a mimebundle
@@ -41,7 +41,7 @@ def spec_to_mimebundle(
         The vegaEmbed options dictionary. Defaults to the embed options set with
         alt.renderers.set_embed_options().
         (See https://github.com/vega/vega-embed for details)
-    engine: string {'vl-convert', 'altair_saver'}
+    engine: string {'vl-convert'}
         the conversion engine to use for 'png', 'svg', 'pdf', and 'vega' formats
     **kwargs :
         Additional arguments will be passed to the generating function
@@ -53,7 +53,7 @@ def spec_to_mimebundle(
 
     Note
     ----
-    The png, svg, pdf, and vega outputs require the altair_saver package
+    The png, svg, pdf, and vega outputs require the vl-convert package
     """
     # Local import to avoid circular ImportError
     from altair.utils.display import (
@@ -130,7 +130,7 @@ def _spec_to_mimebundle_with_engine(
         the format of the mimebundle to be returned
     mode : string {'vega-lite', 'vega'}
         The rendering mode.
-    engine: string {'vl-convert', 'altair_saver'}
+    engine: string {'vl-convert'}
         the conversion engine to use
     format_locale : str or dict
         d3-format locale name or dictionary. Defaults to "en-US" for United States English.
@@ -221,16 +221,6 @@ def _spec_to_mimebundle_with_engine(
             # This should be validated above
             # but raise exception for the sake of future development
             raise ValueError("Unexpected format {fmt!r}".format(fmt=format))
-    elif normalized_engine == "altairsaver":
-        warnings.warn(
-            "The altair_saver export engine is deprecated and will be removed in a future version.\n"
-            "Please migrate to the vl-convert engine",
-            AltairDeprecationWarning,
-            stacklevel=1,
-        )
-        import altair_saver
-
-        return altair_saver.render(spec, format, mode=mode, **kwargs)
     else:
         # This should be validated above
         # but raise exception for the sake of future development
@@ -240,12 +230,12 @@ def _spec_to_mimebundle_with_engine(
 
 
 def _validate_normalize_engine(
-    engine: Optional[Literal["vl-convert", "altair_saver"]],
+    engine: Optional[Literal["vl-convert"]],
     format: Literal["png", "svg", "pdf", "vega"],
 ) -> str:
     """Helper to validate and normalize the user-provided engine
 
-    engine : {None, 'vl-convert', 'altair_saver'}
+    engine : {None, 'vl-convert'}
         the user-provided engine string
     format : string {'png', 'svg', 'pdf', 'vega'}
         the format of the mimebundle to be returned
@@ -255,12 +245,6 @@ def _validate_normalize_engine(
         vlc = import_vl_convert()
     except ImportError:
         vlc = None
-
-    # Try to import altair_saver
-    try:
-        import altair_saver
-    except ImportError:
-        altair_saver = None
 
     # Normalize engine string by lower casing and removing underscores and hyphens
     normalized_engine = (
@@ -273,25 +257,20 @@ def _validate_normalize_engine(
             raise ValueError(
                 "The 'vl-convert' conversion engine requires the vl-convert-python package"
             )
-    elif normalized_engine == "altairsaver":
-        if altair_saver is None:
-            raise ValueError(
-                "The 'altair_saver' conversion engine requires the altair_saver package"
-            )
     elif normalized_engine is None:
         if vlc is not None:
             normalized_engine = "vlconvert"
-        elif altair_saver is not None:
-            normalized_engine = "altairsaver"
         else:
             raise ValueError(
-                "Saving charts in {fmt!r} format requires the vl-convert-python or altair_saver package: "
-                "see http://github.com/altair-viz/altair_saver/".format(fmt=format)
+                "Saving charts in {fmt!r} format requires the vl-convert-python package: "
+                "see https://altair-viz.github.io/user_guide/saving_charts.html#png-svg-and-pdf-format".format(
+                    fmt=format
+                )
             )
     else:
         raise ValueError(
-            "Invalid conversion engine {engine!r}. Expected one of {valid!r}".format(
-                engine=engine, valid=("vl-convert", "altair_saver")
+            "Invalid conversion engine {engine!r}. Expected vl-convert".format(
+                engine=engine
             )
         )
     return normalized_engine

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -6,6 +6,7 @@ from typing import IO, Union, Optional, Literal
 from .mimebundle import spec_to_mimebundle
 from ..vegalite.v5.data import data_transformers
 from altair.utils._vegafusion_data import using_vegafusion
+from altair.utils.deprecation import AltairDeprecationWarning
 
 
 def write_file_or_filename(
@@ -114,7 +115,7 @@ def save(
         Additional keyword arguments are passed to the output method
         associated with the specified format.
     webdriver : string {'chrome' | 'firefox'} (optional)
-        Webdriver to use for png, svg, or pdf output when using altair_saver engine
+        This argument is deprecated as it's not relevant for the new vl-convert engine.
     scale_factor : float (optional)
         scale_factor to use to change size/resolution of png or svg output
     engine: string {'vl-convert'}
@@ -128,6 +129,15 @@ def save(
     **kwargs :
         additional kwargs passed to spec_to_mimebundle.
     """
+    if webdriver is not None:
+        warnings.warn(
+            "The webdriver argument is deprecated as it's not relevant for"
+            + " the new vl-convert engine which replaced altair_saver."
+            + " The argument will be removed in a future release.",
+            AltairDeprecationWarning,
+            stacklevel=1,
+        )
+
     if json_kwds is None:
         json_kwds = {}
 
@@ -174,7 +184,6 @@ def save(
                 vegalite_version=vegalite_version,
                 vegaembed_version=vegaembed_version,
                 embed_options=embed_options,
-                webdriver=webdriver,
                 scale_factor=scale_factor,
                 engine=engine,
                 **kwargs,

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -80,7 +80,7 @@ def save(
     json_kwds: Optional[dict] = None,
     webdriver: Optional[Literal["chrome", "firefox"]] = None,
     scale_factor: float = 1,
-    engine: Optional[Literal["vl-convert", "altair_saver"]] = None,
+    engine: Optional[Literal["vl-convert"]] = None,
     inline: bool = False,
     **kwargs,
 ) -> None:
@@ -117,7 +117,7 @@ def save(
         Webdriver to use for png, svg, or pdf output when using altair_saver engine
     scale_factor : float (optional)
         scale_factor to use to change size/resolution of png or svg output
-    engine: string {'vl-convert', 'altair_saver'}
+    engine: string {'vl-convert'}
         the conversion engine to use for 'png', 'svg', and 'pdf' formats
     inline: bool (optional)
         If False (default), the required JavaScript libraries are loaded

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1155,7 +1155,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         """Save a chart to file in a variety of formats
 
         Supported formats are json, html, png, svg, pdf; the last three require
-        the altair_saver package to be installed.
+        the vl-convert-python package to be installed.
 
         Parameters
         ----------

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -28,6 +28,7 @@ from ...utils._vegafusion_data import (
 )
 from ...utils.core import DataFrameLike
 from ...utils.data import DataType
+from ...utils.deprecation import AltairDeprecationWarning
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -231,9 +232,9 @@ class Parameter(_expr_core.OperatorMixin):
             return {"expr": self.name}
         elif self.param_type == "selection":
             return {
-                "param": self.name.to_dict()
-                if hasattr(self.name, "to_dict")
-                else self.name
+                "param": (
+                    self.name.to_dict() if hasattr(self.name, "to_dict") else self.name
+                )
             }
         else:
             raise ValueError(f"Unrecognized parameter type: {self.param_type}")
@@ -1187,7 +1188,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             Additional keyword arguments are passed to the output method
             associated with the specified format.
         webdriver : string {'chrome' | 'firefox'} (optional)
-            Webdriver to use for png, svg, or pdf output when using altair_saver engine
+            This argument is deprecated as it's not relevant for the new vl-convert engine.
         engine: string {'vl-convert', 'altair_saver'}
             the conversion engine to use for 'png', 'svg', and 'pdf' formats
         inline: bool (optional)
@@ -1199,6 +1200,15 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         **kwargs :
             additional kwargs passed to spec_to_mimebundle.
         """
+        if webdriver is not None:
+            warnings.warn(
+                "The webdriver argument is deprecated as it's not relevant for"
+                + " the new vl-convert engine which replaced altair_saver."
+                + " The argument will be removed in a future release.",
+                AltairDeprecationWarning,
+                stacklevel=1,
+            )
+
         from ...utils.save import save
 
         kwds = dict(
@@ -1212,7 +1222,6 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             vegaembed_version=vegaembed_version,
             embed_options=embed_options,
             json_kwds=json_kwds,
-            webdriver=webdriver,
             engine=engine,
             inline=inline,
             **kwargs,

--- a/doc/getting_started/resources.rst
+++ b/doc/getting_started/resources.rst
@@ -88,14 +88,6 @@ VegaFusion provides server-side scaling for Altair charts, which can accelerate 
 .. List of links.
 .. _VegaFusion: https://vegafusion.io/
 
-altair_saver_
-~~~~~~~~~~~~~
-
-Enables saving charts to a variety of output types.
-
-.. List of links.
-.. _altair_saver: https://github.com/altair-viz/altair_saver
-
 altair_data_server_
 ~~~~~~~~~~~~~~~~~~~
 

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -701,7 +701,6 @@ see :ref:`display-general`.
 .. _nteract: https://nteract.io
 .. _nbconvert: https://nbconvert.readthedocs.io/
 .. _nbviewer: https://nbviewer.jupyter.org/
-.. _Altair Viewer: https://github.com/altair-viz/altair_viewer/
 .. _Colab: https://colab.research.google.com
 .. _Hydrogen: https://github.com/nteract/hydrogen
 .. _Jupyter Notebook: https://jupyter-notebook.readthedocs.io/en/stable/

--- a/doc/user_guide/large_datasets.rst
+++ b/doc/user_guide/large_datasets.rst
@@ -296,8 +296,7 @@ prerender the visualization and send only a static image to your notebook. This 
 greatly reduce the amount of data that is being transmitted. The downside with this approach is,
 that you loose all interactivity features of Altair.
 
-Both renderers require you to install either the `vl-convert`_ or the `altair_saver`_ package, see :ref:`saving-png`,
-whereas `vl-convert`_ is expected to provide the better performance.
+Both renderers require you to install the `vl-convert`_ package, see :ref:`saving-png`.
 
 .. _preaggregate-and-filter:
 
@@ -469,4 +468,3 @@ summary statistics to Altair instead of the full dataset.
 .. _DuckDB: https://duckdb.org/
 .. _VegaFusion DuckDB: https://vegafusion.io/duckdb.html
 .. _vl-convert: https://github.com/vega/vl-convert
-.. _altair_saver: https://github.com/altair-viz/altair_saver/

--- a/doc/user_guide/saving_charts.rst
+++ b/doc/user_guide/saving_charts.rst
@@ -172,10 +172,9 @@ To save an Altair chart object as a PNG, SVG, or PDF image, you can use
     chart.save('chart.svg')
     chart.save('chart.pdf')
 
-Saving these images requires an additional extension to run the
+Saving these images requires an additional extension vl-convert_ to run the
 javascript code necessary to interpret the Vega-Lite specification and output
-it in the form of an image. There are two packages that can be used to enable
-image export: vl-convert_ or altair_saver_.
+it in the form of an image.
 
 .. _install-vl-convert:
 
@@ -189,7 +188,7 @@ or::
 
     pip install vl-convert-python
 
-Unlike altair_saver_, vl-convert_ does not require any external dependencies.
+vl-convert_ does not require any external dependencies.
 See the vl-convert documentation for information and for known
 `limitations <https://github.com/vega/vl-convert#limitations>`_.
 
@@ -198,28 +197,7 @@ altair_saver
 
 .. note::
    
-   altair_saver does not yet support Altair 5.
-
-
-The altair_saver_ package can be installed with::
-
-    conda install -c conda-forge altair_saver
-
-or::
-
-    pip install altair_saver
-
-See the altair_saver_ documentation for information about additional installation
-requirements.
-
-Engine Argument
-^^^^^^^^^^^^^^^
-If both vl-convert and altair_saver are installed, vl-convert will take precedence.
-The engine argument to :meth:`Chart.save` can be used to override this default
-behavior. For example, to use altair_saver for PNG export when vl-convert is also
-installed you can use::
-
-    chart.save('chart.png', engine="altair_saver")
+   altair_saver was used in Altair 4 and earlier versions. It is no longer maintained and got superseded by vl-convert_ which provides a superior user experience and performance.
 
 
 PNG Figure Size/Resolution
@@ -231,10 +209,6 @@ to save the image with a resolution of 200 pixels-per-inch::
 
     chart.save('chart.png', ppi=200)
 
-.. note::
-
-    The ``ppi`` argument is only supported by the ``vl-convert`` engine. It will be ignored if
-    the ``altair_saver`` engine is enabled.
 
 To change the physical size of the resulting image while preserving the resolution, the
 ``scale_factor`` argument may be used. For example, to save the image at double the default
@@ -262,6 +236,5 @@ specification in the online Vega editor_.
     chart.to_url()
 
 .. _vl-convert: https://github.com/vega/vl-convert
-.. _altair_saver: http://github.com/altair-viz/altair_saver/
 .. _vegaEmbed: https://github.com/vega/vega-embed
 .. _editor: https://vega.github.io/editor/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,11 +201,6 @@ line-ending = "lf"
 [tool.ruff.lint.mccabe]
 max-complexity = 18
 
-[tool.pytest.ini_options]
-markers = [
-    "save_engine: marks some of the tests which are using an external package to save a chart to e.g. a png file. This mark is used to run those tests selectively in the build GitHub Action.",
-]
-
 [tool.mypy]
 warn_unused_ignores = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,8 +213,6 @@ warn_unused_ignores = true
 module = [
     "vega_datasets.*",
     "toolz.*",
-    "altair_viewer.*",
-    "altair_saver.*",
     "pyarrow.*",
     "yaml.*",
     "vl_convert.*",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -78,11 +78,6 @@ def test_from_and_to_json_roundtrip(syntax_module):
             ) from err
 
 
-# We do not apply the save_engine mark to this test. This mark is used in
-# the build GitHub Action workflow to select the tests which should be rerun
-# with some of the saving engines uninstalled. This would not make sense for this test
-# as here it is only interesting to run it with all saving engines installed.
-# Furthermore, the runtime of this test is rather long.
 @pytest.mark.parametrize("engine", ["vl-convert"])
 @pytest.mark.parametrize(
     "syntax_module", [examples_arguments_syntax, examples_methods_syntax]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,10 +8,6 @@ from altair.utils.execeval import eval_block
 from tests import examples_arguments_syntax
 from tests import examples_methods_syntax
 
-try:
-    import altair_saver  # noqa: F401
-except ImportError:
-    altair_saver = None
 
 try:
     import vl_convert as vlc  # noqa: F401
@@ -87,7 +83,7 @@ def test_from_and_to_json_roundtrip(syntax_module):
 # with some of the saving engines uninstalled. This would not make sense for this test
 # as here it is only interesting to run it with all saving engines installed.
 # Furthermore, the runtime of this test is rather long.
-@pytest.mark.parametrize("engine", ["vl-convert", "altair_saver"])
+@pytest.mark.parametrize("engine", ["vl-convert"])
 @pytest.mark.parametrize(
     "syntax_module", [examples_arguments_syntax, examples_methods_syntax]
 )
@@ -95,11 +91,6 @@ def test_render_examples_to_png(engine, syntax_module):
     for filename in iter_examples_filenames(syntax_module):
         if engine == "vl-convert" and vlc is None:
             pytest.skip("vl_convert not importable; cannot run mimebundle tests")
-        elif engine == "altair_saver":
-            if altair_saver is None:
-                pytest.skip("altair_saver not importable; cannot run png tests")
-            if "png" not in altair_saver.available_formats("vega-lite"):
-                pytest.skip("altair_saver not configured to save to png")
 
         source = pkgutil.get_data(syntax_module.__name__, filename)
         chart = eval_block(source)

--- a/tests/test_jupyter_chart.py
+++ b/tests/test_jupyter_chart.py
@@ -14,7 +14,7 @@ except ImportError:
 if has_anywidget:
     from altair.jupyter import jupyter_chart
 else:
-    jupyter_chart = None
+    jupyter_chart = None  # type: ignore
 
 
 try:

--- a/tests/test_jupyter_chart.py
+++ b/tests/test_jupyter_chart.py
@@ -1,12 +1,21 @@
 import altair as alt
-from altair.jupyter.jupyter_chart import (
-    IntervalSelection,
-    IndexSelection,
-    PointSelection,
-)
 from vega_datasets import data
 import pandas as pd
 import pytest
+
+# If anywidget is not installed, we will skip the tests in this file.
+try:
+    import anywidget  # noqa: F401
+
+    has_anywidget = True
+except ImportError:
+    has_anywidget = False
+
+if has_anywidget:
+    from altair.jupyter import jupyter_chart
+else:
+    jupyter_chart = None
+
 
 try:
     import vegafusion  # type: ignore # noqa: F401
@@ -18,6 +27,9 @@ except ImportError:
 
 @pytest.mark.parametrize("transformer", transformers)
 def test_chart_with_no_interactivity(transformer):
+    if not has_anywidget:
+        pytest.skip("anywidget not importable; skipping test")
+
     with alt.data_transformers.enable(transformer):
         source = pd.DataFrame(
             {
@@ -44,6 +56,9 @@ def test_chart_with_no_interactivity(transformer):
 
 @pytest.mark.parametrize("transformer", transformers)
 def test_interval_selection_example(transformer):
+    if not has_anywidget:
+        pytest.skip("anywidget not importable; skipping test")
+
     with alt.data_transformers.enable(transformer):
         source = data.cars()
         brush = alt.selection_interval(name="interval")
@@ -73,7 +88,7 @@ def test_interval_selection_example(transformer):
 
         # Check initial interval selection
         selection = widget.selections.interval
-        assert isinstance(selection, IntervalSelection)
+        assert isinstance(selection, jupyter_chart.IntervalSelection)
         assert selection.value == {}
         assert selection.store == []
 
@@ -102,7 +117,7 @@ def test_interval_selection_example(transformer):
         }
 
         selection = widget.selections.interval
-        assert isinstance(selection, IntervalSelection)
+        assert isinstance(selection, jupyter_chart.IntervalSelection)
         assert selection.value == {
             "Horsepower": [40.0, 100],
             "Miles_per_Gallon": [25, 30],
@@ -112,6 +127,9 @@ def test_interval_selection_example(transformer):
 
 @pytest.mark.parametrize("transformer", transformers)
 def test_index_selection_example(transformer):
+    if not has_anywidget:
+        pytest.skip("anywidget not importable; skipping test")
+
     with alt.data_transformers.enable(transformer):
         source = data.cars()
         brush = alt.selection_point(name="index")
@@ -141,7 +159,7 @@ def test_index_selection_example(transformer):
 
         # Check initial interval selection
         selection = widget.selections.index
-        assert isinstance(selection, IndexSelection)
+        assert isinstance(selection, jupyter_chart.IndexSelection)
         assert selection.value == []
         assert selection.store == []
 
@@ -165,13 +183,16 @@ def test_index_selection_example(transformer):
         }
 
         selection = widget.selections.index
-        assert isinstance(selection, IndexSelection)
+        assert isinstance(selection, jupyter_chart.IndexSelection)
         assert selection.value == [219, 329, 340]
         assert selection.store == store
 
 
 @pytest.mark.parametrize("transformer", transformers)
 def test_point_selection(transformer):
+    if not has_anywidget:
+        pytest.skip("anywidget not importable; skipping test")
+
     with alt.data_transformers.enable(transformer):
         source = data.cars()
         brush = alt.selection_point(name="point", encodings=["color"], bind="legend")
@@ -201,7 +222,7 @@ def test_point_selection(transformer):
 
         # Check initial interval selection
         selection = widget.selections.point
-        assert isinstance(selection, PointSelection)
+        assert isinstance(selection, jupyter_chart.PointSelection)
         assert selection.value == []
         assert selection.store == []
 
@@ -228,13 +249,16 @@ def test_point_selection(transformer):
         }
 
         selection = widget.selections.point
-        assert isinstance(selection, PointSelection)
+        assert isinstance(selection, jupyter_chart.PointSelection)
         assert selection.value == [{"Cylinders": 4}, {"Cylinders": 5}]
         assert selection.store == store
 
 
 @pytest.mark.parametrize("transformer", transformers)
 def test_param_updates(transformer):
+    if not has_anywidget:
+        pytest.skip("anywidget not importable; skipping test")
+
     with alt.data_transformers.enable(transformer):
         source = data.cars()
         size_param = alt.param(

--- a/tests/utils/test_compiler.py
+++ b/tests/utils/test_compiler.py
@@ -2,6 +2,11 @@ import json
 import pytest
 from altair import vegalite_compilers, Chart
 
+try:
+    import vl_convert as vlc  # noqa: F401
+except ImportError:
+    vlc = None
+
 
 @pytest.fixture
 def chart():
@@ -24,17 +29,26 @@ def assert_is_vega_spec(vega_spec):
 
 
 def test_vegalite_compiler(chart):
+    if vlc is None:
+        pytest.skip("vl_convert is not installed")
+
     vegalite_spec = chart.to_dict()
     vega_spec = vegalite_compilers.get()(vegalite_spec)
     assert_is_vega_spec(vega_spec)
 
 
 def test_to_dict_with_format_vega(chart):
+    if vlc is None:
+        pytest.skip("vl_convert is not installed")
+
     vega_spec = chart.to_dict(format="vega")
     assert_is_vega_spec(vega_spec)
 
 
 def test_to_json_with_format_vega(chart):
+    if vlc is None:
+        pytest.skip("vl_convert is not installed")
+
     json_spec = chart.to_json(format="vega")
     assert isinstance(json_spec, str)
     spec = json.loads(json_spec)

--- a/tests/utils/test_mimebundle.py
+++ b/tests/utils/test_mimebundle.py
@@ -168,9 +168,8 @@ def vega_spec():
     }
 
 
-@pytest.mark.parametrize("engine", ["vl-convert", None])
-def test_vegalite_to_vega_mimebundle(engine, vegalite_spec, vega_spec):
-    if engine == "vl-convert" and vlc is None:
+def test_vegalite_to_vega_mimebundle(vegalite_spec, vega_spec):
+    if vlc is None:
         pytest.skip("vl_convert not importable; cannot run mimebundle tests")
 
     bundle = spec_to_mimebundle(
@@ -180,7 +179,7 @@ def test_vegalite_to_vega_mimebundle(engine, vegalite_spec, vega_spec):
         vega_version=alt.VEGA_VERSION,
         vegalite_version=alt.VEGALITE_VERSION,
         vegaembed_version=alt.VEGAEMBED_VERSION,
-        engine=engine,
+        engine="vl-convert",
     )
 
     assert bundle == {"application/vnd.vega.v5+json": vega_spec}

--- a/tests/utils/test_mimebundle.py
+++ b/tests/utils/test_mimebundle.py
@@ -5,11 +5,6 @@ from altair import VEGA_VERSION
 from altair.utils.mimebundle import spec_to_mimebundle
 
 try:
-    import altair_saver  # noqa: F401
-except ImportError:
-    altair_saver = None
-
-try:
     import vl_convert as vlc  # noqa: F401
 except ImportError:
     vlc = None
@@ -174,17 +169,10 @@ def vega_spec():
 
 
 @pytest.mark.save_engine
-@pytest.mark.parametrize("engine", ["vl-convert", "altair_saver", None])
+@pytest.mark.parametrize("engine", ["vl-convert", None])
 def test_vegalite_to_vega_mimebundle(engine, vegalite_spec, vega_spec):
     if engine == "vl-convert" and vlc is None:
         pytest.skip("vl_convert not importable; cannot run mimebundle tests")
-    elif engine == "altair_saver" and altair_saver is None:
-        pytest.skip("altair_saver not importable; cannot run mimebundle tests")
-    elif vlc is None and altair_saver is None:
-        pytest.skip(
-            "Neither altair_saver nor vl_convert are importable;"
-            + " cannot run mimebundle tests"
-        )
 
     bundle = spec_to_mimebundle(
         spec=vegalite_spec,

--- a/tests/utils/test_mimebundle.py
+++ b/tests/utils/test_mimebundle.py
@@ -168,7 +168,6 @@ def vega_spec():
     }
 
 
-@pytest.mark.save_engine
 @pytest.mark.parametrize("engine", ["vl-convert", None])
 def test_vegalite_to_vega_mimebundle(engine, vegalite_spec, vega_spec):
     if engine == "vl-convert" and vlc is None:

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -285,7 +285,6 @@ def test_selection_expression():
         getattr(selection, magic_attr)
 
 
-@pytest.mark.save_engine
 @pytest.mark.parametrize("format", ["html", "json", "png", "svg", "pdf", "bogus"])
 @pytest.mark.parametrize("engine", ["vl-convert"])
 def test_save(format, engine, basic_chart):

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -357,6 +357,9 @@ def test_save_html(basic_chart, inline):
 
 
 def test_to_url(basic_chart):
+    if vlc is None:
+        pytest.skip("vl_convert is not installed")
+
     share_url = basic_chart.to_url()
     expected_vegalite_encoding = "N4Igxg9gdgZglgcxALlANzgUwO4tJKAFzigFcJSBnAdTgBNCALFAZgAY2AacaYsiygAlMiRoVYcAvpO50AhoTl4QUOQFtMKEPMUBaAOwA2ABwAWFi1NyTcgEb7TtuabAswc-XTZhMczLdNDAEYQGRA1OQAnAGtlQgBPAAdNZBAnSNDuTChIOhIkVBAAD2V4TAAbOi0lbgTkrSgINRI5csyQeNKsSq1bEFqklJAAR1I5IjhFYjRNaW4AEkowRkwIrTFCRMpkAHodmYQ5ADoEScZSWyO4CB2llYj9zEPdcsnMfYBWI6D9I7YjgBWlGg-W0CjklEwhEoyh0cgMJnMlmsxjsDicLjcHi8Pj8AWCKAA2qAlKkAIKgvrIABMxhkJK0ACFKSgPh96SBSSAAMIs5DmDlcgAifIAnEFBVoAKJ84wSzgM1IAMT5HxYktSAHE+UFRRqQIJZfp9QBJVXUyQAXWkQA"
 

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -14,11 +14,6 @@ import pandas as pd
 import altair.vegalite.v5 as alt
 
 try:
-    import altair_saver  # noqa: F401
-except ImportError:
-    altair_saver = None
-
-try:
     import vl_convert as vlc  # noqa: F401
 except ImportError:
     vlc = None
@@ -292,7 +287,7 @@ def test_selection_expression():
 
 @pytest.mark.save_engine
 @pytest.mark.parametrize("format", ["html", "json", "png", "svg", "pdf", "bogus"])
-@pytest.mark.parametrize("engine", ["altair_saver", "vl-convert"])
+@pytest.mark.parametrize("engine", ["vl-convert"])
 def test_save(format, engine, basic_chart):
     if format in ["pdf", "png"]:
         out = io.BytesIO()
@@ -302,26 +297,7 @@ def test_save(format, engine, basic_chart):
         mode = "r"
 
     if format in ["svg", "png", "pdf", "bogus"]:
-        if engine == "altair_saver":
-            if format == "bogus":
-                with pytest.raises(ValueError) as err:
-                    basic_chart.save(out, format=format, engine=engine)
-                assert f"Unsupported format: '{format}'" in str(err.value)
-                return
-            elif altair_saver is None:
-                with pytest.raises(ValueError) as err:
-                    basic_chart.save(out, format=format, engine=engine)
-                assert "altair_saver" in str(err.value)
-                return
-            elif format not in altair_saver.available_formats():
-                with pytest.raises(ValueError) as err:
-                    basic_chart.save(out, format=format, engine=engine)
-                assert f"No enabled saver found that supports format='{format}'" in str(
-                    err.value
-                )
-                return
-
-        elif engine == "vl-convert":
+        if engine == "vl-convert":
             if format == "bogus":
                 with pytest.raises(ValueError) as err:
                     basic_chart.save(out, format=format, engine=engine)

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -336,10 +336,11 @@ def test_save(format, engine, basic_chart):
             os.remove(fp)
 
 
-# Only test inline=False as altair_viewer is required for inline=True
-# but that package has not yet been released with support for Altair 5
-@pytest.mark.parametrize("inline", [False])
+@pytest.mark.parametrize("inline", [False, True])
 def test_save_html(basic_chart, inline):
+    if vlc is None:
+        pytest.skip("vl_convert not importable; cannot run this test")
+
     out = io.StringIO()
     basic_chart.save(out, format="html", inline=inline)
     out.seek(0)

--- a/tests/vegalite/v5/test_renderers.py
+++ b/tests/vegalite/v5/test_renderers.py
@@ -16,7 +16,7 @@ try:
     import anywidget  # noqa: F401
 
 except ImportError:
-    anywidget = None
+    anywidget = None  # type: ignore
 
 
 @pytest.fixture

--- a/tests/vegalite/v5/test_renderers.py
+++ b/tests/vegalite/v5/test_renderers.py
@@ -7,6 +7,18 @@ import pytest
 import altair.vegalite.v5 as alt
 
 
+try:
+    import vl_convert as vlc  # noqa: F401
+except ImportError:
+    vlc = None
+
+try:
+    import anywidget  # noqa: F401
+
+except ImportError:
+    anywidget = None
+
+
 @pytest.fixture
 def chart():
     return alt.Chart("data.csv").mark_point()
@@ -66,6 +78,9 @@ def test_json_renderer_embed_options(chart, renderer="json"):
 
 
 def test_renderer_with_none_embed_options(chart, renderer="mimetype"):
+    if vlc is None:
+        pytest.skip("vl_convert not importable; cannot run this test")
+
     # Check that setting embed_options to None doesn't crash
     from altair.utils.mimebundle import spec_to_mimebundle
 
@@ -82,6 +97,9 @@ def test_renderer_with_none_embed_options(chart, renderer="mimetype"):
 
 def test_jupyter_renderer_mimetype(chart, renderer="jupyter"):
     """Test that we get the expected widget mimetype when the jupyter renderer is enabled"""
+    if not anywidget:
+        pytest.skip("anywidget not importable; skipping test")
+
     with alt.renderers.enable(renderer):
         assert (
             "application/vnd.jupyter.widget-view+json"


### PR DESCRIPTION
Now that both altair_viewer and altair_saver are archived and not compatible with Altair anyway, I'd suggest to remove all references to them to clean up the code base a bit. In this PR, I:

* removed all references to altair_viewer
* removed all references to altair_saver except for 1 mention in the docs
* uninstall anywidget and vl-convert-python as well in the build workflow to make sure we don't introduce hard dependencies. This is not directly related to the rest of the PR but hope it's ok for efficiency reasons. Else, happy to take it out!
* added a deprecation warning if someone uses the `webdriver` argument to the `.save` method as it's not relevant for `vl-convert`. I didn't want to remove it just now as users might still have it set although they have switched to `vl-convert` in which case it has just been ignored so far
* run test_save_html again with inline=True as vl-convert supports it