### PR TITLE
test: skip `ibis` test on unsupported `python` version

### DIFF
--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -1527,8 +1527,9 @@ def test_polars_with_pandas_nor_pyarrow(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="ibis requires 'python>=3.10'",
+    sys.version_info < (3, 9),
+    reason="The maximum `ibis` version installable on Python 3.8 is `ibis==5.1.0`,"
+    " which doesn't support the dataframe interchange protocol.",
 )
 @pytest.mark.skipif(
     Version("1.5") > PANDAS_VERSION,

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -1527,6 +1527,10 @@ def test_polars_with_pandas_nor_pyarrow(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="ibis requires 'python>=3.10'",
+)
+@pytest.mark.skipif(
     Version("1.5") > PANDAS_VERSION,
     reason="A warning is thrown on old pandas versions",
 )


### PR DESCRIPTION
`test_ibis_with_date_32` was always emitting the same warning on `3.8`:

```
================================================================================================= warnings summary =================================================================================================  
tests/vegalite/v5/test_api.py::test_ibis_with_date_32   

/altair/altair/vegalite/v5/api.py:233: UserWarning: data of type <class 'ibis.expr.types.relations.Table'> not recognized
     warnings.warn(f"data of type {type(data)} not recognized", stacklevel=1)  

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html 
==================================================================================== 210 passed, 1 xfailed, 1 warning in 17.92s ====================================================================================
```

@MarcoGorelli wanted to check in with you to see if this is a reasonable skip?

I was a little confused on the `ibis.expr.types.relations.Table` appearing on a `python` below [their minimum](https://github.com/ibis-project/ibis/blob/6991f044438303fc509630bb4f21065e3e458f9d/pyproject.toml#L39)