### PR TITLE
fix: remove remapped `ruff` rule `PLR1701`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,8 +276,6 @@ select = [
     "PLC0208",
     # manual-from-import
     "PLR0402",
-    # repeated-isinstance-calls
-    "PLR1701",
     # useless-return
     "PLR1711",
     # repeated-equality-comparison


### PR DESCRIPTION
Fixes warnings here https://github.com/vega/altair/actions/runs/9733301918/job/26860053484?pr=3452

This was due to `ruff` updating around the same time as https://github.com/vega/altair/pull/3431#issuecomment-2195071162
The `SIM101` rule that it is remapped to is already part of our config