### PR TITLE
build: pin upperlimit geopandas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dev = [
     "pandas-stubs",
     "types-jsonschema",
     "types-setuptools",
-    "geopandas",
+    "geopandas<=0.14.3",
 ]
 doc = [
     "sphinx",


### PR DESCRIPTION
Pinning geopandas to `"geopandas<=0.14.3"` within `pyproject.toml` as an temporarily attempt of fixing https://github.com/vega/altair/issues/3418