### PR TITLE
refactor: Simplify `SchemaBase` repr

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -909,18 +909,14 @@ class SchemaBase:
         self._kwds[item] = val
 
     def __repr__(self) -> str:
-        if self._kwds:
-            it = (
-                f"{key}: {val!r}"
-                for key, val in sorted(self._kwds.items())
-                if val is not Undefined
-            )
-            args = "\n" + ",\n".join(it)
-            return "{}({{{}\n}})".format(
-                self.__class__.__name__, args.replace("\n", "\n  ")
-            )
+        name = type(self).__name__
+        if kwds := self._kwds:
+            it = (f"{k}: {v!r}" for k, v in sorted(kwds.items()) if v is not Undefined)
+            args = ",\n".join(it).replace("\n", "\n  ")
+            LB, RB = "{", "}"
+            return f"{name}({LB}\n  {args}\n{RB})"
         else:
-            return f"{self.__class__.__name__}({self._args[0]!r})"
+            return f"{name}({self._args[0]!r})"
 
     def __eq__(self, other: Any) -> bool:
         return (

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -907,18 +907,14 @@ class SchemaBase:
         self._kwds[item] = val
 
     def __repr__(self) -> str:
-        if self._kwds:
-            it = (
-                f"{key}: {val!r}"
-                for key, val in sorted(self._kwds.items())
-                if val is not Undefined
-            )
-            args = "\n" + ",\n".join(it)
-            return "{}({{{}\n}})".format(
-                self.__class__.__name__, args.replace("\n", "\n  ")
-            )
+        name = type(self).__name__
+        if kwds := self._kwds:
+            it = (f"{k}: {v!r}" for k, v in sorted(kwds.items()) if v is not Undefined)
+            args = ",\n".join(it).replace("\n", "\n  ")
+            LB, RB = "{", "}"
+            return f"{name}({LB}\n  {args}\n{RB})"
         else:
-            return f"{self.__class__.__name__}({self._args[0]!r})"
+            return f"{name}({self._args[0]!r})"
 
     def __eq__(self, other: Any) -> bool:
         return (


### PR DESCRIPTION
This is a relatively minor change, but I think the result is much easier to understand.

There is no observable difference otherwise, confirmed by the tests:
- `test_expression_function_expr`
- `test_expression_function_string`
- [doctest] `altair.vegalite.v5.api.TopLevelMixin.transform_bin`
- [doctest] `altair.vegalite.v5.api.TopLevelMixin.transform_calculate`
- [doctest] `altair.vegalite.v5.api.TopLevelMixin.transform_timeunit`
- [doctest] `altair.vegalite.v5.api.TopLevelMixin.transform_window`

The above were all failing -  before I figured out what the brace escaping in the original was up to.