### PR TITLE
fix: replace deprecated `sphinx` default

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,7 +60,7 @@ templates_path = ["_templates"]
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'


### PR DESCRIPTION
Removes a warning from doc build

# Before
```cmd
>>> hatch run doc:build-html-win
cmd [1] | if not exist doc\_images md doc\_images
cmd [2] | sphinx-build -b html -d doc\_build\doctrees doc doc\_build\html
Running Sphinx v7.4.7
loading translations [en]... done
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
loading pickled environment... done
```

# After
```cmd
>>> hatch run doc:build-html-win
cmd [1] | if not exist doc\_images md doc\_images
cmd [2] | sphinx-build -b html -d doc\_build\doctrees doc doc\_build\html
Running Sphinx v7.4.7
loading translations [en]... done
making output directory... done
```
