### PR TITLE
docs: Remove reference to `altair_saver` in `save`

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2023,7 +2023,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         json_kwds : dict (optional)
             Additional keyword arguments are passed to the output method
             associated with the specified format.
-        engine: string {'vl-convert', 'altair_saver'}
+        engine: string {'vl-convert'}
             the conversion engine to use for 'png', 'svg', and 'pdf' formats
         inline: bool (optional)
             If False (default), the required JavaScript libraries are loaded


### PR DESCRIPTION
Seems like this was only missed in one place.

Should've caught this in #3509 but better late than never