### PR TITLE
chore: Remove filterwarnings from tests for cross-version pandas compatibility

### DIFF
--- a/tests/examples_arguments_syntax/bump_chart.py
+++ b/tests/examples_arguments_syntax/bump_chart.py
@@ -12,7 +12,7 @@ from vega_datasets import data
 import pandas as pd
 
 stocks = data.stocks()
-source = stocks.groupby([pd.Grouper(key="date", freq="6M"),"symbol"]).mean().reset_index()
+source = stocks.groupby([pd.Grouper(key="date", freq="6MS"),"symbol"]).mean().reset_index()
 
 alt.Chart(source).mark_line(point = True).encode(
     x = alt.X("date:O", timeUnit="yearmonth", title="date"),

--- a/tests/examples_methods_syntax/bump_chart.py
+++ b/tests/examples_methods_syntax/bump_chart.py
@@ -12,7 +12,7 @@ from vega_datasets import data
 import pandas as pd
 
 stocks = data.stocks()
-source = stocks.groupby([pd.Grouper(key="date", freq="6M"),"symbol"]).mean().reset_index()
+source = stocks.groupby([pd.Grouper(key="date", freq="6MS"),"symbol"]).mean().reset_index()
 
 alt.Chart(source).mark_line(point=True).encode(
     x=alt.X("date:O").timeUnit("yearmonth").title("date"),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -82,7 +82,6 @@ def id_func(val) -> str:
 
 
 @pytest.mark.filterwarnings(
-    "ignore:'M' is deprecated.*:FutureWarning",
     "ignore:DataFrameGroupBy.apply.*:DeprecationWarning",
 )
 @pytest.mark.parametrize(("source", "filename"), distributed_examples, ids=id_func)
@@ -102,7 +101,6 @@ def test_render_examples_to_chart(source, filename) -> None:
 
 
 @pytest.mark.filterwarnings(
-    "ignore:'M' is deprecated.*:FutureWarning",
     "ignore:DataFrameGroupBy.apply.*:DeprecationWarning",
 )
 @pytest.mark.parametrize(("source", "filename"), distributed_examples, ids=id_func)
@@ -134,7 +132,6 @@ def test_from_and_to_json_roundtrip(source, filename) -> None:
 
 
 @pytest.mark.filterwarnings(
-    "ignore:'M' is deprecated.*:FutureWarning",
     "ignore:DataFrameGroupBy.apply.*:DeprecationWarning",
 )
 @pytest.mark.parametrize(("source", "filename"), distributed_examples, ids=id_func)

--- a/tests/test_transformed_data.py
+++ b/tests/test_transformed_data.py
@@ -17,7 +17,6 @@ XDIST_ENABLED: bool = "xdist" in sys.modules
 """Use as an `xfail` condition, if running in parallel may cause the test to fail."""
 
 @pytest.mark.filterwarnings(
-    "ignore:'M' is deprecated.*:FutureWarning",
     "ignore:DataFrameGroupBy.apply.*:DeprecationWarning"
 )
 @pytest.mark.skipif(vf is None, reason="vegafusion not installed")
@@ -29,7 +28,7 @@ XDIST_ENABLED: bool = "xdist" in sys.modules
     ("bar_chart_faceted_compact.py", 27, ["p", "p_end"]),
     ("beckers_barley_facet.py", 120, ["year", "site"]),
     ("beckers_barley_wrapped_facet.py", 120, ["site", "median_yield"]),
-    ("bump_chart.py", 100, ["rank", "yearmonth_date"]),
+    ("bump_chart.py", 96, ["rank", "yearmonth_date"]),
     ("comet_chart.py", 120, ["variety", "delta"]),
     ("diverging_stacked_bar_chart.py", 40, ["value", "percentage_start"]),
     ("donut_chart.py", 6, ["value_start", "value_end"]),

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -45,7 +45,6 @@ def test_infer_vegalite_type():
             _check([], "nominal")
 
 
-@pytest.mark.filterwarnings("ignore:'H' is deprecated.*:FutureWarning")
 def test_sanitize_dataframe():
     # create a dataframe with various types
     df = pd.DataFrame(
@@ -129,7 +128,6 @@ def test_sanitize_dataframe_arrow_columns():
     json.dumps(records)
 
 
-@pytest.mark.filterwarnings("ignore:'H' is deprecated.*:FutureWarning")
 @pytest.mark.skipif(pa is None, reason="pyarrow not installed")
 @pytest.mark.xfail(
     sys.platform == "win32", reason="Timezone database is not installed on Windows"

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -328,11 +328,10 @@ def test_multiple_encodings(args, kwargs):
     assert dct["encoding"]["tooltip"] == encoding_dct
 
 
-@pytest.mark.filterwarnings("ignore:'Y' is deprecated.*:FutureWarning")
 def test_chart_operations():
     data = pd.DataFrame(
         {
-            "x": pd.date_range("2012", periods=10, freq="Y"),
+            "x": pd.date_range("2012", periods=10, freq="YS"),
             "y": range(10),
             "c": list("abcabcabca"),
         }


### PR DESCRIPTION
pandas has two month-related offsets:
- MonthBegin, which is aliased to 'MS'
- MonthEnd, which is aliased to 'M' and is being renamed to 'ME' (because it was a common source of confusion, people would see 'M' and expect it to mean 'month', not 'month end'... https://github.com/pandas-dev/pandas/issues/9586)

When doing a monthly group-by, I think the first one gives the results that people are usually actually looking for, and is the same across versions, hence removing the need for filterwarnings or version checks

In the `bump_chart.py` example:
- grouping by `'6MS'` means that the windows are:
  - [2000-01-01, 2000-07-01)
  - [2000-07-01, 2001-01-01)
  - ...
- grouping by '6M' (or, now, '6ME') means that the windows are:
  - (1999-07-31 23:59:59.999999999, 2000-01-31 23:59:59.999999999]
  - (2000-01-31 23:59:59.999999999, 2000-07-31 23:59:59.999999999]
  - (2000-07-31 23:59:59.999999999, 2001-01-31 23:59:59.999999999]

I think the former is a much more natural way of thinking about time series, and so is better suited to the examples anyway (in addition to helping avoid `filterwarnings`

---

Output:

**before**

![image](https://github.com/user-attachments/assets/4b4dcd95-ef5c-4e8d-8057-40c03a9ac780)


**after**

![image](https://github.com/user-attachments/assets/c8dd86b7-fe52-4280-ace9-c145ded1552e)

Due to the explanation above, I think the second one would align more closely without how people would read the chart