### PR TITLE
ci: Add `python-version=="3.9"` to github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         jsonschema-version: ["3.0", "latest"]
     name: py ${{ matrix.python-version }} js ${{ matrix.jsonschema-version }}
     steps:


### PR DESCRIPTION
Addresses one item in https://github.com/vega/altair/issues/3497

> This one is a pretty minor fix, and could be added now - since eventually it will be the lower bound.