### PR TITLE
refactor(DRAFT): Remove `toolz` dependency

### DIFF
--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -10,7 +10,6 @@ import warnings
 import IPython
 from IPython.core import magic_arguments
 import pandas as pd
-from toolz import curried
 
 from altair.vegalite import v5 as vegalite_v5
 
@@ -41,7 +40,9 @@ def _prepare_data(data, data_transformers):
     if data is None or isinstance(data, dict):
         return data
     elif isinstance(data, pd.DataFrame):
-        return curried.pipe(data, data_transformers.get())
+        if func := data_transformers.get():
+            data = func(data)
+        return data
     elif isinstance(data, str):
         return {"url": data}
     else:

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -1,8 +1,10 @@
-from toolz import curried
 import uuid
 from weakref import WeakValueDictionary
 
 from typing import (
+    Any,
+    Literal,
+    Optional,
     Union,
     Dict,
     Set,
@@ -10,11 +12,18 @@ from typing import (
     TypedDict,
     Final,
     TYPE_CHECKING,
+    overload,
 )
+from collections.abc import Callable
 
 from altair.utils._importers import import_vegafusion
 from altair.utils.core import DataFrameLike
-from altair.utils.data import DataType, ToValuesReturnType, MaxRowsError
+from altair.utils.data import (
+    DataType,
+    ToValuesReturnType,
+    MaxRowsError,
+    NonLikeDataType,
+)
 from altair.vegalite.data import default_data_transformer
 
 if TYPE_CHECKING:
@@ -36,21 +45,41 @@ class _ToVegaFusionReturnUrlDict(TypedDict):
     url: str
 
 
-@curried.curry
+_VegaFusionReturnType = Union[_ToVegaFusionReturnUrlDict, ToValuesReturnType]
+
+
+@overload
 def vegafusion_data_transformer(
-    data: DataType, max_rows: int = 100000
-) -> Union[_ToVegaFusionReturnUrlDict, ToValuesReturnType]:
+    data: Literal[None] = ..., max_rows: int = ...
+) -> Callable[..., Any]: ...
+
+
+@overload
+def vegafusion_data_transformer(
+    data: DataFrameLike, max_rows: int
+) -> ToValuesReturnType: ...
+
+
+@overload
+def vegafusion_data_transformer(
+    data: NonLikeDataType, max_rows: int
+) -> _VegaFusionReturnType: ...
+
+
+def vegafusion_data_transformer(
+    data: Optional[DataType] = None, max_rows: int = 100000
+) -> Union[Callable[..., Any], _VegaFusionReturnType]:
     """VegaFusion Data Transformer"""
-    if hasattr(data, "__geo_interface__"):
-        # Use default transformer for geo interface objects
-        # # (e.g. a geopandas GeoDataFrame)
-        return default_data_transformer(data)
+    if data is None:
+        return vegafusion_data_transformer
     elif isinstance(data, DataFrameLike):
         table_name = f"table_{uuid.uuid4()}".replace("-", "_")
         extracted_inline_tables[table_name] = data
         return {"url": VEGAFUSION_PREFIX + table_name}
     else:
-        # Use default transformer if we don't recognize data type
+        # Use default transformer for geo interface objects
+        # # (e.g. a geopandas GeoDataFrame)
+        # Or if we don't recognize data type
         return default_data_transformer(data)
 
 

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -3,7 +3,22 @@ import os
 import random
 import hashlib
 import warnings
-from typing import Union, MutableMapping, Optional, Dict, Sequence, TYPE_CHECKING, List
+from typing import (
+    Union,
+    MutableMapping,
+    Optional,
+    Dict,
+    Sequence,
+    TYPE_CHECKING,
+    List,
+    TypeVar,
+    Protocol,
+    TypedDict,
+    Literal,
+    overload,
+    runtime_checkable,
+    Any,
+)
 
 import pandas as pd
 from toolz import curried
@@ -15,14 +30,16 @@ from .core import sanitize_geo_interface
 from .deprecation import AltairDeprecationWarning
 from .plugin_registry import PluginRegistry
 
-
-from typing import Protocol, TypedDict, Literal
-
+if sys.version_info >= (3, 13):
+    from typing import TypeIs
+else:
+    from typing_extensions import TypeIs
 
 if TYPE_CHECKING:
     import pyarrow.lib
 
 
