### PR TITLE
fix(typing): Resolve `mypy==1.11.0` issues in `plugin_registry`

### DIFF
--- a/altair/utils/compiler.py
+++ b/altair/utils/compiler.py
@@ -7,5 +7,5 @@ from altair.utils import PluginRegistry
 VegaLiteCompilerType = Callable[[dict], dict]
 
 
-class VegaLiteCompilerRegistry(PluginRegistry[VegaLiteCompilerType]):
+class VegaLiteCompilerRegistry(PluginRegistry[VegaLiteCompilerType, dict]):
     pass

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -16,8 +16,9 @@ from typing import (
     Dict,
     overload,
     runtime_checkable,
+    Callable,
 )
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, ParamSpec, Concatenate
 from pathlib import Path
 from functools import partial
 import sys
@@ -82,17 +83,14 @@ def is_data_type(obj: Any) -> TypeIs[DataType]:
 # VegaLite spec, after the Data model has been put into a schema compliant
 # form.
 # ==============================================================================
-class DataTransformerType(Protocol):
-    @overload
-    def __call__(self, data: None = None, **kwargs) -> DataTransformerType: ...
-    @overload
-    def __call__(self, data: DataType, **kwargs) -> VegaLiteDataDict: ...
-    def __call__(
-        self, data: DataType | None = None, **kwargs
-    ) -> DataTransformerType | VegaLiteDataDict: ...
+
+P = ParamSpec("P")
+# NOTE: `Any` required due to the complexity of existing signatures imported in `altair.vegalite.v5.data.py`
+R = TypeVar("R", VegaLiteDataDict, Any)
+DataTransformerType = Callable[Concatenate[DataType, P], R]
 
 
-class DataTransformerRegistry(PluginRegistry[DataTransformerType]):
+class DataTransformerRegistry(PluginRegistry[DataTransformerType, R]):
     _global_settings = {"consolidate_datasets": True}
 
     @property

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -31,7 +31,7 @@ DefaultRendererReturnType: TypeAlias = Tuple[
 ]
 
 
-class RendererRegistry(PluginRegistry[RendererType]):
+class RendererRegistry(PluginRegistry[RendererType, MimeBundleType]):
     entrypoint_err_messages = {
         "notebook": textwrap.dedent(
             """

--- a/altair/utils/theme.py
+++ b/altair/utils/theme.py
@@ -6,5 +6,5 @@ from typing import Callable
 ThemeType = Callable[..., dict]
 
 
-class ThemeRegistry(PluginRegistry[ThemeType]):
+class ThemeRegistry(PluginRegistry[ThemeType, dict]):
     pass

--- a/altair/vegalite/v5/data.py
+++ b/altair/vegalite/v5/data.py
@@ -25,7 +25,8 @@ ENTRY_POINT_GROUP: Final = "altair.vegalite.v5.data_transformer"
 data_transformers = DataTransformerRegistry(entry_point_group=ENTRY_POINT_GROUP)
 data_transformers.register("default", default_data_transformer)
 data_transformers.register("json", to_json)
-data_transformers.register("csv", to_csv)
+# FIXME: `to_csv` cannot accept all `DataType` https://github.com/vega/altair/issues/3441
+data_transformers.register("csv", to_csv)  # type: ignore[arg-type]
 data_transformers.register("vegafusion", vegafusion_data_transformer)
 data_transformers.enable("default")
 

--- a/tests/utils/test_plugin_registry.py
+++ b/tests/utils/test_plugin_registry.py
@@ -2,7 +2,7 @@ from altair.utils.plugin_registry import PluginRegistry
 from typing import Callable
 
 
-class TypedCallableRegistry(PluginRegistry[Callable[[int], int]]):
+class TypedCallableRegistry(PluginRegistry[Callable[[int], int], int]):
     pass
 
 


### PR DESCRIPTION
Fixes
- https://github.com/vega/altair/actions/runs/10020215927/job/27697611769
- https://github.com/vega/altair/actions/runs/10013817103/job/27682236626#step:7:15
- https://github.com/vega/altair/actions/runs/10020215927/job/27697611769

```log
altair/utils/plugin_registry.py:213: error: "PluginType" not callable  [misc]
altair/utils/plugin_registry.py:213: note: Error code "misc" not covered by "type: ignore" comment
Found 1 error in 1 file (checked 369 source files)
Error: Process completed with exit code 1.
```

# Description
The release of [Mypy 1.11](https://mypy-lang.blogspot.com/2024/07/mypy-111-released.html?m=1) introduced stricter typing for `functools.partial`.
The existing `# type: ignore` comments were no longer sufficient and correcting everything (whilst not breaking all the derived registries) was more complex than I'd like. 
Hopefully this summary is easier to understand than the diff alone.

# Fix

The fix is mostly 2 changes:

1. Propagating the return type of plugin functions
2. Switching from `assert isinstance(...)` to a narrowing function

For **2**, I have added a [courtesy deprecation](ttps://github.com/dangotbanned/altair/blob/b5aab1d467d8251eaa55812b99d451899c2d6518/altair/utils/plugin_registry.py#L114). 
No current `altair` code (including tests) used the `plugin_type` argument.
I don't think `PluginRegistry` is intended to be public as it doesn't appear in `alt.__all__`. 

**The new default has identical behaviour to the previous default**
It is also safer as it won't be [disabled by optimizations](https://docs.astral.sh/ruff/rules/assert/) & better adheres to the current [typing spec](https://typing.readthedocs.io/en/latest/spec/narrowing.html) guidance.