### PR TITLE
ci: remove `toolz` from `[[tool.mypy.overrides]]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,7 +342,6 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = [
     "vega_datasets.*",
-    "toolz.*",
     "pyarrow.*",
     "yaml.*",
     "vl_convert.*",


### PR DESCRIPTION
I should have removed this in https://github.com/vega/altair/pull/3426 but better late than never

