### PR TITLE
fix: remove unsupported `sphinx` theme option `'footer_items'`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -142,7 +142,6 @@ html_theme_options = {
     "navbar_center": ["navbar-nav"],
     "navbar_end": ["theme-switcher", "navbar-icon-links"],
     "primary_sidebar_end": [],
-    "footer_items": [],
     "icon_links": [
         {
             "name": "GitHub",


### PR DESCRIPTION
Removes this warning when building docs:

```log
preparing documents... WARNING: unsupported theme option 'footer_items' given
```

![image](https://github.com/user-attachments/assets/9a6ec4c5-fed4-4cb3-99c5-5a58fb6fcaf4)
