### PR TITLE
docs: Add example of cumulative line chart with facet

### DIFF
--- a/tests/examples_arguments_syntax/line_chart_with_cumsum_faceted.py
+++ b/tests/examples_arguments_syntax/line_chart_with_cumsum_faceted.py
@@ -1,0 +1,36 @@
+"""
+Faceted Line Chart with Cumulative Sum
+------------------------------
+This chart creates multiple line subcharts from the cumulative sum of a field, one for each category.
+"""
+# category: line charts
+import altair as alt
+from vega_datasets import data
+
+source = data.disasters()
+columns_sorted = ['Drought', 'Epidemic', 'Earthquake', 'Flood']
+
+alt.Chart(source).mark_line(
+    interpolate='basis' # Use linear interpolation with B-spline method
+).encode( 
+    alt.X('Year:Q', title=None, axis=alt.Axis(format='d')),
+    alt.Y('cumulative:Q', title=None),
+    alt.Color('Entity:N', legend=None)
+).properties(width=300, height=150).facet(
+    facet=alt.Facet(
+        'Entity:N',
+        title=None,
+        sort=columns_sorted,
+        header=alt.Header(labelAnchor='start', labelFontStyle='italic')
+    ),
+    title={
+        'text': ['Cumulative casualties by type of disaster', 'in the 20th century'],
+        'anchor': 'middle'
+    },
+    columns=2
+).resolve_scale(y='independent').transform_filter(
+    {'and': [
+        alt.FieldOneOfPredicate(field='Entity', oneOf=columns_sorted), # Filter data to show only disasters in columns_sorted
+        alt.FieldRangePredicate(field='Year', range=[1900, 2000]) # Filter data to show only 20th century
+    ]}
+).transform_window(cumulative='sum(Deaths)', groupby=['Entity']) # Calculate cumulative sum of Deaths by Entity and name it cumulative

--- a/tests/examples_arguments_syntax/line_chart_with_cumsum_faceted.py
+++ b/tests/examples_arguments_syntax/line_chart_with_cumsum_faceted.py
@@ -1,36 +1,40 @@
 """
 Faceted Line Chart with Cumulative Sum
-------------------------------
-This chart creates multiple line subcharts from the cumulative sum of a field, one for each category.
+--------------------------------------
+This chart creates one facet per natural disaster and shows the cumulative number of deaths for that category.
+Note the use of different predicates to filter based on both a list and a range.
 """
-# category: line charts
+# category: advanced calculations
 import altair as alt
 from vega_datasets import data
 
 source = data.disasters()
 columns_sorted = ['Drought', 'Epidemic', 'Earthquake', 'Flood']
 
-alt.Chart(source).mark_line(
-    interpolate='basis' # Use linear interpolation with B-spline method
-).encode( 
+alt.Chart(source).transform_filter(
+    {'and': [
+        alt.FieldOneOfPredicate(field='Entity', oneOf=columns_sorted), # Filter data to show only disasters in columns_sorted
+        alt.FieldRangePredicate(field='Year', range=[1900, 2000]) # Filter data to show only 20th century
+    ]}
+).transform_window(
+    cumulative_deaths='sum(Deaths)', groupby=['Entity'] # Calculate cumulative sum of Deaths by Entity
+).mark_line().encode( 
     alt.X('Year:Q', title=None, axis=alt.Axis(format='d')),
-    alt.Y('cumulative:Q', title=None),
+    alt.Y('cumulative_deaths:Q', title=None),
     alt.Color('Entity:N', legend=None)
-).properties(width=300, height=150).facet(
+).properties(
+    width=300,
+    height=150
+).facet(
     facet=alt.Facet(
         'Entity:N',
         title=None,
         sort=columns_sorted,
         header=alt.Header(labelAnchor='start', labelFontStyle='italic')
     ),
-    title={
-        'text': ['Cumulative casualties by type of disaster', 'in the 20th century'],
-        'anchor': 'middle'
-    },
+    title=alt.Title(
+        text=['Cumulative casualties by type of disaster', 'in the 20th century'],
+        anchor='middle'
+    ),
     columns=2
-).resolve_scale(y='independent').transform_filter(
-    {'and': [
-        alt.FieldOneOfPredicate(field='Entity', oneOf=columns_sorted), # Filter data to show only disasters in columns_sorted
-        alt.FieldRangePredicate(field='Year', range=[1900, 2000]) # Filter data to show only 20th century
-    ]}
-).transform_window(cumulative='sum(Deaths)', groupby=['Entity']) # Calculate cumulative sum of Deaths by Entity and name it cumulative
+).resolve_scale(y='independent')

--- a/tests/examples_arguments_syntax/line_chart_with_cumsum_faceted.py
+++ b/tests/examples_arguments_syntax/line_chart_with_cumsum_faceted.py
@@ -37,4 +37,4 @@ alt.Chart(source).transform_filter(
         anchor='middle'
     ),
     columns=2
-).resolve_scale(y='independent')
+).resolve_axis(y='independent', x='independent')

--- a/tests/examples_methods_syntax/line_chart_with_cumsum_faceted.py
+++ b/tests/examples_methods_syntax/line_chart_with_cumsum_faceted.py
@@ -1,36 +1,40 @@
 """
 Faceted Line Chart with Cumulative Sum
-------------------------------
-This chart creates multiple line subcharts from the cumulative sum of a field, one for each category.
+--------------------------------------
+This chart creates one facet per natural disaster and shows the cumulative number of deaths for that category.
+Note the use of different predicates to filter based on both a list and a range.
 """
-# category: line charts
+# category: advanced calcuations
 import altair as alt
 from vega_datasets import data
 
 source = data.disasters()
 columns_sorted = ['Drought', 'Epidemic', 'Earthquake', 'Flood']
 
