### PR TITLE
docs: Link to `Vega Theme Test` in user guide

### DIFF
--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -763,6 +763,8 @@ If you would like to use any theme just for a single chart, you can use the
 Currently Altair does not offer many built-in themes, but we plan to add
 more options in the future.
 
+See `Vega Theme Test`_ for an interactive demo of themes inherited from `Vega Themes`_.
+
 Defining a Custom Theme
 ~~~~~~~~~~~~~~~~~~~~~~~
 The theme registry also allows defining and registering custom themes.
@@ -861,3 +863,4 @@ The configured localization settings persist upon saving.
 
 .. _Vega Themes: https://github.com/vega/vega-themes/
 .. _`D3's localization support`: https://d3-wiki.readthedocs.io/zh-cn/master/Localization/
+.. _Vega Theme Test: https://vega.github.io/vega-themes/?renderer=canvas


### PR DESCRIPTION
Resolves 1 item in https://github.com/vega/altair/issues/3519

[Vega Theme Test](https://vega.github.io/vega-themes/?renderer=canvas)

![image](https://github.com/user-attachments/assets/0a039d54-bdb7-4631-9cdb-825fdb45cb44)