+@runtime_checkable
 class SupportsGeoInterface(Protocol):
     __geo_interface__: MutableMapping
 
@@ -32,6 +49,8 @@ TDataType = TypeVar("TDataType", bound=DataType)
 
 VegaLiteDataDict = Dict[str, Union[str, dict, List[dict]]]
 ToValuesReturnType = Dict[str, Union[dict, List[dict]]]
+def is_data_type(obj: Any) -> TypeIs[DataType]:
+    return isinstance(obj, (dict, pd.DataFrame, DataFrameLike, SupportsGeoInterface))
 
 
 # ==============================================================================

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -72,8 +72,15 @@ def is_data_type(obj: Any) -> TypeIs[DataType]:
 # form.
 # ==============================================================================
 class DataTransformerType(Protocol):
-    def __call__(self, data: DataType, **kwargs) -> VegaLiteDataDict:
-        pass
+    @overload
+    def __call__(
+        self, data: Literal[None] = None, **kwargs
+    ) -> "DataTransformerType": ...
+    @overload
+    def __call__(self, data: DataType, **kwargs) -> VegaLiteDataDict: ...
+    def __call__(
+        self, data: Optional[DataType] = None, **kwargs
+    ) -> Union["DataTransformerType", VegaLiteDataDict]: ...
 
 
 class DataTransformerRegistry(PluginRegistry[DataTransformerType]):

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -23,8 +23,6 @@ from typing import (
 )
 
 import pandas as pd
-from toolz import curried
-from typing import TypeVar
 
 from ._importers import import_pyarrow_interchange
 from .core import sanitize_dataframe, sanitize_arrow_table, DataFrameLike
@@ -414,7 +412,9 @@ def pipe(data, *funcs):
         AltairDeprecationWarning,
         stacklevel=1,
     )
-    return curried.pipe(data, *funcs)
+    from toolz.curried import pipe
+
+    return pipe(data, *funcs)
 
 
 def curry(*args, **kwargs):
@@ -428,7 +428,9 @@ def curry(*args, **kwargs):
         AltairDeprecationWarning,
         stacklevel=1,
     )
