### PR TITLE
refactor: remove dead `_get_channels_mapping` code

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -232,15 +232,6 @@ core.FacetedEncoding._class_is_valid_at_instantiation = False
 TOPLEVEL_ONLY_KEYS = {"background", "config", "autosize", "padding", "$schema"}
 
 
-def _get_channels_mapping() -> dict[type[SchemaBase], str]:
-    mapping: dict[type[SchemaBase], str] = {}
-    for attr in dir(channels):
-        cls = getattr(channels, attr)
-        if isinstance(cls, type) and issubclass(cls, core.SchemaBase):
-            mapping[cls] = attr.replace("Value", "").lower()
-    return mapping
-
-
 # -------------------------------------------------------------------------
 # Tools for working with parameters
 class Parameter(_expr_core.OperatorMixin):


### PR DESCRIPTION
> "_get_channels_mapping" is not accessed Pylance

I've been seeing this message for a while and thought I'd investigate.

This function appears in the first `v5` commit to `api` https://github.com/vega/altair/blob/14bbb8de37794d9b1040e847f333fbd5792afec8/altair/vegalite/v5/api.py#L146-L152

Was not referenced back then (2021), and still is not referenced.

It looks like an early version of the `channels` module manipulation code replaced in https://github.com/vega/altair/pull/3444

As this is a private function, I don't feel there's a strong case for keeping it around. 
It also doesn't behave the same as the old `infer_encoding_types` - so any hypothetical usage wouldn't produce the same spec:

```py
channel_objs = (getattr(channels, name) for name in dir(channels))
        if channels
    channel_objs = (
        else _ChannelCache.from_cache()
        c for c in channel_objs if isinstance(c, type) and issubclass(c, SchemaBase)
    )
    )
    channel_to_name: dict[type[SchemaBase], str] = {
        c: c._encoding_name for c in channel_objs
    }
    name_to_channel: dict[str, dict[str, type[SchemaBase]]] = {}
    for chan, name in channel_to_name.items():
        chans = name_to_channel.setdefault(name, {})
        if chan.__name__.endswith("Datum"):
            key = "datum"
        elif chan.__name__.endswith("Value"):
            key = "value"
        else:
            key = "field"
        chans[key] = chan
```