### PR TITLE
ci: relax `numpy<=2.0.0` constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ all = [
     "vega_datasets>=0.9.0",
     "vl-convert-python>=1.5.0",
     "pandas>=0.25.3",
-    "numpy<2.0.0",
+    "numpy",
     "pyarrow>=11",
     "vegafusion[embed]>=1.6.6",
     "anywidget>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,6 +305,8 @@ select = [
     "D",
     # multi-line-summary-second-line
     "D213",
+    # numpy-specific-rules
+    "NPY",
 ]
 ignore = [  
     # Whitespace before ':'

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -30,7 +30,8 @@ def test_infer_vegalite_type():
     _check(pd.date_range("2012", "2013"), "temporal")
     _check(pd.timedelta_range(365, periods=12), "temporal")
 
-    nulled = pd.Series(np.random.randint(10, size=10))
+    rng = np.random.default_rng()
+    nulled = pd.Series(rng.integers(10, size=10))
     nulled[0] = None
     _check(nulled, "quantitative")
     _check(["a", "b", "c"], "nominal")


### PR DESCRIPTION
Follow-up: https://github.com/vega/altair/pull/3438

Most of the `numpy` usage is within the test examples, which *is not* run through `ruff`.

Applying all of [`NPY`](https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy) only required one fix, so AFAIK `altair` is compatible with `NumPy 2.0`.

---

Moving out of draft after checking for issues in `r"tests/examples_.+_syntax/*.py"`

Edit: See https://github.com/vega/altair/pull/3504#issuecomment-2251050382