### PR TITLE
refactor(typing): Reuse generated `Literal` aliases in `api`

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -85,6 +85,13 @@ if TYPE_CHECKING:
         InlineDataset,
     )
     from altair.expr.core import Expression, GetAttrExpression
+    from .schema._typing import (
+        ImputeMethod_T,
+        SelectionType_T,
+        SelectionResolution_T,
+        SingleDefUnitChannel_T,
+        StackOffset_T,
+    )
 
 ChartDataType: TypeAlias = Optional[Union[DataType, core.Data, str, core.Generator]]
 
@@ -505,9 +512,7 @@ def param(
     return parameter
 
 
-def _selection(
-    type: Optional[Literal["interval", "point"]] = Undefined, **kwds
-) -> Parameter:
+def _selection(type: Optional[SelectionType_T] = Undefined, **kwds) -> Parameter:
     # We separate out the parameter keywords from the selection keywords
 
     select_kwds = {"name", "bind", "value", "empty", "init", "views"}
@@ -537,9 +542,7 @@ def _selection(
     message="""'selection' is deprecated.
    Use 'selection_point()' or 'selection_interval()' instead; these functions also include more helpful docstrings."""
 )
-def selection(
-    type: Optional[Literal["interval", "point"]] = Undefined, **kwds
-) -> Parameter:
+def selection(type: Optional[SelectionType_T] = Undefined, **kwds) -> Parameter:
     """
     Users are recommended to use either 'selection_point' or 'selection_interval' instead, depending on the type of parameter they want to create.
 
@@ -568,10 +571,10 @@ def selection_interval(
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,
     expr: Optional[str | Expr | Expression] = Undefined,
-    encodings: Optional[list[str]] = Undefined,
+    encodings: Optional[list[SingleDefUnitChannel_T]] = Undefined,
     on: Optional[str] = Undefined,
     clear: Optional[str | bool] = Undefined,
-    resolve: Optional[Literal["global", "union", "intersect"]] = Undefined,
+    resolve: Optional[SelectionResolution_T] = Undefined,
     mark: Optional[Mark] = Undefined,
     translate: Optional[str | bool] = Undefined,
     zoom: Optional[str | bool] = Undefined,
@@ -680,11 +683,11 @@ def selection_point(
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,
     expr: Optional[Expr] = Undefined,
-    encodings: Optional[list[str]] = Undefined,
+    encodings: Optional[list[SingleDefUnitChannel_T]] = Undefined,
     fields: Optional[list[str]] = Undefined,
     on: Optional[str] = Undefined,
     clear: Optional[str | bool] = Undefined,
-    resolve: Optional[Literal["global", "union", "intersect"]] = Undefined,
+    resolve: Optional[SelectionResolution_T] = Undefined,
     toggle: Optional[str | bool] = Undefined,
     nearest: Optional[bool] = Undefined,
     **kwds,
@@ -1853,9 +1856,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         frame: Optional[list[int | None]] = Undefined,
         groupby: Optional[list[str | FieldName]] = Undefined,
         keyvals: Optional[list[Any] | ImputeSequence] = Undefined,
-        method: Optional[
-            Literal["value", "mean", "median", "max", "min"] | ImputeMethod
-        ] = Undefined,
+        method: Optional[ImputeMethod_T | ImputeMethod] = Undefined,
         value=Undefined,
     ) -> Self:
         """
@@ -2378,7 +2379,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         as_: str | FieldName | list[str],
         stack: str | FieldName,
         groupby: list[str | FieldName],
-        offset: Optional[Literal["zero", "center", "normalize"]] = Undefined,
+        offset: Optional[StackOffset_T] = Undefined,
         sort: Optional[list[SortField]] = Undefined,
     ) -> Self:
         """
@@ -3061,7 +3062,7 @@ class Chart(
             copy of self, with interactive axes added
 
         """
-        encodings = []
+        encodings: list[SingleDefUnitChannel_T] = []
         if bind_x:
             encodings.append("x")
         if bind_y:
@@ -3351,7 +3352,7 @@ class ConcatChart(TopLevelMixin, core.TopLevelConcatSpec):
             copy of self, with interactive axes added
 
         """
-        encodings = []
+        encodings: list[SingleDefUnitChannel_T] = []
         if bind_x:
             encodings.append("x")
         if bind_y:
@@ -3448,7 +3449,7 @@ class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
             copy of self, with interactive axes added
 
         """
-        encodings = []
+        encodings: list[SingleDefUnitChannel_T] = []
         if bind_x:
             encodings.append("x")
         if bind_y:
@@ -3547,7 +3548,7 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
             copy of self, with interactive axes added
 
         """
-        encodings = []
+        encodings: list[SingleDefUnitChannel_T] = []
         if bind_x:
             encodings.append("x")
         if bind_y:


### PR DESCRIPTION
Following https://github.com/vega/altair/pull/3431 a number of these are now importable.

Additionally, I spotted the `encodings` parameter (e.g. in `selection_point`) was annotated with `str`, but should be constrained to only `SingleDefUnitChannel_T`.