-    return curried.curry(*args, **kwargs)
+    from toolz.curried import curry
+
+    return curry(*args, **kwargs)
 
 
 def arrow_table_from_dfi_dataframe(dfi_df: DataFrameLike) -> "pyarrow.lib.Table":

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -233,7 +233,7 @@ def to_csv(
 def to_values(data: DataType) -> ToValuesReturnType:
     """Replace a DataFrame by a data model with values."""
     check_data_type(data)
-    if hasattr(data, "__geo_interface__"):
+    if isinstance(data, SupportsGeoInterface):
         if isinstance(data, pd.DataFrame):
             data = sanitize_dataframe(data)
         # Maybe the type could be further clarified here that it is
@@ -276,7 +276,7 @@ def _compute_data_hash(data_str: str) -> str:
 def _data_to_json_string(data: DataType) -> str:
     """Return a JSON string representation of the input data"""
     check_data_type(data)
-    if hasattr(data, "__geo_interface__"):
+    if isinstance(data, SupportsGeoInterface):
         if isinstance(data, pd.DataFrame):
             data = sanitize_dataframe(data)
         # Maybe the type could be further clarified here that it is
@@ -302,7 +302,7 @@ def _data_to_json_string(data: DataType) -> str:
 def _data_to_csv_string(data: Union[dict, pd.DataFrame, DataFrameLike]) -> str:
     """return a CSV string representation of the input data"""
     check_data_type(data)
-    if hasattr(data, "__geo_interface__"):
+    if isinstance(data, SupportsGeoInterface):
         raise NotImplementedError(
             "to_csv does not work with data that "
             "contains the __geo_interface__ attribute"

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -230,7 +230,6 @@ def to_csv(
     return {"url": os.path.join(urlpath, filename), "format": {"type": "csv"}}
 
 
-@curried.curry
 def to_values(data: DataType) -> ToValuesReturnType:
     """Replace a DataFrame by a data model with values."""
     check_data_type(data)

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -3,6 +3,7 @@ import os
 import random
 import hashlib
 import warnings
+import sys
 from typing import (
     Union,
     MutableMapping,
@@ -256,9 +257,7 @@ def to_values(data: DataType) -> ToValuesReturnType:
 
 
 def check_data_type(data: DataType) -> None:
-    if not isinstance(data, (dict, pd.DataFrame, DataFrameLike)) and not any(
-        hasattr(data, attr) for attr in ["__geo_interface__"]
-    ):
+    if not is_data_type(data):
         raise TypeError(
             "Expected dict, DataFrame or a __geo_interface__ attribute, got: {}".format(
                 type(data)

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -47,6 +47,7 @@ class SupportsGeoInterface(Protocol):
 DataType = Union[dict, pd.DataFrame, SupportsGeoInterface, DataFrameLike]
 TDataType = TypeVar("TDataType", bound=DataType)
 NonGeoDataType = Union[dict, pd.DataFrame, DataFrameLike]
+NonLikeDataType = Union[dict, pd.DataFrame, SupportsGeoInterface]
 
 VegaLiteDataDict = Dict[str, Union[str, dict, List[dict]]]
 ToValuesReturnType = Dict[str, Union[dict, List[dict]]]

--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, List, Optional, Generic, TypeVar, cast
+from functools import partial
+from typing import Any, Dict, List, Optional, Generic, TypeVar, Union, cast
 from types import TracebackType
-
+from collections.abc import Callable
 from importlib.metadata import entry_points
-
-from toolz import curry
 
 
 PluginType = TypeVar("PluginType")
@@ -71,7 +70,7 @@ class PluginRegistry(Generic[PluginType]):
     # in the registry rather than passed to the plugins
     _global_settings = {}  # type: Dict[str, Any]
 
-    def __init__(self, entry_point_group: str = "", plugin_type: type = object):
+    def __init__(self, entry_point_group: str = "", plugin_type: type[Any] = Callable):
         """Create a PluginRegistry for a named entry point group.
 
         Parameters
@@ -90,7 +89,9 @@ class PluginRegistry(Generic[PluginType]):
         self._options = {}  # type: Dict[str, Any]
         self._global_settings = self.__class__._global_settings.copy()  # type: dict
 
-    def register(self, name: str, value: Optional[PluginType]) -> Optional[PluginType]:
+    def register(
+        self, name: str, value: Union[Optional[PluginType], Any]
+    ) -> Optional[PluginType]:
         """Register a plugin by name and value.
 
         This method is used for explicit registration of a plugin and shouldn't be
@@ -199,10 +200,15 @@ class PluginRegistry(Generic[PluginType]):
         """Return the current options dictionary"""
         return self._options
 
-    def get(self) -> Optional[PluginType]:
+    def get(self) -> Optional[Union[PluginType, Callable[..., Any]]]:
         """Return the currently active plugin."""
         if self._options:
-            return curry(self._active, **self._options)
+            if func := self._active:
+                # NOTE: Fully do not understand this one
+                # error: Argument 1 to "partial" has incompatible type "PluginType"; expected "Callable[..., Never]"
+                return partial(func, **self._options)  # type: ignore[arg-type]
+            else:
+                raise TypeError("Unclear what this meant by passing to curry.")
         else:
             return self._active
 


### PR DESCRIPTION
This PR is a proof-of-concept, entirely* removing the hard dependency on `toolz`.
*Excluding usage in tests and twice for a deprecation warning.

I've tried to provide reasoning on each commit, but generally, it seemed to me that the behaviour `altair` needs is easily replicated within `stdlib`. 

### Additional Notes

- `pipe` and `curry` were the only imports
  - `pipe` is trivial to replace.
  - `curry` seems overkill when the only non-default argument is always `data`
    - Also has the drawback of [less type safety](https://github.com/pytoolz/toolz/issues/496)
- While this is documented under [Advanced Usage](https://altair-viz.github.io/user_guide/data_transformers.html#piping), I haven't come across any more complex examples.
  - I'd imagine users could see a benefit to performance performance, given the complexity of [curry](https://github.com/pytoolz/toolz/blob/7a0382e326eb2549e4dc7b833dc666a877feca38/toolz/functoolz.py#L168C5-L168C6).
  - If anyone has some sample code that heavily uses data transformers, it could be helpful to benchmark any changes.

If there was any desire to pursue this further, in b9dc070c30a23f09adac2d3686114ac3fc9c5cc9 I mentioned that this could be implemented as a decorator. 
I stopped short of that for now, but would be happy to go down that route to simplify the `@overload` usage. 
