### PR TITLE
fix(typing): Ignore `[arg-type]` error in `_deduplicate_enum_errors`

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -409,20 +409,6 @@ def _group_errors_by_validator(errors: ValidationErrorList) -> GroupedValidation
     return dict(errors_by_validator)
 
 
-def _safe_validator_value_iter(errors: ValidationErrorList, /) -> Iterator[str]:
-    for err in errors:
-        if isinstance(err.validator_value, Iterable):
-            yield ",".join(err.validator_value)
-        else:
-            msg = (
-                "It is assumed that values (and therefore `validator_value`) of an enum are always arrays.\n"
-                "Therefore, this error should be unreachable.\n"
-                "see https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values\n\n"
-                f"{type(err.validator_value).__name__!r} is not `Iterable`."
-            )
-            raise TypeError(msg)
-
-
 def _deduplicate_enum_errors(errors: ValidationErrorList) -> ValidationErrorList:
     """Deduplicate enum errors by removing the errors where the allowed values
     are a subset of another error. For example, if `enum` contains two errors
@@ -431,7 +417,10 @@ def _deduplicate_enum_errors(errors: ValidationErrorList) -> ValidationErrorList
     `enum` list only contains the error with ["A", "B", "C"].
     """
     if len(errors) > 1:
-        value_strings = list(_safe_validator_value_iter(errors))
+        # Values (and therefore `validator_value`) of an enum are always arrays,
+        # see https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values
+        # which is why we can use join below
+        value_strings = [",".join(err.validator_value) for err in errors]  # type: ignore
         longest_enums: ValidationErrorList = []
         for value_str, err in zip(value_strings, errors):
             if not _contained_at_start_of_one_of_other_values(value_str, value_strings):

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -409,6 +409,20 @@ def _group_errors_by_validator(errors: ValidationErrorList) -> GroupedValidation
     return dict(errors_by_validator)
 
 
+def _safe_validator_value_iter(errors: ValidationErrorList, /) -> Iterator[str]:
+    for err in errors:
+        if isinstance(err.validator_value, Iterable):
+            yield ",".join(err.validator_value)
+        else:
+            msg = (
+                "It is assumed that values (and therefore `validator_value`) of an enum are always arrays.\n"
+                "Therefore, this error should be unreachable.\n"
+                "see https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values\n\n"
+                f"{type(err.validator_value).__name__!r} is not `Iterable`."
+            )
+            raise TypeError(msg)
+
+
 def _deduplicate_enum_errors(errors: ValidationErrorList) -> ValidationErrorList:
     """Deduplicate enum errors by removing the errors where the allowed values
     are a subset of another error. For example, if `enum` contains two errors
@@ -417,10 +431,7 @@ def _deduplicate_enum_errors(errors: ValidationErrorList) -> ValidationErrorList
     `enum` list only contains the error with ["A", "B", "C"].
     """
     if len(errors) > 1:
-        # Values (and therefore `validator_value`) of an enum are always arrays,
-        # see https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values
-        # which is why we can use join below
-        value_strings = [",".join(err.validator_value) for err in errors]
+        value_strings = list(_safe_validator_value_iter(errors))
         longest_enums: ValidationErrorList = []
         for value_str, err in zip(value_strings, errors):
             if not _contained_at_start_of_one_of_other_values(value_str, value_strings):

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -407,6 +407,20 @@ def _group_errors_by_validator(errors: ValidationErrorList) -> GroupedValidation
     return dict(errors_by_validator)
 
 
+def _safe_validator_value_iter(errors: ValidationErrorList, /) -> Iterator[str]:
+    for err in errors:
+        if isinstance(err.validator_value, Iterable):
+            yield ",".join(err.validator_value)
+        else:
+            msg = (
+                "It is assumed that values (and therefore `validator_value`) of an enum are always arrays.\n"
+                "Therefore, this error should be unreachable.\n"
+                "see https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values\n\n"
+                f"{type(err.validator_value).__name__!r} is not `Iterable`."
+            )
+            raise TypeError(msg)
+
+
 def _deduplicate_enum_errors(errors: ValidationErrorList) -> ValidationErrorList:
     """Deduplicate enum errors by removing the errors where the allowed values
     are a subset of another error. For example, if `enum` contains two errors
@@ -415,10 +429,7 @@ def _deduplicate_enum_errors(errors: ValidationErrorList) -> ValidationErrorList
     `enum` list only contains the error with ["A", "B", "C"].
     """
     if len(errors) > 1:
-        # Values (and therefore `validator_value`) of an enum are always arrays,
-        # see https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values
-        # which is why we can use join below
-        value_strings = [",".join(err.validator_value) for err in errors]
+        value_strings = list(_safe_validator_value_iter(errors))
         longest_enums: ValidationErrorList = []
         for value_str, err in zip(value_strings, errors):
             if not _contained_at_start_of_one_of_other_values(value_str, value_strings):


### PR DESCRIPTION
Fixes `mypy` error that appeared during a merge https://github.com/vega/altair/actions/runs/9905108163/job/27364368641

```
altair/utils/schemapi.py:423: error: Argument 1 to "join" of "str" has incompatible type "Any | Unset"; expected "Iterable[str]"  [arg-type]
Found 1 error in 1 file (checked 367 source files)
Error: Process completed with exit code 1.
```

# Edit
This is ready to merge and is blocking for all other PRs