### PR TITLE
docs: Add `empty` as a explicit `condition` kwarg

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1480,15 +1480,6 @@ def condition(
 @overload
 def condition(
     predicate: _PredicateType,
-    if_true: str,
-    if_false: str,
-    *,
-    empty: Optional[bool] = ...,
-    **kwargs,
-) -> Never: ...
-@overload
-def condition(
-    predicate: _PredicateType,
     if_true: Map | SchemaBase,
     if_false: Map | str,
     *,
@@ -1504,6 +1495,15 @@ def condition(
     empty: Optional[bool] = ...,
     **kwargs,
 ) -> dict[str, _ConditionType | Any]: ...
+@overload
+def condition(
+    predicate: _PredicateType,
+    if_true: str,
+    if_false: str,
+    *,
+    empty: Optional[bool] = ...,
+    **kwargs,
+) -> Never: ...
 # TODO: update the docstring
 def condition(
     predicate: _PredicateType,

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1524,6 +1524,9 @@ def condition(
         the spec or object to use if the selection predicate is true
     if_false:
         the spec or object to use if the selection predicate is false
+    empty
+        For selection parameters, the predicate of empty selections returns ``True`` by default.
+        Override this behavior, with ``empty=False``.
     **kwargs:
         additional keyword args are added to the resulting dict
 

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1497,12 +1497,7 @@ def condition(
 ) -> dict[str, _ConditionType | Any]: ...
 @overload
 def condition(
-    predicate: _PredicateType,
-    if_true: str,
-    if_false: str,
-    *,
-    empty: Optional[bool] = ...,
-    **kwargs,
+    predicate: _PredicateType, if_true: str, if_false: str, **kwargs
 ) -> Never: ...
 # TODO: update the docstring
 def condition(

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1492,6 +1492,8 @@ def condition(
     predicate: _PredicateType,
     if_true: _StatementType,
     if_false: _StatementType,
+    *,
+    empty: Optional[bool] = Undefined,
     **kwargs,
 ) -> SchemaBase | dict[str, _ConditionType | Any]:
     """A conditional attribute or encoding
@@ -1513,7 +1515,6 @@ def condition(
     spec: dict or VegaLiteSchema
         the spec that describes the condition
     """
-    empty = kwargs.pop("empty", Undefined)
     condition = _predicate_to_condition(predicate, empty=empty)
     return _condition_to_selection(condition, if_true, if_false, **kwargs)
 

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1470,21 +1470,38 @@ def binding_range(**kwargs):
 
 @overload
 def condition(
-    predicate: _PredicateType, if_true: _StatementType, if_false: _TSchemaBase, **kwargs
+    predicate: _PredicateType,
+    if_true: _StatementType,
+    if_false: _TSchemaBase,
+    *,
+    empty: Optional[bool] = ...,
+    **kwargs,
 ) -> _TSchemaBase: ...
 @overload
 def condition(
-    predicate: _PredicateType, if_true: str, if_false: str, **kwargs
+    predicate: _PredicateType,
+    if_true: str,
+    if_false: str,
+    *,
+    empty: Optional[bool] = ...,
+    **kwargs,
 ) -> Never: ...
 @overload
 def condition(
-    predicate: _PredicateType, if_true: Map | SchemaBase, if_false: Map | str, **kwargs
+    predicate: _PredicateType,
+    if_true: Map | SchemaBase,
+    if_false: Map | str,
+    *,
+    empty: Optional[bool] = ...,
+    **kwargs,
 ) -> dict[str, _ConditionType | Any]: ...
 @overload
 def condition(
     predicate: _PredicateType,
     if_true: Map | str,
     if_false: Map,
+    *,
+    empty: Optional[bool] = ...,
     **kwargs,
 ) -> dict[str, _ConditionType | Any]: ...
 # TODO: update the docstring

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1527,6 +1527,10 @@ def condition(
     empty
         For selection parameters, the predicate of empty selections returns ``True`` by default.
         Override this behavior, with ``empty=False``.
+
+        .. note::
+            When ``predicate`` is a ``Parameter`` that is used more than once,
+            ``alt.condition(..., empty=...)`` provides granular control for each :func:`.condition()`.
     **kwargs:
         additional keyword args are added to the resulting dict
 


### PR DESCRIPTION
Partial fix:
- https://github.com/vega/altair/pull/3485#pullrequestreview-2189012089
- https://github.com/vega/altair/pull/3485#issue-2418667202

This was already being [handled internally](https://github.com/vega/altair/blob/24e03154fb93c26eccf72d0d31fc6bc777cc0526/altair/vegalite/v5/api.py#L1516), but now aligns more closely with `when` and provides a documentable argument.

I was hoping to get this doc approved, [before moving onto](https://github.com/vega/altair/discussions/3478#discussioncomment-10104219) `when-then-otherwise` as this is a smaller change - but will be reused there multiple times