### PR TITLE
ci: include optional dependencies for Polars backend in ibis-framework install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ all = [
     "pandas>=0.25.3",
     "numpy<2.0.0",
     "pyarrow>=11",
-    "pyarrow_hotfix; pyarrow<\"14.0.1\"",    
     "vegafusion[embed]>=1.6.6",
     "anywidget>=0.9.0",
     "altair_tiles>=0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ all = [
 dev = [
     "hatch",
     "ruff>=0.5.3",
-    "ibis-framework",
+    "ibis-framework[polars]",
     "ipython",
     "pandas>=0.25.3",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ all = [
     "pandas>=0.25.3",
     "numpy<2.0.0",
     "pyarrow>=11",
+    "pyarrow_hotfix; pyarrow<\"14.0.1\"",    
     "vegafusion[embed]>=1.6.6",
     "anywidget>=0.9.0",
     "altair_tiles>=0.3.0"


### PR DESCRIPTION
I'm seeing a CI failure in the downstream tests: https://github.com/narwhals-dev/narwhals/actions/runs/10055785067/job/27793203912?pr=587

<!-- Click "Preview" to read this message; then delete it. -->

Thanks for contributing to Altair!

Please follow these guidelines when submitting your PR:

- Describe the purpose of the changes in PR, so that it is easy to understand the implication of the suggested changes.
    - Here is a [helpful article about writing effective PR descriptions](https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3).
- Include unit tests and documentation for new features
- Ensure that the title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "feat: Add `embed_options` to charts").
    - Append `!` if the change is breaking (e.g. "fix!: Raise error when `embed_options` is `None`")
