### PR TITLE
docs: Fix and improve `alt.Optional` doc

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -746,15 +746,33 @@ class UndefinedType:
 Undefined = UndefinedType()
 T = TypeVar("T")
 Optional: TypeAlias = Union[T, UndefinedType]
-"""One of the sepcified types, or the `Undefined` singleton.
-
+"""One of ``T`` specified type(s), or the ``Undefined`` singleton.
 
 Examples
 --------
-```py
-MaybeDictOrStr: TypeAlias = Optional[dict[str, Any] | str]
-LongerDictOrStr: TypeAlias = dict[str, Any] | str | UndefinedType
-```
+The parameters ``short``, ``long`` accept the same range of types::
+
+    # ruff: noqa: UP006, UP007
+    from altair import Optional
+
+    def func_1(
+        short: Optional[str | bool | float | dict[str, Any] | SchemaBase] = Undefined,
+        long: Union[
+            str, bool, float, Dict[str, Any], SchemaBase, UndefinedType
+        ] = Undefined,
+    ): ...
+
+This is distinct from `typing.Optional <https://typing.readthedocs.io/en/latest/spec/historical.html#union-and-optional>`__, as ``altair.Optional`` treats ``None`` like any other type::
+
+    # ruff: noqa: UP006, UP007
+    from altair import Optional
+
+    def func_2(
+        short: Optional[str | float | dict[str, Any] | None | SchemaBase] = Undefined,
+        long: Union[
+            str, float, Dict[str, Any], None, SchemaBase, UndefinedType
+        ] = Undefined,
+    ): ...
 """
 
 

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -762,7 +762,7 @@ The parameters ``short``, ``long`` accept the same range of types::
         ] = Undefined,
     ): ...
 
-This is distinct from `typing.Optional <https://typing.readthedocs.io/en/latest/spec/historical.html#union-and-optional>`__, as ``altair.Optional`` treats ``None`` like any other type::
+This is distinct from `typing.Optional <https://typing.readthedocs.io/en/latest/spec/historical.html#union-and-optional>`__ as ``altair.Optional`` treats ``None`` like any other type::
 
     # ruff: noqa: UP006, UP007
     from altair import Optional

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -744,15 +744,33 @@ class UndefinedType:
 Undefined = UndefinedType()
 T = TypeVar("T")
 Optional: TypeAlias = Union[T, UndefinedType]
-"""One of the sepcified types, or the `Undefined` singleton.
-
+"""One of ``T`` specified type(s), or the ``Undefined`` singleton.
 
 Examples
 --------
-```py
-MaybeDictOrStr: TypeAlias = Optional[dict[str, Any] | str]
-LongerDictOrStr: TypeAlias = dict[str, Any] | str | UndefinedType
-```
+The parameters ``short``, ``long`` accept the same range of types::
+
+    # ruff: noqa: UP006, UP007
+    from altair import Optional
+
+    def func_1(
+        short: Optional[str | bool | float | dict[str, Any] | SchemaBase] = Undefined,
+        long: Union[
+            str, bool, float, Dict[str, Any], SchemaBase, UndefinedType
+        ] = Undefined,
+    ): ...
+
+This is distinct from `typing.Optional <https://typing.readthedocs.io/en/latest/spec/historical.html#union-and-optional>`__, as ``altair.Optional`` treats ``None`` like any other type::
+
+    # ruff: noqa: UP006, UP007
+    from altair import Optional
+
+    def func_2(
+        short: Optional[str | float | dict[str, Any] | None | SchemaBase] = Undefined,
+        long: Union[
+            str, float, Dict[str, Any], None, SchemaBase, UndefinedType
+        ] = Undefined,
+    ): ...
 """
 
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -760,7 +760,7 @@ The parameters ``short``, ``long`` accept the same range of types::
         ] = Undefined,
     ): ...
 
-This is distinct from `typing.Optional <https://typing.readthedocs.io/en/latest/spec/historical.html#union-and-optional>`__, as ``altair.Optional`` treats ``None`` like any other type::
+This is distinct from `typing.Optional <https://typing.readthedocs.io/en/latest/spec/historical.html#union-and-optional>`__ as ``altair.Optional`` treats ``None`` like any other type::
 
     # ruff: noqa: UP006, UP007
     from altair import Optional


### PR DESCRIPTION
Fixes an issue identified in https://github.com/vega/altair/pull/3431#issuecomment-2194905942 and addresses `typing.Optional`

This is a follow-up PR to #3431, following @binste [comment](https://github.com/vega/altair/pull/3431#issuecomment-2195062569)


![image](https://github.com/vega/altair/assets/125183946/4f7d4b6b-c3e6-498d-aba2-1947a7d7e82a)
