### PR TITLE
revert: Remove `sphinx` version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -425,7 +425,6 @@ module = [
     "nbformat.*",
     "ipykernel.*",
     "ibis.*",
-    "m2r.*",
     # This refers to schemapi in the tools folder which is imported
     # by the tools scripts such as generate_schema_wrapper.py
     "schemapi.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ all = [
 ]
 dev = [
     "hatch",
-    "ruff>=0.5.7",
+    "ruff>=0.6.0",
     "ibis-framework[polars]",
     "ipython[kernel]",
     "pandas>=0.25.3",
@@ -231,7 +231,9 @@ extend-safe-fixes=[
     # ends-in-period
     "D400",
     # missing-return-type-special-method 
-    "ANN204"
+    "ANN204",
+    # unnecessary-dict-comprehension-for-iterable
+    "C420",
 ]
 
 # https://docs.astral.sh/ruff/preview/#using-rules-that-are-in-preview

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dev = [
     "polars>=0.20.3",
 ]
 doc = [
-    "sphinx>=8.0.0",
+    "sphinx",
     "docutils",
     "sphinxext_altair",
     "jinja2",


### PR DESCRIPTION
Partially reverts https://github.com/vega/altair/pull/3527

Didn't fix the issue in https://github.com/vega/altair/pull/3515#discussion_r1709995028

Caused a **local** regression when running `hatch test --all`

```cmd
>>> hatch test --python 3.8       
────────────────────────────────────────────────────────────────────────────────────────────────────── hatch-test.py3.8 ───────────────────────────────────────────────────────────────────────────────────────────────────────
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of myst-parser are available:
          myst-parser<=0.4.0
          myst-parser>=0.5.0,<=0.5.1
          myst-parser>=0.6.0,<=0.7.1
          myst-parser>=0.8.0,<=0.13.7
          myst-parser>=0.14.0
      and myst-parser==0.3.0 was yanked (reason: no sphinx pinning), we can
      conclude that any of:
          myst-parser<0.3.1
          myst-parser>0.4.0,<0.5.0
          myst-parser>0.5.1,<0.6.0
          myst-parser>0.7.1,<0.8.0
          myst-parser>0.13.7,<0.14.0
       cannot be used.
      And because myst-parser==0.3.1 was yanked (reason: no sphinx pinning)
      and myst-parser==0.3.2 was yanked (reason: no sphinx pinning), we can
      conclude that any of:
          myst-parser<0.4.0
          myst-parser>0.4.0,<0.5.0
          myst-parser>0.5.1,<0.6.0
          myst-parser>0.7.1,<0.8.0
          myst-parser>0.13.7,<0.14.0
       cannot be used.
      And because myst-parser==0.4.0 was yanked (reason: no sphinx pinning)
      and myst-parser==0.5.0 was yanked (reason: no sphinx pinning), we can
      conclude that any of:
          myst-parser<0.5.1
          myst-parser>0.5.1,<0.6.0
          myst-parser>0.7.1,<0.8.0
          myst-parser>0.13.7,<0.14.0
       cannot be used.
      And because myst-parser==0.5.1 was yanked (reason: no sphinx pinning)
      and myst-parser==0.6.0 was yanked (reason: no sphinx pinning), we can
      conclude that any of:
          myst-parser<0.7.0
          myst-parser>0.7.1,<0.8.0
          myst-parser>0.13.7,<0.14.0
       cannot be used.
      And because myst-parser==0.7.0 was yanked (reason: no sphinx pinning)
      and myst-parser==0.7.1 was yanked (reason: no sphinx pinning), we can
      conclude that any of:
          myst-parser<0.8.0
          myst-parser>0.13.7,<0.14.0
       cannot be used.
      And because myst-parser==0.8.0 was yanked (reason: no sphinx pinning)
      and myst-parser==0.8.1 was yanked (reason: no sphinx pinning), we can
      conclude that any of:
          myst-parser<0.8.2
          myst-parser>0.13.7,<0.14.0
       cannot be used.
      And because myst-parser==0.8.2 was yanked (reason: no sphinx pinning)
      and myst-parser>=0.9.0,<=0.9.1 depends on sphinx>=2,<3, we can conclude
      that any of:
          myst-parser<0.10.0
          myst-parser>0.13.7,<0.14.0
      depend on sphinx>=2,<3.
      And because any of:
          myst-parser>=0.10.0,<=0.13.3
          myst-parser>=0.13.5,<=0.13.6
      depend on sphinx>=2,<4 and myst-parser==0.13.4 was yanked (reason:
      Extensions bug regression), we can conclude that any of:
          myst-parser<0.13.7
          myst-parser>0.13.7,<0.14.0
      depend on sphinx>=2,<4.
      And because any of:
          myst-parser==0.13.7
          myst-parser==0.14.0
      depend on sphinx>=2.1,<4 and sphinx>=3,<5, we can conclude that
      myst-parser<0.15.2 depends on sphinx>=2,<5.
      And because myst-parser>=0.15.2,<=0.17.2 depends on sphinx>=3.1,<5
      and sphinx>=4,<6, we can conclude that myst-parser<0.19.0 depends on
      sphinx>=2,<6.
      And because myst-parser>=0.19.0,<=1.0.0 depends on sphinx>=5,<7
      and sphinx>=6,<8, we can conclude that myst-parser<4.0.0 depends on
      sphinx>=2,<8. (1)

      Because the current Python version (3.8.19) does not satisfy Python>=3.9
      and myst-parser==4.0.0 depends on Python>=3.10, we can conclude that
      myst-parser==4.0.0 cannot be used.
      And because we know from (1) that myst-parser<4.0.0 depends on
      sphinx>=2,<8, we can conclude that all versions of myst-parser depend
      on sphinx>=2,<8.
      And because altair[doc]==5.5.0.dev0 depends on myst-parser and
      sphinx>=8.0.0, we can conclude that altair[doc]==5.5.0.dev0 cannot be
      used.
      And because only altair[doc]==5.5.0.dev0 is available and you require
      altair[doc], we can conclude that the requirements are unsatisfiable.

      hint: Pre-releases are available for myst-parser in the requested
      range (e.g., 0.14.0a3), but pre-releases weren't enabled (try:
      `--prerelease=allow`)
```