-alt.Chart(source).mark_line(
-    interpolate='basis' # Use linear interpolation with B-spline method
-).encode( 
+alt.Chart(source).transform_filter(
+    {'and': [
+        alt.FieldOneOfPredicate(field='Entity', oneOf=columns_sorted), # Filter data to show only disasters in columns_sorted
+        alt.FieldRangePredicate(field='Year', range=[1900, 2000]) # Filter data to show only 20th century
+    ]}
+).transform_window(
+    cumulative_deaths='sum(Deaths)', groupby=['Entity'] # Calculate cumulative sum of Deaths by Entity
+).mark_line().encode( 
     alt.X('Year:Q', title=None).axis(format='d'),
-    alt.Y('cumulative:Q', title=None),
+    alt.Y('cumulative_deaths:Q', title=None),
     alt.Color('Entity:N', legend=None)
-).properties(width=300, height=150).facet(
+).properties(
+    width=300,
+    height=150
+).facet(
     facet=alt.Facet(
         'Entity:N',
         title=None,
         sort=columns_sorted,
         header=alt.Header(labelAnchor='start', labelFontStyle='italic')
     ),
-    title={
-        'text': ['Cumulative casualties by type of disaster', 'in the 20th century'],
-        'anchor': 'middle'
-    },
+    title=alt.Title(
+        text=['Cumulative casualties by type of disaster', 'in the 20th century'],
+        anchor='middle'
+    ),
     columns=2
-).resolve_scale(y='independent').transform_filter(
-    {'and': [
-        alt.FieldOneOfPredicate(field='Entity', oneOf=columns_sorted), # Filter data to show only disasters in columns_sorted
-        alt.FieldRangePredicate(field='Year', range=[1900, 2000]) # Filter data to show only 20th century
-    ]}
-).transform_window(cumulative='sum(Deaths)', groupby=['Entity']) # Calculate cumulative sum of Deaths by Entity and name it cumulative
+).resolve_scale(y='independent')

--- a/tests/examples_methods_syntax/line_chart_with_cumsum_faceted.py
+++ b/tests/examples_methods_syntax/line_chart_with_cumsum_faceted.py
@@ -37,4 +37,4 @@ alt.Chart(source).transform_filter(
         anchor='middle'
     ),
     columns=2
-).resolve_scale(y='independent')
+).resolve_axis(y='independent', x='independent')

--- a/tests/examples_methods_syntax/line_chart_with_cumsum_faceted.py
+++ b/tests/examples_methods_syntax/line_chart_with_cumsum_faceted.py
@@ -1,0 +1,36 @@
+"""
+Faceted Line Chart with Cumulative Sum
+------------------------------
+This chart creates multiple line subcharts from the cumulative sum of a field, one for each category.
+"""
+# category: line charts
+import altair as alt
+from vega_datasets import data
+
+source = data.disasters()
+columns_sorted = ['Drought', 'Epidemic', 'Earthquake', 'Flood']
+
+alt.Chart(source).mark_line(
+    interpolate='basis' # Use linear interpolation with B-spline method
+).encode( 
+    alt.X('Year:Q', title=None).axis(format='d'),
+    alt.Y('cumulative:Q', title=None),
+    alt.Color('Entity:N', legend=None)
+).properties(width=300, height=150).facet(
+    facet=alt.Facet(
+        'Entity:N',
+        title=None,
+        sort=columns_sorted,
+        header=alt.Header(labelAnchor='start', labelFontStyle='italic')
+    ),
+    title={
+        'text': ['Cumulative casualties by type of disaster', 'in the 20th century'],
+        'anchor': 'middle'
+    },
+    columns=2
+).resolve_scale(y='independent').transform_filter(
+    {'and': [
+        alt.FieldOneOfPredicate(field='Entity', oneOf=columns_sorted), # Filter data to show only disasters in columns_sorted
+        alt.FieldRangePredicate(field='Year', range=[1900, 2000]) # Filter data to show only 20th century
+    ]}
+).transform_window(cumulative='sum(Deaths)', groupby=['Entity']) # Calculate cumulative sum of Deaths by Entity and name it cumulative


### PR DESCRIPTION
### Description

This PR replaces the "Cumulative Wikipedia Donations" example with a new chart, based on issue #2424. The original example was broken and went against the Contribution guideline that requires local datasets, and a new faceted cumulative sum chart was proposed in 2021. This PR incorporates the suggestion made by @jakevdp to improve x-axis labels. The example was developed and proposed by @harabat, but had not been 100% finalized. I made some very small tweaks to get it working in Altair v5 and to incorporate small recommendations in #2424.

### Changes Made

- Introduced a new cumulative sum chart to replace the broken (and since-removed) example of Cumulative Wikipedia Donations.
>The following code provides an illustration of a cumulative sum (to replace the broken chart), but also clarifies the styling of titles, headers, order, and marks of a facet plot, and gives an example of combining predicates with the filter transform.
>
> Source: [@harabat](https://github.com/vega/altair/issues/2424#issue-820036700)
- Improved x-axis label formatting per @jakevdp [suggestion](https://github.com/vega/altair/issues/2424#issuecomment-789203132).
- Assigned to category of line charts. (@jakevdp in 2021 [suggested](https://github.com/vega/altair/issues/2424#issuecomment-789203132) this be categorized as a case study, but the example gallery has evolved significantly since then. This example builds on a simpler cumulative line [example](https://altair-viz.github.io/gallery/line_chart_with_cumsum.html) and seemed to be a good fit within that section.)

### Issue Reference
Resolves #2424

![facetline_cumsum](https://github.com/vega/altair/assets/63077097/80fef39f-8889-4929-942e-88909116f600)
