### PR TITLE
ci: remove again geopandas pin and disable flaky test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dev = [
     "pandas-stubs",
     "types-jsonschema",
     "types-setuptools",
-    "geopandas<=0.14.3",
+    "geopandas",
 ]
 doc = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,10 @@ max-complexity = 18
 markers = [
     "save_engine: marks some of the tests which are using an external package to save a chart to e.g. a png file. This mark is used to run those tests selectively in the build GitHub Action.",
 ]
+# Pytest does not need to search these folders for test functions.
+# They contain examples which are being executed by the
+# test_examples tests.
+norecursedirs = ["tests/examples_arguments_syntax", "tests/examples_methods_syntax"]
 
 [tool.mypy]
 warn_unused_ignores = true

--- a/tests/examples_arguments_syntax/__init__.py
+++ b/tests/examples_arguments_syntax/__init__.py
@@ -18,13 +18,7 @@ def iter_examples_arguments_syntax():
     examples_arguments_syntax_dir = os.path.abspath(os.path.dirname(__file__))
     for filename in os.listdir(examples_arguments_syntax_dir):
         name, ext = os.path.splitext(filename)
-        if (
-            name.startswith("_")
-            or ext != ".py"
-            # Temporarily skip this test until https://github.com/vega/altair/issues/3418
-            # is fixed
-            or name == "interval_selection_map_quakes"
-        ):
+        if name.startswith("_") or ext != ".py":
             continue
         yield {
             "name": name,

--- a/tests/examples_arguments_syntax/__init__.py
+++ b/tests/examples_arguments_syntax/__init__.py
@@ -18,10 +18,16 @@ def iter_examples_arguments_syntax():
     examples_arguments_syntax_dir = os.path.abspath(os.path.dirname(__file__))
     for filename in os.listdir(examples_arguments_syntax_dir):
         name, ext = os.path.splitext(filename)
-        if name.startswith("_") or ext != ".py":
+        if (
+            name.startswith("_")
+            or ext != ".py"
+            # Temporarily skip this test until https://github.com/vega/altair/issues/3418
+            # is fixed
+            or name == "interval_selection_map_quakes"
+        ):
             continue
         yield {
             "name": name,
             "filename": os.path.join(examples_arguments_syntax_dir, filename),
-            "use_svg": name in SVG_EXAMPLES
+            "use_svg": name in SVG_EXAMPLES,
         }

--- a/tests/examples_methods_syntax/__init__.py
+++ b/tests/examples_methods_syntax/__init__.py
@@ -16,10 +16,16 @@ def iter_examples_methods_syntax():
     examples_methods_syntax_dir = os.path.abspath(os.path.dirname(__file__))
     for filename in os.listdir(examples_methods_syntax_dir):
         name, ext = os.path.splitext(filename)
-        if name.startswith("_") or ext != ".py":
+        if (
+            name.startswith("_")
+            or ext != ".py"
+            # Temporarily skip this test until https://github.com/vega/altair/issues/3418
+            # is fixed
+            or name == "interval_selection_map_quakes"
+        ):
             continue
         yield {
             "name": name,
             "filename": os.path.join(examples_methods_syntax_dir, filename),
-            "use_svg": name in SVG_EXAMPLES
+            "use_svg": name in SVG_EXAMPLES,
         }

--- a/tests/examples_methods_syntax/__init__.py
+++ b/tests/examples_methods_syntax/__init__.py
@@ -16,13 +16,7 @@ def iter_examples_methods_syntax():
     examples_methods_syntax_dir = os.path.abspath(os.path.dirname(__file__))
     for filename in os.listdir(examples_methods_syntax_dir):
         name, ext = os.path.splitext(filename)
-        if (
-            name.startswith("_")
-            or ext != ".py"
-            # Temporarily skip this test until https://github.com/vega/altair/issues/3418
-            # is fixed
-            or name == "interval_selection_map_quakes"
-        ):
+        if name.startswith("_") or ext != ".py":
             continue
         yield {
             "name": name,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -21,7 +21,13 @@ except ImportError:
 
 def iter_examples_filenames(syntax_module):
     for _importer, modname, ispkg in pkgutil.iter_modules(syntax_module.__path__):
-        if ispkg or modname.startswith("_"):
+        if (
+            ispkg
+            or modname.startswith("_")
+            # Temporarily skip this test until https://github.com/vega/altair/issues/3418
+            # is fixed
+            or modname == "interval_selection_map_quakes"
+        ):
             continue
         yield modname + ".py"
 


### PR DESCRIPTION
Temporary fix for #3418. Seems like the failing test is flaky and the geopandas pin introduced in #3421 did not solve it as it happened again in https://github.com/vega/altair/actions/runs/9138091817/job/25128832186?pr=3419.

This PR disables the test for now and removes again the pin.