### PR TITLE
ci: Update dependabot.yaml to include prefix

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Follow up of https://github.com/vega/altair/pull/3437.

The PR created by the dependabot workflow, eg https://github.com/vega/altair/pull/3439, is not adhering its title to a semantic pull request. This PR aims to solve this by including:

```yml
    commit-message:
      prefix: "ci"
```

In the workflow yaml-file as is documented here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message.

It is not fully clear yet if this also will work for the title of the PR. 