### PR TITLE
feat: Adds 4 missing `carbon` themes, provide autocomplete

### DIFF
--- a/altair/utils/theme.py
+++ b/altair/utils/theme.py
@@ -1,11 +1,49 @@
 """Utilities for registering and working with themes."""
 
-from typing import Callable
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Callable
 
 from .plugin_registry import PluginRegistry
+
+if sys.version_info >= (3, 11):
+    from typing import LiteralString
+else:
+    from typing_extensions import LiteralString
+
+if TYPE_CHECKING:
+    from altair.utils.plugin_registry import PluginEnabler
+    from altair.vegalite.v5.theme import _ThemeName
 
 ThemeType = Callable[..., dict]
 
 
 class ThemeRegistry(PluginRegistry[ThemeType, dict]):
-    pass
+    def enable(
+        self, name: LiteralString | _ThemeName | None = None, **options
+    ) -> PluginEnabler:
+        """
+        Enable a theme by name.
+
+        This can be either called directly, or used as a context manager.
+
+        Parameters
+        ----------
+        name : string (optional)
+            The name of the theme to enable. If not specified, then use the
+            current active name.
+        **options :
+            Any additional parameters will be passed to the theme as keyword
+            arguments
+
+        Returns
+        -------
+        PluginEnabler:
+            An object that allows enable() to be used as a context manager
+
+        Notes
+        -----
+        Default `vega` themes can be previewed at https://vega.github.io/vega-themes/
+        """
+        return super().enable(name, **options)

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -7,6 +7,10 @@ from typing import Final
 from altair.utils.theme import ThemeRegistry
 
 VEGA_THEMES = [
+    "carbonwhite",
+    "carbong10",
+    "carbong90",
+    "carbong100",
     "dark",
     "excel",
     "fivethirtyeight",

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import TypeAlias
 
+    # If you add a theme here, also add it in `VEGA_THEMES` below.
     _ThemeName: TypeAlias = Literal[
         "default",
         "carbonwhite",
@@ -33,6 +34,7 @@ if TYPE_CHECKING:
         "vox",
     ]
 
+# If you add a theme here, also add it in `_ThemeName` above.
 VEGA_THEMES = [
     "carbonwhite",
     "carbong10",

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -7,16 +7,16 @@ from typing import Final
 from altair.utils.theme import ThemeRegistry
 
 VEGA_THEMES = [
-    "ggplot2",
-    "quartz",
-    "vox",
-    "fivethirtyeight",
     "dark",
-    "latimes",
-    "urbaninstitute",
     "excel",
+    "fivethirtyeight",
+    "ggplot2",
     "googlecharts",
+    "latimes",
     "powerbi",
+    "quartz",
+    "urbaninstitute",
+    "vox",
 ]
 
 

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -2,9 +2,36 @@
 
 from __future__ import annotations
 
-from typing import Final
+from typing import TYPE_CHECKING, Final, Literal
 
 from altair.utils.theme import ThemeRegistry
+
+if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+
+    _ThemeName: TypeAlias = Literal[
+        "default",
+        "carbonwhite",
+        "carbong10",
+        "carbong90",
+        "carbong100",
+        "dark",
+        "excel",
+        "fivethirtyeight",
+        "ggplot2",
+        "googlecharts",
+        "latimes",
+        "opaque",
+        "powerbi",
+        "quartz",
+        "urbaninstitute",
+        "vox",
+    ]
 
 VEGA_THEMES = [
     "carbonwhite",

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -69,7 +69,7 @@ class VegaTheme:
 
 # The entry point group that can be used by other packages to declare other
 # themes that will be auto-detected. Explicit registration is also
-# allowed by the PluginRegistery API.
+# allowed by the PluginRegistry API.
 ENTRY_POINT_GROUP: Final = "altair.vegalite.v5.theme"
 themes = ThemeRegistry(entry_point_group=ENTRY_POINT_GROUP)
 


### PR DESCRIPTION
# Related 
- https://github.com/vega/vega-themes/pull/587
- https://github.com/pola-rs/polars/pull/17995#issuecomment-2266683585


# Examples 
- https://vega.github.io/vega-themes/?theme=carbonwhite
- https://vega.github.io/vega-themes/?theme=carbong10
- https://vega.github.io/vega-themes/?theme=carbong90
- https://vega.github.io/vega-themes/?theme=carbong100


![image](https://github.com/user-attachments/assets/b559166b-a434-4f41-b61d-0ca392d56e4e)

![image](https://github.com/user-attachments/assets/30c4b61b-7f69-46d8-9987-2c765f5c3ca3)

![image](https://github.com/user-attachments/assets/0c1df2c1-efe7-4007-a05e-968deda9482b)

![image](https://github.com/user-attachments/assets/5349cb47-ed11-485e-b821-562272fd7ac1)

# Bonus

Support autocomplete for `themes.enable(name)`.

![image](https://github.com/user-attachments/assets/3cb99d06-ed9c-45f9-972f-3543b8da80e2)
