### PR TITLE
ci: Remove `m2r` from `mypy.overrides`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -423,7 +423,6 @@ module = [
     "nbformat.*",
     "ipykernel.*",
     "ibis.*",
-    "m2r.*",
     # This refers to schemapi in the tools folder which is imported
     # by the tools scripts such as generate_schema_wrapper.py
     "schemapi.*"


### PR DESCRIPTION
Not needed since #3506