### PR TITLE
docs: Add example for *Bar Chart with Highlighting on Hover and Selection on Click*

### DIFF
--- a/tests/examples_arguments_syntax/interactive_bar_select_highlight.py
+++ b/tests/examples_arguments_syntax/interactive_bar_select_highlight.py
@@ -27,10 +27,8 @@ select = alt.selection_point(name="select", on="click")
 highlight = alt.selection_point(name="highlight", on="pointerover", empty=False)
 
 stroke_width = (
-    alt.when(select)
-    .then(alt.value(2, empty=False))
-    .when(highlight)
-    .then(alt.value(1))
+    alt.when(select).then(alt.value(2, empty=False))
+    .when(highlight).then(alt.value(1))
     .otherwise(alt.value(0))
 )
 

--- a/tests/examples_arguments_syntax/interactive_bar_select_highlight.py
+++ b/tests/examples_arguments_syntax/interactive_bar_select_highlight.py
@@ -1,0 +1,47 @@
+"""
+Bar Chart with Highlighting on Hover and Selection on Click
+-----------------------------------------------------------
+This example shows a bar chart with highlighting on hover and selecting on click. (Inspired by Tableau's interaction style.)
+
+Based on https://vega.github.io/vega-lite/examples/interactive_bar_select_highlight.html
+"""
+
+# category: interactive charts
+import altair as alt
+
+source = {
+    "values": [
+        {"a": "A", "b": 28},
+        {"a": "B", "b": 55},
+        {"a": "C", "b": 43},
+        {"a": "D", "b": 91},
+        {"a": "E", "b": 81},
+        {"a": "F", "b": 53},
+        {"a": "G", "b": 19},
+        {"a": "H", "b": 87},
+        {"a": "I", "b": 52},
+    ]
+}
+
+select = alt.selection_point(name="select", on="click")
+highlight = alt.selection_point(name="highlight", on="pointerover", empty=False)
+
+stroke_width = (
+    alt.when(select)
+    .then(alt.value(2, empty=False))
+    .when(highlight)
+    .then(alt.value(1))
+    .otherwise(alt.value(0))
+)
+
+
+alt.Chart(
+    source,
+    height=200,
+    config=alt.Config(scale=alt.ScaleConfig(bandPaddingInner=0.2)),
+).mark_bar(fill="#4C78A8", stroke="black", cursor="pointer").encode(
+    x="a:O",
+    y="b:Q",
+    fillOpacity=alt.when(select).then(alt.value(1)).otherwise(alt.value(0.3)),
+    strokeWidth=stroke_width,
+).add_params(select, highlight)

--- a/tests/examples_methods_syntax/interactive_bar_select_highlight.py
+++ b/tests/examples_methods_syntax/interactive_bar_select_highlight.py
@@ -27,10 +27,8 @@ select = alt.selection_point(name="select", on="click")
 highlight = alt.selection_point(name="highlight", on="pointerover", empty=False)
 
 stroke_width = (
-    alt.when(select)
-    .then(alt.value(2, empty=False))
-    .when(highlight)
-    .then(alt.value(1))
+    alt.when(select).then(alt.value(2, empty=False))
+    .when(highlight).then(alt.value(1))
     .otherwise(alt.value(0))
 )
 

--- a/tests/examples_methods_syntax/interactive_bar_select_highlight.py
+++ b/tests/examples_methods_syntax/interactive_bar_select_highlight.py
@@ -1,0 +1,45 @@
+"""
+Bar Chart with Highlighting on Hover and Selection on Click
+-----------------------------------------------------------
+This example shows a bar chart with highlighting on hover and selecting on click. (Inspired by Tableau's interaction style.)
+
+Based on https://vega.github.io/vega-lite/examples/interactive_bar_select_highlight.html
+"""
+
+# category: interactive charts
+import altair as alt
+
+source = {
+    "values": [
+        {"a": "A", "b": 28},
+        {"a": "B", "b": 55},
+        {"a": "C", "b": 43},
+        {"a": "D", "b": 91},
+        {"a": "E", "b": 81},
+        {"a": "F", "b": 53},
+        {"a": "G", "b": 19},
+        {"a": "H", "b": 87},
+        {"a": "I", "b": 52},
+    ]
+}
+
+select = alt.selection_point(name="select", on="click")
+highlight = alt.selection_point(name="highlight", on="pointerover", empty=False)
+
+stroke_width = (
+    alt.when(select)
+    .then(alt.value(2, empty=False))
+    .when(highlight)
+    .then(alt.value(1))
+    .otherwise(alt.value(0))
+)
+
+
+alt.Chart(source, height=200).mark_bar(
+    fill="#4C78A8", stroke="black", cursor="pointer"
+).encode(
+    x="a:O",
+    y="b:Q",
+    fillOpacity=alt.when(select).then(alt.value(1)).otherwise(alt.value(0.3)),
+    strokeWidth=stroke_width,
+).configure_scale(bandPaddingInner=0.2).add_params(select, highlight)


### PR DESCRIPTION
Fixes https://github.com/vega/altair/issues/3301

Utilises `alt.when`, introduced in https://github.com/vega/altair/pull/3427

![image](https://github.com/user-attachments/assets/9f8a27e9-b803-4382-aa8c-c44415610f8d)

---

@mattijn I thought adding this first would be something to refer to in the follow-up PR discussed in https://github.com/vega/altair/pull/3427#issuecomment-2237588984

Also revisiting since https://github.com/vega/altair/issues/2759#issuecomment-2138158202 I have a better explanation for the `empty=False` placement.

For `select`, the `Parameter` is used twice - once with `empty=False` and another with the default.
Whereas `highlight` is used only once.

I think this could be helpful to add to the `alt.condition(empty)` and each `.when(empty)` doc, as this is a good justification for why you can pass `empty` there.

https://github.com/dangotbanned/altair/blob/ef81573b9c709989d3965f778a5b0c5d77f6d4c3/tests/examples_methods_syntax/interactive_bar_select_highlight.py#L26-L45