### PR TITLE
ci: prepare for `numpy 2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "jinja2",
     # If you update the minimum required jsonschema version, also update it in build.yml
     "jsonschema>=3.0",
-    "numpy",
+    "numpy<2.0.0",
     # If you update the minimum required pandas version, also update it in build.yml
     "pandas>=0.25",
     "toolz",


### PR DESCRIPTION
[numpy 2.0.0](https://github.com/numpy/numpy/releases/tag/v2.0.0) is now released.

See [numpy-2-migration-guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html)

Also the `ruff` group `NPY` mentioned in https://github.com/vega/altair/pull/3431 could be useful here, especially [numpy2-deprecation](https://docs.astral.sh/ruff/rules/numpy2-deprecation/) which has an autofix.
I've split this out since at least the pin will need to be merged prior to 5.4.0, but updating any code might be more complicated until `python<3.9` is dropped.