### PR TITLE
docs: Undoc deprecated functionality

### DIFF
--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -83,7 +83,6 @@ def save(
     vegalite_version: str | None = None,
     embed_options: dict | None = None,
     json_kwds: dict | None = None,
-    webdriver: Literal["chrome", "firefox"] | None = None,
     scale_factor: float = 1,
     engine: Literal["vl-convert"] | None = None,
     inline: bool = False,
@@ -119,8 +118,6 @@ def save(
     json_kwds : dict (optional)
         Additional keyword arguments are passed to the output method
         associated with the specified format.
-    webdriver : string {'chrome' | 'firefox'} (optional)
-        This argument is deprecated as it's not relevant for the new vl-convert engine.
     scale_factor : float (optional)
         scale_factor to use to change size/resolution of png or svg output
     engine: string {'vl-convert'}
@@ -134,7 +131,7 @@ def save(
     **kwargs :
         additional kwargs passed to spec_to_mimebundle.
     """
-    if webdriver is not None:
+    if _ := kwargs.pop("webdriver", None):
         deprecated_warn(
             "The webdriver argument is not relevant for the new vl-convert engine which replaced altair_saver. "
             "The argument will be removed in a future release.",

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1980,7 +1980,6 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         vegaembed_version: str = VEGAEMBED_VERSION,
         embed_options: dict | None = None,
         json_kwds: dict | None = None,
-        webdriver: str | None = None,
         engine: str | None = None,
         inline=False,
         **kwargs,
@@ -2020,8 +2019,6 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         json_kwds : dict (optional)
             Additional keyword arguments are passed to the output method
             associated with the specified format.
-        webdriver : string {'chrome' | 'firefox'} (optional)
-            This argument is deprecated as it's not relevant for the new vl-convert engine.
         engine: string {'vl-convert', 'altair_saver'}
             the conversion engine to use for 'png', 'svg', and 'pdf' formats
         inline: bool (optional)
@@ -2033,7 +2030,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         **kwargs :
             additional kwargs passed to spec_to_mimebundle.
         """
-        if webdriver is not None:
+        if _ := kwargs.pop("webdriver", None):
             utils.deprecated_warn(
                 "The webdriver argument is not relevant for the new vl-convert engine which replaced altair_saver. "
                 "The argument will be removed in a future release.",

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -348,9 +348,13 @@ class Parameter(_expr_core.OperatorMixin):
         self.param = param
         self.param_type = param_type
 
-    @utils.deprecated(version="5.0.0", alternative="to_dict")
+    @utils.deprecated(
+        version="5.0.0",
+        alternative="to_dict",
+        message="No need to call '.ref()' anymore.",
+    )
     def ref(self) -> dict:
-        """'ref' is deprecated. Use '.to_dict()' instead."""
+        """'ref' is deprecated. No need to call '.ref()' anymore."""
         return self.to_dict()
 
     def to_dict(self) -> dict[str, str | dict]:

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -350,7 +350,7 @@ class Parameter(_expr_core.OperatorMixin):
 
     @utils.deprecated(version="5.0.0", alternative="to_dict")
     def ref(self) -> dict:
-        """'ref' is deprecated. No need to call '.ref()' anymore."""
+        """'ref' is deprecated. Use '.to_dict()' instead."""
         return self.to_dict()
 
     def to_dict(self) -> dict[str, str | dict]:
@@ -1332,24 +1332,7 @@ def _selection(type: Optional[SelectionType_T] = Undefined, **kwds) -> Parameter
     message="These functions also include more helpful docstrings.",
 )
 def selection(type: Optional[SelectionType_T] = Undefined, **kwds) -> Parameter:
-    """
-    Users are recommended to use either 'selection_point' or 'selection_interval' instead, depending on the type of parameter they want to create.
-
-    Create a selection parameter.
-
-    Parameters
-    ----------
-    type : enum('point', 'interval') (required)
-        Determines the default event processing and data query for the
-        selection. Vega-Lite currently supports two selection types:
-        * "point" - to select multiple discrete data values; the first
-        value is selected on click and additional values toggled on
-        shift-click.
-        * "interval" - to select a continuous range of data values on
-        drag.
-    **kwds :
-        additional keywords to control the selection.
-    """
+    """'selection' is deprecated use 'selection_point' or 'selection_interval' instead, depending on the type of parameter you want to create."""
     return _selection(type=type, **kwds)
 
 
@@ -3461,36 +3444,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         http_server=None,
         **kwargs,
     ):
-        """
-        'serve' is deprecated. Use 'show' instead.
-
-        Open a browser window and display a rendering of the chart
-
-        Parameters
-        ----------
-        html : string
-            HTML to serve
-        ip : string (default = '127.0.0.1')
-            ip address at which the HTML will be served.
-        port : int (default = 8888)
-            the port at which to serve the HTML
-        n_retries : int (default = 50)
-            the number of nearby ports to search if the specified port
-            is already in use.
-        files : dictionary (optional)
-            dictionary of extra content to serve
-        jupyter_warning : bool (optional)
-            if True (default), then print a warning if this is used
-            within the Jupyter notebook
-        open_browser : bool (optional)
-            if True (default), then open a web browser to the given HTML
-        http_server : class (optional)
-            optionally specify an HTTPServer class to use for showing the
-            figure. The default is Python's basic HTTPServer.
-        **kwargs :
-            additional keyword arguments passed to the save() method
-
-        """
+        """'serve' is deprecated. Use 'show' instead."""
         from ...utils.server import serve
 
         html = io.StringIO()

--- a/doc/user_guide/api.rst
+++ b/doc/user_guide/api.rst
@@ -156,11 +156,8 @@ API Functions
    layer
    param
    repeat
-   selection
    selection_interval
-   selection_multi
    selection_point
-   selection_single
    sequence
    sphere
    topo_feature

--- a/tools/generate_api_docs.py
+++ b/tools/generate_api_docs.py
@@ -90,6 +90,8 @@ def iter_objects(
             not (isinstance(obj, type) and issubclass(obj, restrict_to_subclass))
         ):
             continue
+        if hasattr(obj, "__deprecated__"):
+            continue
         yield name
 
 


### PR DESCRIPTION
Partially addresses #3454 

> - Should deprecated features be documented to the same level as their replacements?
>	- Deprecated: https://altair-viz.github.io/user_guide/generated/api/altair.selection_single.html#altair-selection-single 
>	- Replacement: https://altair-viz.github.io/user_guide/generated/api/altair.selection_point.html#altair.selection_point

---

Mainly impacts [API Functions](https://altair-viz.github.io/user_guide/api.html#api-functions) where it is much clearer which `selection_` functions should be used, since 3/5 are no longer there.

![image](https://github.com/user-attachments/assets/0e15efcf-d21b-4544-9d70-1c94c6614b8e)
