### PR TITLE
refactor(ruff): Organize imports w/ (`I001`, `TID252`) rules

### DIFF
--- a/altair/expr/consts.py
+++ b/altair/expr/consts.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 CONST_LISTING = {
     "NaN": "not a number (same as JavaScript literal NaN)",
     "LN10": "the natural log of 10 (alias to Math.LN10)",

--- a/altair/expr/core.py
+++ b/altair/expr/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, Union
 from typing_extensions import TypeAlias
 
-from ..utils import SchemaBase
+from altair.utils import SchemaBase
 
 
 class DatumType:

--- a/altair/expr/core.py
+++ b/altair/expr/core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Union, Dict
-
+from typing import Any, Dict, Union
 from typing_extensions import TypeAlias
 
 from ..utils import SchemaBase

--- a/altair/jupyter/jupyter_chart.py
+++ b/altair/jupyter/jupyter_chart.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
+
 import json
-import anywidget
-import traitlets
 import pathlib
 from typing import Any
 
+import anywidget
+import traitlets
+
 import altair as alt
-from altair.utils._vegafusion_data import (
-    using_vegafusion,
-    compile_to_vegafusion_chart_state,
-)
 from altair import TopLevelSpec
-from altair.utils.selection import IndexSelection, PointSelection, IntervalSelection
+from altair.utils._vegafusion_data import (
+    compile_to_vegafusion_chart_state,
+    using_vegafusion,
+)
+from altair.utils.selection import IndexSelection, IntervalSelection, PointSelection
 
 _here = pathlib.Path(__file__).parent
 

--- a/altair/utils/__init__.py
+++ b/altair/utils/__init__.py
@@ -1,20 +1,19 @@
 from .core import (
-    infer_vegalite_type_for_pandas,
-    infer_encoding_types,
-    sanitize_pandas_dataframe,
-    sanitize_narwhals_dataframe,
-    parse_shorthand,
-    use_signature,
-    update_nested,
-    display_traceback,
-    SchemaBase,
     SHORTHAND_KEYS,
+    SchemaBase,
+    display_traceback,
+    infer_encoding_types,
+    infer_vegalite_type_for_pandas,
+    parse_shorthand,
+    sanitize_narwhals_dataframe,
+    sanitize_pandas_dataframe,
+    update_nested,
+    use_signature,
 )
+from .deprecation import AltairDeprecationWarning, deprecated, deprecated_warn
 from .html import spec_to_html
 from .plugin_registry import PluginRegistry
-from .deprecation import AltairDeprecationWarning, deprecated, deprecated_warn
-from .schemapi import Undefined, Optional, is_undefined
-
+from .schemapi import Optional, Undefined, is_undefined
 
 __all__ = (
     "SHORTHAND_KEYS",

--- a/altair/utils/_dfi_types.py
+++ b/altair/utils/_dfi_types.py
@@ -5,6 +5,7 @@
 #
 # These classes are only for use in type signatures
 from __future__ import annotations
+
 import enum
 from typing import Any, Iterable, Protocol
 

--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -67,7 +67,7 @@ def import_vl_convert() -> ModuleType:
 
 
 def vl_version_for_vl_convert() -> str:
-    from ..vegalite import SCHEMA_VERSION
+    from altair.vegalite import SCHEMA_VERSION
 
     # Compute VlConvert's vl_version string (of the form 'v5_2')
     # from SCHEMA_VERSION (of the form 'v5.2.0')

--- a/altair/utils/_show.py
+++ b/altair/utils/_show.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Iterable

--- a/altair/utils/_transformed_data.py
+++ b/altair/utils/_transformed_data.py
@@ -1,28 +1,30 @@
 from __future__ import annotations
-from typing import Any, Iterable, overload, TYPE_CHECKING, Dict, Tuple
+
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Tuple, overload
 from typing_extensions import TypeAlias
+
 from altair import (
     Chart,
-    FacetChart,
-    LayerChart,
-    HConcatChart,
-    VConcatChart,
     ConcatChart,
-    TopLevelUnitSpec,
+    ConcatSpecGenericSpec,
+    FacetChart,
     FacetedUnitSpec,
+    FacetSpec,
+    HConcatChart,
+    HConcatSpecGenericSpec,
+    LayerChart,
+    LayerSpec,
+    NonNormalizedSpec,
+    TopLevelConcatSpec,
+    TopLevelFacetSpec,
+    TopLevelHConcatSpec,
+    TopLevelLayerSpec,
+    TopLevelUnitSpec,
+    TopLevelVConcatSpec,
     UnitSpec,
     UnitSpecWithFrame,
-    NonNormalizedSpec,
-    TopLevelLayerSpec,
-    LayerSpec,
-    TopLevelConcatSpec,
-    ConcatSpecGenericSpec,
-    TopLevelHConcatSpec,
-    HConcatSpecGenericSpec,
-    TopLevelVConcatSpec,
+    VConcatChart,
     VConcatSpecGenericSpec,
-    TopLevelFacetSpec,
-    FacetSpec,
     data_transformers,
 )
 from altair.utils._vegafusion_data import get_inline_tables, import_vegafusion

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -1,31 +1,33 @@
 from __future__ import annotations
+
 import uuid
-from weakref import WeakValueDictionary
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Union,
+    Callable,
+    Final,
     MutableMapping,
     TypedDict,
-    Final,
-    TYPE_CHECKING,
+    Union,
     overload,
-    Callable,
 )
+from weakref import WeakValueDictionary
 
 import narwhals.stable.v1 as nw
 
 from altair.utils._importers import import_vegafusion
+from altair.utils.core import DataFrameLike
 from altair.utils.data import (
     DataType,
-    ToValuesReturnType,
     MaxRowsError,
     SupportsGeoInterface,
+    ToValuesReturnType,
 )
-from altair.utils.core import DataFrameLike
 from altair.vegalite.data import default_data_transformer
 
 if TYPE_CHECKING:
     from narwhals.typing import IntoDataFrame
+
     from vegafusion.runtime import ChartState  # type: ignore
 
 # Temporary storage for dataframes that have been extracted
@@ -182,7 +184,7 @@ def compile_to_vegafusion_chart_state(
         A VegaFusion ChartState object
     """
     # Local import to avoid circular ImportError
-    from altair import vegalite_compilers, data_transformers
+    from altair import data_transformers, vegalite_compilers
 
     vf = import_vegafusion()
 
@@ -234,7 +236,7 @@ def compile_with_vegafusion(vegalite_spec: dict[str, Any]) -> dict[str, Any]:
         A Vega spec that has been pre-transformed by VegaFusion
     """
     # Local import to avoid circular ImportError
-    from altair import vegalite_compilers, data_transformers
+    from altair import data_transformers, vegalite_compilers
 
     vf = import_vegafusion()
 

--- a/altair/utils/compiler.py
+++ b/altair/utils/compiler.py
@@ -1,4 +1,5 @@
-from typing import Callable, Dict, Any
+from typing import Any, Callable, Dict
+
 from altair.utils import PluginRegistry
 
 # ==============================================================================

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -2,29 +2,29 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, MutableMapping
-from copy import deepcopy
-import json
 import itertools
+import json
 import re
 import sys
 import traceback
 import warnings
-from typing import Callable, TypeVar, Any, Iterator, cast, Literal, TYPE_CHECKING
+from collections.abc import Mapping, MutableMapping
+from copy import deepcopy
 from itertools import groupby
 from operator import itemgetter
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, TypeVar, cast
 
 import jsonschema
 import narwhals.stable.v1 as nw
-from narwhals.dependencies import is_pandas_dataframe, get_polars
+from narwhals.dependencies import get_polars, is_pandas_dataframe
 from narwhals.typing import IntoDataFrame
 
 from altair.utils.schemapi import SchemaBase, Undefined
 
 if sys.version_info >= (3, 12):
-    from typing import runtime_checkable, Protocol
+    from typing import Protocol, runtime_checkable
 else:
-    from typing_extensions import runtime_checkable, Protocol
+    from typing_extensions import Protocol, runtime_checkable
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
 else:
@@ -32,12 +32,14 @@ else:
 
 
 if TYPE_CHECKING:
-    from types import ModuleType
     import typing as t
-    from altair.vegalite.v5.schema._typing import StandardType_T as InferredVegaLiteType
-    from altair.utils._dfi_types import DataFrame as DfiDataFrame
-    from narwhals.typing import IntoExpr
+    from types import ModuleType
+
     import pandas as pd
+    from narwhals.typing import IntoExpr
+
+    from altair.utils._dfi_types import DataFrame as DfiDataFrame
+    from altair.vegalite.v5.schema._typing import StandardType_T as InferredVegaLiteType
 
 V = TypeVar("V")
 P = ParamSpec("P")
@@ -337,8 +339,8 @@ def sanitize_pandas_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     """
     # This is safe to import here, as this function is only called on pandas input.
     # NumPy is a required dependency of pandas so is also safe to import.
-    import pandas as pd
     import numpy as np
+    import pandas as pd
 
     df = df.copy()
 

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -1,27 +1,28 @@
 from __future__ import annotations
+
+import hashlib
 import json
 import random
-import hashlib
+import sys
+from functools import partial
+from pathlib import Path
 from typing import (
-    Any,
-    List,
-    MutableMapping,
-    Sequence,
     TYPE_CHECKING,
-    Protocol,
-    TypedDict,
+    Any,
+    Callable,
+    Dict,
+    List,
     Literal,
+    MutableMapping,
+    Protocol,
+    Sequence,
+    TypedDict,
     TypeVar,
     Union,
-    Dict,
     overload,
     runtime_checkable,
-    Callable,
 )
-from typing_extensions import TypeAlias, ParamSpec, Concatenate
-from pathlib import Path
-from functools import partial
-import sys
+from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
 import narwhals.stable.v1 as nw
 from narwhals.dependencies import is_pandas_dataframe as _is_pandas_dataframe
@@ -29,12 +30,12 @@ from narwhals.typing import IntoDataFrame
 
 from ._importers import import_pyarrow_interchange
 from .core import (
-    sanitize_pandas_dataframe,
     DataFrameLike,
+    sanitize_geo_interface,
     sanitize_narwhals_dataframe,
+    sanitize_pandas_dataframe,
     to_eager_narwhals_dataframe,
 )
-from .core import sanitize_geo_interface
 from .plugin_registry import PluginRegistry
 
 if sys.version_info >= (3, 13):
@@ -43,8 +44,8 @@ else:
     from typing_extensions import TypeIs
 
 if TYPE_CHECKING:
-    import pyarrow as pa
     import pandas as pd
+    import pyarrow as pa
 
 
 @runtime_checkable

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
+
 import json
 import pkgutil
 import textwrap
-from typing import Callable, Any, Dict, Tuple, Union
-from typing_extensions import TypeAlias
 import uuid
+from typing import Any, Callable, Dict, Tuple, Union
+from typing_extensions import TypeAlias
 
 from ._vegafusion_data import compile_with_vegafusion, using_vegafusion
-from .plugin_registry import PluginRegistry, PluginEnabler
 from .mimebundle import spec_to_mimebundle
+from .plugin_registry import PluginEnabler, PluginRegistry
 from .schemapi import validate_jsonschema
-
 
 # ==============================================================================
 # Renderer registry

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
+
+import struct
 from typing import Any, Literal, cast, overload
 from typing_extensions import TypeAlias
-from .html import spec_to_html
+
 from ._importers import import_vl_convert, vl_version_for_vl_convert
-import struct
+from .html import spec_to_html
 
 MimeBundleFormat: TypeAlias = Literal[
     "html", "json", "png", "svg", "pdf", "vega", "vega-lite"
@@ -108,11 +110,8 @@ def spec_to_mimebundle(
     The png, svg, pdf, and vega outputs require the vl-convert package
     """
     # Local import to avoid circular ImportError
-    from altair.utils.display import (
-        compile_with_vegafusion,
-        using_vegafusion,
-    )
     from altair import renderers
+    from altair.utils.display import compile_with_vegafusion, using_vegafusion
 
     if mode != "vega-lite":
         msg = "mode must be 'vega-lite'"

--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, Generic, cast, Callable, TYPE_CHECKING
-from typing_extensions import TypeAliasType, TypeVar, TypeIs
-
 from importlib.metadata import entry_points
+from typing import TYPE_CHECKING, Any, Callable, Generic, cast
+from typing_extensions import TypeAliasType, TypeIs, TypeVar
 
 from altair.utils.deprecation import deprecated_warn
 

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
+
 import json
 import pathlib
 import warnings
-from typing import IO, Any, Literal, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any, Literal
 
-from .mimebundle import spec_to_mimebundle
-from ..vegalite.v5.data import data_transformers
 from altair.utils._vegafusion_data import using_vegafusion
 from altair.utils.deprecation import deprecated_warn
+
+from ..vegalite.v5.data import data_transformers
+from .mimebundle import spec_to_mimebundle
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -7,8 +7,8 @@ from typing import IO, TYPE_CHECKING, Any, Literal
 
 from altair.utils._vegafusion_data import using_vegafusion
 from altair.utils.deprecation import deprecated_warn
+from altair.vegalite.v5.data import data_transformers
 
-from ..vegalite.v5.data import data_transformers
 from .mimebundle import spec_to_mimebundle
 
 if TYPE_CHECKING:

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -6,28 +6,29 @@ import contextlib
 import copy
 import inspect
 import json
+import sys
 import textwrap
-from math import ceil
 from collections import defaultdict
+from functools import partial
 from importlib.metadata import version as importlib_version
 from itertools import chain, zip_longest
-import sys
+from math import ceil
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
     Final,
     Iterable,
     Iterator,
+    List,
     Literal,
     Sequence,
     TypeVar,
     Union,
     overload,
-    List,
-    Dict,
 )
 from typing_extensions import TypeAlias
-from functools import partial
+
 import jsonschema
 import jsonschema.exceptions
 import jsonschema.validators
@@ -39,10 +40,11 @@ from packaging.version import Version
 from altair import vegalite
 
 if TYPE_CHECKING:
+    from typing import ClassVar
+
     from referencing import Registry
 
     from altair import ChartType
-    from typing import ClassVar
 
     if sys.version_info >= (3, 13):
         from typing import TypeIs
@@ -50,9 +52,9 @@ if TYPE_CHECKING:
         from typing_extensions import TypeIs
 
     if sys.version_info >= (3, 11):
-        from typing import Self, Never
+        from typing import Never, Self
     else:
-        from typing_extensions import Self, Never
+        from typing_extensions import Never, Self
 
 ValidationErrorList: TypeAlias = List[jsonschema.exceptions.ValidationError]
 GroupedValidationErrors: TypeAlias = Dict[str, ValidationErrorList]

--- a/altair/utils/selection.py
+++ b/altair/utils/selection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import List, Dict, Any, NewType
 
+from dataclasses import dataclass
+from typing import Any, Dict, List, NewType
 
 # Type representing the "{selection}_store" dataset that corresponds to a
 # Vega-Lite selection

--- a/altair/utils/server.py
+++ b/altair/utils/server.py
@@ -5,14 +5,14 @@ This is adapted from the mpld3 package; see
 https://github.com/mpld3/mpld3/blob/master/mpld3/_server.py
 """
 
+import itertools
+import random
+import socket
 import sys
 import threading
 import webbrowser
-import socket
 from http import server
 from io import BytesIO as IO
-import itertools
-import random
 
 JUPYTER_WARNING = """
 Note: if you're in the Jupyter notebook, Chart.serve() is not the best

--- a/altair/utils/theme.py
+++ b/altair/utils/theme.py
@@ -1,7 +1,8 @@
 """Utilities for registering and working with themes."""
 
-from .plugin_registry import PluginRegistry
 from typing import Callable
+
+from .plugin_registry import PluginRegistry
 
 ThemeType = Callable[..., dict]
 

--- a/altair/vegalite/data.py
+++ b/altair/vegalite/data.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, overload
 
-from ..utils.core import sanitize_pandas_dataframe
-from ..utils.data import DataTransformerRegistry as _DataTransformerRegistry
-from ..utils.data import (
+from altair.utils.core import sanitize_pandas_dataframe
+from altair.utils.data import DataTransformerRegistry as _DataTransformerRegistry
+from altair.utils.data import (
     MaxRowsError,
     check_data_type,
     limit_rows,
@@ -15,8 +15,8 @@ from ..utils.data import (
 )
 
 if TYPE_CHECKING:
-    from ..utils.data import DataType, ToValuesReturnType
-    from ..utils.plugin_registry import PluginEnabler
+    from altair.utils.data import DataType, ToValuesReturnType
+    from altair.utils.plugin_registry import PluginEnabler
 
 
 @overload

--- a/altair/vegalite/data.py
+++ b/altair/vegalite/data.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, overload, Callable
+
+from typing import TYPE_CHECKING, Callable, overload
 
 from ..utils.core import sanitize_pandas_dataframe
+from ..utils.data import DataTransformerRegistry as _DataTransformerRegistry
 from ..utils.data import (
     MaxRowsError,
+    check_data_type,
     limit_rows,
     sample,
     to_csv,
     to_json,
     to_values,
-    check_data_type,
 )
-from ..utils.data import DataTransformerRegistry as _DataTransformerRegistry
 
 if TYPE_CHECKING:
-    from ..utils.plugin_registry import PluginEnabler
     from ..utils.data import DataType, ToValuesReturnType
+    from ..utils.plugin_registry import PluginEnabler
 
 
 @overload

--- a/altair/vegalite/display.py
+++ b/altair/vegalite/display.py
@@ -1,11 +1,11 @@
 from ..utils.display import (
+    DefaultRendererReturnType,
     Displayable,
+    HTMLRenderer,
+    RendererRegistry,
     default_renderer_base,
     json_renderer_base,
-    DefaultRendererReturnType,
 )
-from ..utils.display import RendererRegistry, HTMLRenderer
-
 
 __all__ = (
     "DefaultRendererReturnType",

--- a/altair/vegalite/display.py
+++ b/altair/vegalite/display.py
@@ -1,4 +1,4 @@
-from ..utils.display import (
+from altair.utils.display import (
     DefaultRendererReturnType,
     Displayable,
     HTMLRenderer,

--- a/altair/vegalite/v5/__init__.py
+++ b/altair/vegalite/v5/__init__.py
@@ -1,26 +1,24 @@
 # ruff: noqa: F401, F403
-from .schema import *
-from .api import *
-
 from altair.expr.core import datum
 
-from .display import (
-    VegaLite,
-    renderers,
-    VEGALITE_VERSION,
-    VEGAEMBED_VERSION,
-    VEGA_VERSION,
-)
+from .api import *
 from .compiler import vegalite_compilers
-
 from .data import (
     MaxRowsError,
+    data_transformers,
+    default_data_transformer,
     limit_rows,
     sample,
-    to_json,
     to_csv,
+    to_json,
     to_values,
-    default_data_transformer,
-    data_transformers,
 )
+from .display import (
+    VEGA_VERSION,
+    VEGAEMBED_VERSION,
+    VEGALITE_VERSION,
+    VegaLite,
+    renderers,
+)
+from .schema import *
 from .theme import themes

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -24,19 +24,19 @@ from typing_extensions import TypeAlias
 
 import jsonschema
 
+from altair import utils
+from altair.expr import core as _expr_core
 from altair.utils import Optional, Undefined
+from altair.utils._vegafusion_data import (
+    compile_with_vegafusion as _compile_with_vegafusion,
+)
+from altair.utils._vegafusion_data import using_vegafusion as _using_vegafusion
 from altair.utils.core import (
     to_eager_narwhals_dataframe as _to_eager_narwhals_dataframe,
 )
 from altair.utils.data import DataType
 from altair.utils.data import is_data_type as _is_data_type
 
-from ... import utils
-from ...expr import core as _expr_core
-from ...utils._vegafusion_data import (
-    compile_with_vegafusion as _compile_with_vegafusion,
-)
-from ...utils._vegafusion_data import using_vegafusion as _using_vegafusion
 from .compiler import vegalite_compilers
 from .data import data_transformers
 from .display import VEGA_VERSION, VEGAEMBED_VERSION, VEGALITE_VERSION, renderers
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import IO, Iterable, Iterator
 
-    from ...utils.core import DataFrameLike
+    from altair.utils.core import DataFrameLike
 
     if sys.version_info >= (3, 13):
         from typing import Required, TypeIs
@@ -1972,7 +1972,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         fullscreen : bool
             If True, editor will open chart in fullscreen mode. Default False
         """
-        from ...utils._importers import import_vl_convert
+        from altair.utils._importers import import_vl_convert
 
         vlc = import_vl_convert()
         if _using_vegafusion():
@@ -2062,7 +2062,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
                 version="5.0.0",
             )
 
-        from ...utils.save import save
+        from altair.utils.save import save
 
         kwds: dict[str, Any] = dict(
             chart=self,
@@ -3469,7 +3469,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         **kwargs,  # noqa: ANN003
     ) -> None:
         """'serve' is deprecated. Use 'show' instead."""
-        from ...utils.server import serve
+        from altair.utils.server import serve
 
         html = io.StringIO()
         self.save(html, format="html", **kwargs)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1,46 +1,48 @@
 from __future__ import annotations
 
-import sys
-import warnings
+import functools
 import hashlib
 import io
-import json
-import jsonschema
 import itertools
+import json
+import operator
+import sys
+import typing as t
+import warnings
+from copy import deepcopy as _deepcopy
 from typing import (
-    Any,
-    overload,
-    Literal,
-    Union,
     TYPE_CHECKING,
-    TypeVar,
+    Any,
+    Literal,
     Protocol,
     Sequence,
+    TypeVar,
+    Union,
+    overload,
 )
 from typing_extensions import TypeAlias
-import typing as t
-import functools
-import operator
-from copy import deepcopy as _deepcopy
 
-from .schema import core, channels, mixins, SCHEMA_URL
+import jsonschema
 
 from altair.utils import Optional, Undefined
-from .data import data_transformers
-from ... import utils
-from ...expr import core as _expr_core
-from .display import renderers, VEGALITE_VERSION, VEGAEMBED_VERSION, VEGA_VERSION
-from .theme import themes
-from .compiler import vegalite_compilers
-from ...utils._vegafusion_data import (
-    using_vegafusion as _using_vegafusion,
-    compile_with_vegafusion as _compile_with_vegafusion,
-)
-from altair.utils.data import DataType, is_data_type as _is_data_type
 from altair.utils.core import (
     to_eager_narwhals_dataframe as _to_eager_narwhals_dataframe,
 )
+from altair.utils.data import DataType
+from altair.utils.data import is_data_type as _is_data_type
+
+from ... import utils
+from ...expr import core as _expr_core
+from ...utils._vegafusion_data import (
+    compile_with_vegafusion as _compile_with_vegafusion,
+)
+from ...utils._vegafusion_data import using_vegafusion as _using_vegafusion
+from .compiler import vegalite_compilers
+from .data import data_transformers
+from .display import VEGA_VERSION, VEGAEMBED_VERSION, VEGALITE_VERSION, renderers
+from .schema import SCHEMA_URL, channels, core, mixins
 from .schema._typing import Map
+from .theme import themes
 
 if sys.version_info >= (3, 13):
     from typing import TypedDict
@@ -48,69 +50,20 @@ else:
     from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
-    from ...utils.core import DataFrameLike
     from pathlib import Path
-    from typing import Iterable, IO, Iterator
+    from typing import IO, Iterable, Iterator
+
+    from ...utils.core import DataFrameLike
 
     if sys.version_info >= (3, 13):
-        from typing import TypeIs, Required
+        from typing import Required, TypeIs
     else:
-        from typing_extensions import TypeIs, Required
+        from typing_extensions import Required, TypeIs
     if sys.version_info >= (3, 11):
-        from typing import Self, Never
+        from typing import Never, Self
     else:
-        from typing_extensions import Self, Never
+        from typing_extensions import Never, Self
 
-    from .schema.channels import Facet, Row, Column
-    from .schema.core import (
-        SchemaBase,
-        Expr,
-        PredicateComposition,
-        Binding,
-        IntervalSelectionConfig,
-        PointSelectionConfig,
-        Mark,
-        LayerRepeatMapping,
-        RepeatMapping,
-        ProjectionType,
-        ExprRef,
-        Vector2number,
-        Vector2Vector2number,
-        Vector3number,
-        Transform,
-        AggregatedFieldDef,
-        FieldName,
-        BinParams,
-        ImputeSequence,
-        ImputeMethod,
-        JoinAggregateFieldDef,
-        ParameterName,
-        Predicate,
-        LookupSelection,
-        AggregateOp,
-        SortField,
-        TimeUnit,
-        WindowFieldDef,
-        FacetFieldDef,
-        FacetedEncoding,
-        AnyMark,
-        Step,
-        RepeatRef,
-        UrlData,
-        SequenceGenerator,
-        GraticuleGenerator,
-        SphereGenerator,
-        VariableParameter,
-        TopLevelSelectionParameter,
-        SelectionParameter,
-        InlineDataset,
-        NamedData,
-        InlineData,
-        BindCheckbox,
-        BindRadioSelect,
-        BindRange,
-    )
-    from altair.utils.display import MimeBundleType
     from altair.expr.core import (
         BinaryExpression,
         Expression,
@@ -118,21 +71,72 @@ if TYPE_CHECKING:
         GetItemExpression,
         IntoExpression,
     )
+    from altair.utils.display import MimeBundleType
+
     from .schema._typing import (
-        ImputeMethod_T,
-        SelectionType_T,
-        SelectionResolution_T,
-        SingleDefUnitChannel_T,
-        StackOffset_T,
-        ResolveMode_T,
-        ProjectionType_T,
         AggregateOp_T,
-        MultiTimeUnit_T,
-        SingleTimeUnit_T,
-        OneOrSeq,
         AutosizeType_T,
         ColorName_T,
+        ImputeMethod_T,
         LayoutAlign_T,
+        MultiTimeUnit_T,
+        OneOrSeq,
+        ProjectionType_T,
+        ResolveMode_T,
+        SelectionResolution_T,
+        SelectionType_T,
+        SingleDefUnitChannel_T,
+        SingleTimeUnit_T,
+        StackOffset_T,
+    )
+    from .schema.channels import Column, Facet, Row
+    from .schema.core import (
+        AggregatedFieldDef,
+        AggregateOp,
+        AnyMark,
+        BindCheckbox,
+        Binding,
+        BindRadioSelect,
+        BindRange,
+        BinParams,
+        Expr,
+        ExprRef,
+        FacetedEncoding,
+        FacetFieldDef,
+        FieldName,
+        GraticuleGenerator,
+        ImputeMethod,
+        ImputeSequence,
+        InlineData,
+        InlineDataset,
+        IntervalSelectionConfig,
+        JoinAggregateFieldDef,
+        LayerRepeatMapping,
+        LookupSelection,
+        Mark,
+        NamedData,
+        ParameterName,
+        PointSelectionConfig,
+        Predicate,
+        PredicateComposition,
+        ProjectionType,
+        RepeatMapping,
+        RepeatRef,
+        SchemaBase,
+        SelectionParameter,
+        SequenceGenerator,
+        SortField,
+        SphereGenerator,
+        Step,
+        TimeUnit,
+        TopLevelSelectionParameter,
+        Transform,
+        UrlData,
+        VariableParameter,
+        Vector2number,
+        Vector2Vector2number,
+        Vector3number,
+        WindowFieldDef,
     )
 
 __all__ = [

--- a/altair/vegalite/v5/compiler.py
+++ b/altair/vegalite/v5/compiler.py
@@ -1,8 +1,7 @@
-from ...utils._importers import import_vl_convert
-from ...utils.compiler import VegaLiteCompilerRegistry
-
 from typing import Final
 
+from ...utils._importers import import_vl_convert
+from ...utils.compiler import VegaLiteCompilerRegistry
 
 ENTRY_POINT_GROUP: Final = "altair.vegalite.v5.vegalite_compiler"
 vegalite_compilers = VegaLiteCompilerRegistry(entry_point_group=ENTRY_POINT_GROUP)

--- a/altair/vegalite/v5/compiler.py
+++ b/altair/vegalite/v5/compiler.py
@@ -1,7 +1,7 @@
 from typing import Final
 
-from ...utils._importers import import_vl_convert
-from ...utils.compiler import VegaLiteCompilerRegistry
+from altair.utils._importers import import_vl_convert
+from altair.utils.compiler import VegaLiteCompilerRegistry
 
 ENTRY_POINT_GROUP: Final = "altair.vegalite.v5.vegalite_compiler"
 vegalite_compilers = VegaLiteCompilerRegistry(entry_point_group=ENTRY_POINT_GROUP)

--- a/altair/vegalite/v5/data.py
+++ b/altair/vegalite/v5/data.py
@@ -1,7 +1,7 @@
 from typing import Final
 
-from ...utils._vegafusion_data import vegafusion_data_transformer
-from ..data import (
+from altair.utils._vegafusion_data import vegafusion_data_transformer
+from altair.vegalite.data import (
     DataTransformerRegistry,
     MaxRowsError,
     default_data_transformer,

--- a/altair/vegalite/v5/data.py
+++ b/altair/vegalite/v5/data.py
@@ -1,4 +1,8 @@
+from typing import Final
+
+from ...utils._vegafusion_data import vegafusion_data_transformer
 from ..data import (
+    DataTransformerRegistry,
     MaxRowsError,
     default_data_transformer,
     limit_rows,
@@ -6,13 +10,7 @@ from ..data import (
     to_csv,
     to_json,
     to_values,
-    DataTransformerRegistry,
 )
-
-from ...utils._vegafusion_data import vegafusion_data_transformer
-
-from typing import Final
-
 
 # ==============================================================================
 # VegaLite 5 data transformers

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
+
 from pathlib import Path
-from typing import Final, TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from ...utils.mimebundle import spec_to_mimebundle
 from ..display import (
     Displayable,
+    HTMLRenderer,
+    RendererRegistry,
     default_renderer_base,
     json_renderer_base,
-    RendererRegistry,
-    HTMLRenderer,
 )
-
 from .schema import SCHEMA_VERSION
 
 if TYPE_CHECKING:

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -3,18 +3,19 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
-from ...utils.mimebundle import spec_to_mimebundle
-from ..display import (
+from altair.utils.mimebundle import spec_to_mimebundle
+from altair.vegalite.display import (
     Displayable,
     HTMLRenderer,
     RendererRegistry,
     default_renderer_base,
     json_renderer_base,
 )
+
 from .schema import SCHEMA_VERSION
 
 if TYPE_CHECKING:
-    from ..display import DefaultRendererReturnType
+    from altair.vegalite.display import DefaultRendererReturnType
 
 
 VEGALITE_VERSION: Final = SCHEMA_VERSION.lstrip("v")

--- a/altair/vegalite/v5/schema/_typing.py
+++ b/altair/vegalite/v5/schema/_typing.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from typing import Any, Literal, Mapping, Sequence, TypeVar, Union
-
 from typing_extensions import TypeAlias, TypeAliasType
 
 __all__ = [

--- a/altair/vegalite/v5/schema/mixins.py
+++ b/altair/vegalite/v5/schema/mixins.py
@@ -14,7 +14,6 @@ from . import core
 if TYPE_CHECKING:
     from altair import Parameter, SchemaBase
 
-
 if sys.version_info >= (3, 11):
     from typing import Self
 else:

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -1,6 +1,7 @@
 """Tools for enabling and registering chart themes."""
 
 from __future__ import annotations
+
 from typing import Final
 
 from ...utils.theme import ThemeRegistry

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from ...utils.theme import ThemeRegistry
+from altair.utils.theme import ThemeRegistry
 
 VEGA_THEMES = [
     "ggplot2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,8 +313,6 @@ select = [
     "ANN",
     # unsorted-imports
     "I001",
-    # missing-required-import
-    # "I002",
 ]
 ignore = [  
     # Whitespace before ':'
@@ -376,7 +374,6 @@ known-first-party=[
     "vegafusion",
     "vl_convert",
 ]
-required-imports = ["from __future__ import annotations"]
 split-on-trailing-comma = false
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,6 +311,10 @@ select = [
     "NPY",
     # flake8-annotations
     "ANN",
+    # unsorted-imports
+    "I001",
+    # missing-required-import
+    # "I002",
 ]
 ignore = [  
     # Whitespace before ':'
@@ -362,6 +366,18 @@ ignore = [
 pydocstyle={ convention="numpy" }
 mccabe={ max-complexity=18 }
 
+[tool.ruff.lint.isort]
+classes = ["expr", "datum"]
+extra-standard-library = ["typing_extensions"]
+known-first-party=[
+    "altair_tiles",
+    "sphinxext_altair",
+    "vega_datasets",
+    "vegafusion",
+    "vl_convert",
+]
+required-imports = ["from __future__ import annotations"]
+split-on-trailing-comma = false
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 # https://docs.astral.sh/ruff/settings/#lint_flake8-tidy-imports_banned-api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,8 +321,6 @@ ignore = [
     "E266",
     # Line too long
     "E501",
-    # Relative imports are banned
-    "TID252",
     # zip() without an explicit strict= parameter set.
     # python>=3.10 only
     "B905",

--- a/sphinxext/altairgallery.py
+++ b/sphinxext/altairgallery.py
@@ -1,33 +1,32 @@
 from __future__ import annotations
 
+import collections
 import hashlib
 import json
-from pathlib import Path
 import random
-import collections
-from operator import itemgetter
-import warnings
 import shutil
-from typing import Any, TYPE_CHECKING
+import warnings
+from operator import itemgetter
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import jinja2
-
 from docutils import nodes
-from docutils.statemachine import ViewList
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import flag
-
+from docutils.statemachine import ViewList
 from sphinx.util.nodes import nested_parse_with_titles
 
-from .utils import (
-    get_docstring_and_rest,
-    prev_this_next,
-    create_thumbnail,
-    create_generic_image,
-)
 from altair.utils.execeval import eval_block
 from tests.examples_arguments_syntax import iter_examples_arguments_syntax
 from tests.examples_methods_syntax import iter_examples_methods_syntax
+
+from .utils import (
+    create_generic_image,
+    create_thumbnail,
+    get_docstring_and_rest,
+    prev_this_next,
+)
 
 if TYPE_CHECKING:
     from docutils.nodes import Node

--- a/sphinxext/schematable.py
+++ b/sphinxext/schematable.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
+
 import importlib
 import re
-from typing import Any, Iterator, Sequence
 import warnings
-from docutils import nodes, utils, frontend
+from typing import Any, Iterator, Sequence
+
+from docutils import frontend, nodes, utils
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import flag
 from myst_parser.docutils_ import Parser
 from sphinx import addnodes
 
-from tools.schemapi.utils import fix_docstring_issues, SchemaInfo
+from tools.schemapi.utils import SchemaInfo, fix_docstring_issues
 
 
 def type_description(schema: dict[str, Any]) -> str:

--- a/sphinxext/utils.py
+++ b/sphinxext/utils.py
@@ -4,8 +4,8 @@ import ast
 import hashlib
 import itertools
 import json
-from pathlib import Path
 import re
+from pathlib import Path
 from typing import Any
 
 
@@ -38,8 +38,8 @@ def create_generic_image(
     filename: Path, shape: tuple[float, float] = (200, 300), gradient: bool = True
 ) -> None:
     """Create a generic image."""
-    from PIL import Image
     import numpy as np
+    from PIL import Image
 
     assert len(shape) == 2
 

--- a/tests/expr/test_expr.py
+++ b/tests/expr/test_expr.py
@@ -8,7 +8,7 @@ from typing import Any, Iterator
 import pytest
 from jsonschema.exceptions import ValidationError
 
-from altair import ExprRef, datum, expr
+from altair import datum, expr, ExprRef
 from altair.expr import _ConstExpressionType
 
 # This maps vega expression function names to the Python name

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -21,15 +21,15 @@ from __future__ import annotations
 
 import io
 import pkgutil
+import re
 import sys
 from typing import Any, Iterable, Iterator
-import re
+
 import pytest
 
 import altair as alt
 from altair.utils.execeval import eval_block
-from tests import examples_arguments_syntax
-from tests import examples_methods_syntax
+from tests import examples_arguments_syntax, examples_methods_syntax
 
 try:
     import vl_convert as vlc  # noqa: F401, RUF100

--- a/tests/test_jupyter_chart.py
+++ b/tests/test_jupyter_chart.py
@@ -1,7 +1,8 @@
-import altair as alt
-from vega_datasets import data
 import pandas as pd
 import pytest
+
+import altair as alt
+from vega_datasets import data
 
 # If anywidget is not installed, we will skip the tests in this file.
 try:

--- a/tests/test_magics.py
+++ b/tests/test_magics.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 try:
@@ -9,7 +10,6 @@ except ImportError:
     IPYTHON_AVAILABLE = False
 
 from altair.vegalite.v5 import VegaLite
-
 
 DATA_RECORDS = [
     {"amount": 28, "category": "A"},

--- a/tests/test_toplevel.py
+++ b/tests/test_toplevel.py
@@ -1,5 +1,4 @@
 import altair as alt
-
 from tools import update_init_file
 
 

--- a/tests/utils/test_compiler.py
+++ b/tests/utils/test_compiler.py
@@ -1,6 +1,8 @@
 import json
+
 import pytest
-from altair import vegalite_compilers, Chart
+
+from altair import Chart, vegalite_compilers
 
 try:
     import vl_convert as vlc

--- a/tests/utils/test_core.py
+++ b/tests/utils/test_core.py
@@ -1,14 +1,14 @@
 import types
-from packaging.version import Version
 from importlib.metadata import version as importlib_version
 
 import numpy as np
 import pandas as pd
 import pytest
+from packaging.version import Version
+from pandas.api.types import infer_dtype
 
 import altair as alt
-from altair.utils.core import parse_shorthand, update_nested, infer_encoding_types
-from pandas.api.types import infer_dtype
+from altair.utils.core import infer_encoding_types, parse_shorthand, update_nested
 
 json_schema_specification = alt.load_schema()["$schema"]
 json_schema_dict_str = f'{{"$schema": "{json_schema_specification}"}}'

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -1,17 +1,18 @@
 from pathlib import Path
-
 from typing import Any, Callable
-import pytest
+
+import narwhals.stable.v1 as nw
 import pandas as pd
 import polars as pl
-import narwhals.stable.v1 as nw
+import pytest
+
 from altair.utils.data import (
-    limit_rows,
     MaxRowsError,
+    limit_rows,
     sample,
-    to_values,
-    to_json,
     to_csv,
+    to_json,
+    to_values,
 )
 
 

--- a/tests/utils/test_deprecation.py
+++ b/tests/utils/test_deprecation.py
@@ -1,5 +1,7 @@
-import pytest
 import re
+
+import pytest
+
 from altair.utils.deprecation import (
     AltairDeprecationWarning,
     deprecated,

--- a/tests/utils/test_plugin_registry.py
+++ b/tests/utils/test_plugin_registry.py
@@ -1,5 +1,6 @@
-from altair.utils.plugin_registry import PluginRegistry
 from typing import Callable
+
+from altair.utils.plugin_registry import PluginRegistry
 
 
 class TypedCallableRegistry(PluginRegistry[Callable[[int], int], int]):

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1,28 +1,28 @@
 # ruff: noqa: W291
 import copy
-import io
 import inspect
+import io
 import json
-import jsonschema
-import jsonschema.exceptions
 import pickle
 import warnings
 
+import jsonschema
+import jsonschema.exceptions
 import numpy as np
 import pandas as pd
 import pytest
-from vega_datasets import data
 
 import altair as alt
 from altair import load_schema
 from altair.utils.schemapi import (
-    UndefinedType,
-    SchemaBase,
-    Undefined,
-    _FromDict,
-    SchemaValidationError,
     _DEFAULT_JSON_SCHEMA_DRAFT_URL,
+    SchemaBase,
+    SchemaValidationError,
+    Undefined,
+    UndefinedType,
+    _FromDict,
 )
+from vega_datasets import data
 
 _JSON_SCHEMA_DRAFT_URL = load_schema()["$schema"]
 # Make tests inherit from _TestSchema, so that when we test from_dict it won't

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -1,6 +1,6 @@
 """Test http server."""
 
-from altair.utils.server import serve, MockServer
+from altair.utils.server import MockServer, serve
 
 
 def test_serve():

--- a/tests/utils/test_to_values_narwhals.py
+++ b/tests/utils/test_to_values_narwhals.py
@@ -1,9 +1,10 @@
+import sys
 from datetime import datetime
 from pathlib import Path
+
+import narwhals.stable.v1 as nw
 import pandas as pd
 import pytest
-import sys
-import narwhals.stable.v1 as nw
 
 try:
     import pyarrow as pa

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -10,8 +10,8 @@ import pytest
 
 from altair.utils import (
     infer_vegalite_type_for_pandas,
-    sanitize_pandas_dataframe,
     sanitize_narwhals_dataframe,
+    sanitize_pandas_dataframe,
 )
 
 try:

--- a/tests/vegalite/test_common.py
+++ b/tests/vegalite/test_common.py
@@ -1,8 +1,7 @@
 """Tests of functionality that should work in all vegalite versions."""
 
-import pytest
-
 import pandas as pd
+import pytest
 
 from altair.vegalite import v5
 

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -2,25 +2,24 @@
 
 from __future__ import annotations
 
-
-from datetime import date
 import io
-import ibis
-import sys
 import json
 import operator
 import os
 import pathlib
 import re
+import sys
 import tempfile
+from datetime import date
 from importlib.metadata import version as importlib_version
-from packaging.version import Version
 
+import ibis
 import jsonschema
 import narwhals.stable.v1 as nw
-import pytest
 import pandas as pd
 import polars as pl
+import pytest
+from packaging.version import Version
 
 import altair as alt
 from altair.utils.schemapi import Undefined
@@ -528,6 +527,7 @@ def test_when_labels_position_based_on_condition() -> None:
     """
     import numpy as np
     import pandas as pd
+
     from altair.utils.schemapi import SchemaValidationError
 
     rand = np.random.RandomState(42)

--- a/tests/vegalite/v5/test_geo_interface.py
+++ b/tests/vegalite/v5/test_geo_interface.py
@@ -1,4 +1,5 @@
 import pytest
+
 import altair.vegalite.v5 as alt
 
 

--- a/tests/vegalite/v5/test_params.py
+++ b/tests/vegalite/v5/test_params.py
@@ -1,11 +1,10 @@
 """Tests for variable parameters and selection parameters."""
 
-import pandas as pd
-
-import warnings
-import pytest
-
 import re
+import warnings
+
+import pandas as pd
+import pytest
 
 import altair.vegalite.v5 as alt
 from altair.utils.deprecation import AltairDeprecationWarning

--- a/tests/vegalite/v5/test_renderers.py
+++ b/tests/vegalite/v5/test_renderers.py
@@ -6,7 +6,6 @@ import pytest
 
 import altair.vegalite.v5 as alt
 
-
 try:
     import vl_convert as vlc
 except ImportError:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,4 +1,4 @@
-from tools import schemapi, generate_api_docs, generate_schema_wrapper, update_init_file
+from tools import generate_api_docs, generate_schema_wrapper, schemapi, update_init_file
 
 __all__ = [
     "generate_api_docs",

--- a/tools/generate_api_docs.py
+++ b/tools/generate_api_docs.py
@@ -1,10 +1,11 @@
 """Fills the contents of doc/user_guide/api.rst based on the updated Altair schema."""
 
 from __future__ import annotations
-from pathlib import Path
+
 import types
-from typing import Final, Iterator
+from pathlib import Path
 from types import ModuleType
+from typing import Final, Iterator
 
 import altair as alt
 

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -1,30 +1,30 @@
 """Generate a schema wrapper from a schema."""
 
 from __future__ import annotations
+
 import argparse
 import copy
 import json
-from pathlib import Path
 import re
 import sys
 import textwrap
 from dataclasses import dataclass
-from typing import Final, Iterable, Literal, Iterator
 from itertools import chain
+from pathlib import Path
+from typing import Final, Iterable, Iterator, Literal
 from urllib import request
 
 sys.path.insert(0, str(Path.cwd()))
-from tools.schemapi import codegen, CodeSnippet, SchemaInfo
+from tools.schemapi import CodeSnippet, SchemaInfo, codegen
 from tools.schemapi.utils import (
     get_valid_identifier,
-    resolve_references,
-    ruff_format_py,
-    rst_syntax_for_class,
     indent_docstring,
-    ruff_write_lint_format_str,
+    resolve_references,
     rst_parse,
+    rst_syntax_for_class,
+    ruff_format_py,
+    ruff_write_lint_format_str,
 )
-
 
 SCHEMA_VERSION: Final = "v5.19.0"
 

--- a/tools/schemapi/__init__.py
+++ b/tools/schemapi/__init__.py
@@ -1,8 +1,8 @@
 """schemapi: tools for generating Python APIs from JSON schemas."""
 
-from tools.schemapi.schemapi import SchemaBase, Undefined
-from tools.schemapi.utils import SchemaInfo
 from tools.schemapi import codegen, utils
 from tools.schemapi.codegen import CodeSnippet
+from tools.schemapi.schemapi import SchemaBase, Undefined
+from tools.schemapi.utils import SchemaInfo
 
 __all__ = ["CodeSnippet", "SchemaBase", "SchemaInfo", "Undefined", "codegen", "utils"]

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -1,17 +1,18 @@
 """Code generation utilities."""
 
 from __future__ import annotations
+
 import re
 import textwrap
-from typing import Final
 from dataclasses import dataclass
+from typing import Final
 
 from .utils import (
     SchemaInfo,
-    is_valid_identifier,
-    indent_docstring,
-    jsonschema_to_python_types,
     flatten,
+    indent_docstring,
+    is_valid_identifier,
+    jsonschema_to_python_types,
 )
 
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -4,28 +4,29 @@ import contextlib
 import copy
 import inspect
 import json
+import sys
 import textwrap
-from math import ceil
 from collections import defaultdict
+from functools import partial
 from importlib.metadata import version as importlib_version
 from itertools import chain, zip_longest
-import sys
+from math import ceil
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
     Final,
     Iterable,
     Iterator,
+    List,
     Literal,
     Sequence,
     TypeVar,
     Union,
     overload,
-    List,
-    Dict,
 )
 from typing_extensions import TypeAlias
-from functools import partial
+
 import jsonschema
 import jsonschema.exceptions
 import jsonschema.validators
@@ -37,10 +38,11 @@ from packaging.version import Version
 from altair import vegalite
 
 if TYPE_CHECKING:
+    from typing import ClassVar
+
     from referencing import Registry
 
     from altair import ChartType
-    from typing import ClassVar
 
     if sys.version_info >= (3, 13):
         from typing import TypeIs
@@ -48,9 +50,9 @@ if TYPE_CHECKING:
         from typing_extensions import TypeIs
 
     if sys.version_info >= (3, 11):
-        from typing import Self, Never
+        from typing import Never, Self
     else:
-        from typing_extensions import Self, Never
+        from typing_extensions import Never, Self
 
 ValidationErrorList: TypeAlias = List[jsonschema.exceptions.ValidationError]
 GroupedValidationErrors: TypeAlias = Dict[str, ValidationErrorList]

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -1,15 +1,16 @@
 """Utilities for working with schemas."""
 
 from __future__ import annotations
-from itertools import chain
+
 import keyword
 import re
 import subprocess
 import textwrap
 import urllib
-from typing import Any, Final, Iterable, TYPE_CHECKING, Iterator, Sequence
-from operator import itemgetter
 from html import unescape
+from itertools import chain
+from operator import itemgetter
+from typing import TYPE_CHECKING, Any, Final, Iterable, Iterator, Sequence
 
 import mistune
 from mistune.renderers.rst import RSTRenderer as _RSTRenderer
@@ -17,9 +18,10 @@ from mistune.renderers.rst import RSTRenderer as _RSTRenderer
 from tools.schemapi.schemapi import _resolve_references as resolve_references
 
 if TYPE_CHECKING:
-    from mistune import BlockState
-    from typing_extensions import LiteralString
     from pathlib import Path
+    from typing_extensions import LiteralString
+
+    from mistune import BlockState
 
 EXCLUDE_KEYS: Final = ("definitions", "title", "description", "$schema", "id")
 

--- a/tools/update_init_file.py
+++ b/tools/update_init_file.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from inspect import ismodule, getattr_static
-from pathlib import Path
-from typing import TYPE_CHECKING
 import typing as t
 import typing_extensions as te
+from inspect import getattr_static, ismodule
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from tools.schemapi.utils import ruff_write_lint_format_str
 


### PR DESCRIPTION
This PR defines and applies import rules.

Something like this had been on my radar for a while, adding this now seems to be the least disruptive time.

Autogenerated code already had `I001` applied for import sorting:
https://github.com/vega/altair/blob/a84783359b933b371dad1d1f1233304c5daf84e5/tools/schemapi/utils.py#L830-L847

In addition to the visual changes, this makes navigating via imports much easier.

# Ruff links
- https://docs.astral.sh/ruff/rules/#isort-i
- https://docs.astral.sh/ruff/settings/#lintisort

# Related Issues
- https://github.com/vega/altair/issues/3337
  - Will be much easier now that all references are absolute
  - https://code.visualstudio.com/docs/python/editing#_rename-module
  - https://code.visualstudio.com/docs/python/editing#_move-symbol