### PR TITLE
build: Add `ipykernel` optional dependency to `dev` group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dev = [
     "hatch",
     "ruff>=0.5.3",
     "ibis-framework[polars]",
-    "ipython",
+    "ipython[kernel]",
     "pandas>=0.25.3",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
This PR adds the optional `ipython` dependency `ipykernel`, to avoid the following issue.

# Bug

## Attempting to run a notebook
![image](https://github.com/user-attachments/assets/9fcc23b7-41e4-42b4-b5a5-799defc22431)

## Install failing due to `uv` instead of `pip`
![image](https://github.com/user-attachments/assets/191981d3-a59a-49d3-b20b-24d1c3c764a7)

## Error command

![image](https://github.com/user-attachments/assets/b61f45ac-b8f9-4944-926a-4b0f525a3a49)

This has to be modified to fix:

```bash
# >>> python -m pip install ipykernel -U --force-reinstall
>>> python -m uv pip install ipykernel -U --force-reinstall
```

---

I have been manually working around this since we moved from `pip` -> `uv` in https://github.com/vega/altair/pull/3431#issuecomment-2168654915

But this change is much simpler and doesn't need to be repeated for each new environment.