### PR TITLE
ci(ruff): Remove stale `docstring-code-format` comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -365,7 +365,6 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "lf"
-# Enable once `D` are applied to non-generated code
 # https://docs.astral.sh/ruff/formatter/#docstring-formatting
 docstring-code-format = true
 docstring-code-line-length = 88


### PR DESCRIPTION
I left this as a TODO during #3493 and only spotted it after merging.

See for detail:
- https://github.com/vega/altair/pull/3493#issuecomment-2243507107
- https://github.com/vega/altair/pull/3493#issuecomment-2243639106