### PR TITLE
feat(typing): Ban `typing.Optional` import using `ruff`

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -14,7 +14,6 @@ from typing import (
     TypeVar,
     Union,
     Dict,
-    Optional,
     overload,
     runtime_checkable,
 )
@@ -54,7 +53,7 @@ VegaLiteDataDict: TypeAlias = Dict[
     str, Union[str, Dict[Any, Any], List[Dict[Any, Any]]]
 ]
 ToValuesReturnType: TypeAlias = Dict[str, Union[Dict[Any, Any], List[Dict[Any, Any]]]]
-SampleReturnType = Optional[Union[pd.DataFrame, Dict[str, Sequence], "pa.lib.Table"]]
+SampleReturnType = Union[pd.DataFrame, Dict[str, Sequence], "pa.lib.Table", None]
 
 
 def is_data_type(obj: Any) -> TypeIs[DataType]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,6 +319,10 @@ unfixable= [
 [tool.ruff.lint.mccabe]
 max-complexity = 18
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+# https://docs.astral.sh/ruff/settings/#lint_flake8-tidy-imports_banned-api
+"typing.Optional".msg = "Use `Union[T, None]` instead.\n`typing.Optional` is likely to be confused with `altair.Optional`, which have similar but different semantic meaning.\nSee https://github.com/vega/altair/pull/3449"
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,7 +321,7 @@ max-complexity = 18
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 # https://docs.astral.sh/ruff/settings/#lint_flake8-tidy-imports_banned-api
-"typing.Optional".msg = "Use `Union[T, None]` instead.\n`typing.Optional` is likely to be confused with `altair.Optional`, which have similar but different semantic meaning.\nSee https://github.com/vega/altair/pull/3449"
+"typing.Optional".msg = "Use `Union[T, None]` instead.\n`typing.Optional` is likely to be confused with `altair.Optional`, which have a similar but different semantic meaning.\nSee https://github.com/vega/altair/pull/3449"
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
The ~~user~~ contributor will see this message:

```bash
altair\utils\data.py:17:5: TID251 `typing.Optional` is banned: Use `Union[T, None]` instead. 
`typing.Optional` is likely to be confused with `altair.Optional`, which have a similar but different semantic meaning. 
See https://github.com/vega/altair/pull/3449 
Found 1 error.
```

Partial fix for https://github.com/vega/altair/pull/3452#discussion_r1663857513