### PR TITLE
refactor: Simplify `SchemaBase.copy`

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -931,21 +931,11 @@ class SchemaBase:
             A list of keys for which the contents should not be copied, but
             only stored by reference.
         """
-        try:
-            deep = list(deep)  # type: ignore[arg-type]
-        except TypeError:
-            deep_is_list = False
-        else:
-            deep_is_list = True
-
-        if deep and not deep_is_list:
+        if deep is True:
             return cast("Self", _deep_copy(self, ignore=ignore))
-
         with debug_mode(False):
             copy = self.__class__(*self._args, **self._kwds)
-        if deep_is_list:
-            # Assert statement is for the benefit of Mypy
-            assert isinstance(deep, list)
+        if _is_iterable(deep):
             for attr in deep:
                 copy[attr] = _shallow_copy(copy._get(attr))
         return copy

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -841,9 +841,7 @@ def _shallow_copy(obj: Any) -> Any: ...
 def _shallow_copy(obj: _CopyImpl | Any) -> _CopyImpl | Any:
     if isinstance(obj, SchemaBase):
         return obj.copy(deep=False)
-    elif isinstance(obj, list):
-        return obj[:]
-    elif isinstance(obj, dict):
+    elif isinstance(obj, (list, dict)):
         return obj.copy()
     else:
         return obj

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -848,29 +848,20 @@ def _shallow_copy(obj: _CopyImpl | Any) -> _CopyImpl | Any:
 
 
 @overload
-def _deep_copy(obj: _CopyImpl, ignore: Any = ...) -> _CopyImpl: ...
+def _deep_copy(obj: _CopyImpl, by_ref: set[str]) -> _CopyImpl: ...
 @overload
-def _deep_copy(obj: Any, ignore: Any = ...) -> Any: ...
-def _deep_copy(
-    obj: _CopyImpl | Any, ignore: list[str] | None = None
-) -> _CopyImpl | Any:
-    if ignore is None:
-        ignore = []
+def _deep_copy(obj: Any, by_ref: set[str]) -> Any: ...
+def _deep_copy(obj: _CopyImpl | Any, by_ref: set[str]) -> _CopyImpl | Any:
+    copy = partial(_deep_copy, by_ref=by_ref)
     if isinstance(obj, SchemaBase):
-        args = tuple(_deep_copy(arg) for arg in obj._args)
-        kwds = {
-            k: (_deep_copy(v, ignore=ignore) if k not in ignore else v)
-            for k, v in obj._kwds.items()
-        }
+        args = (copy(arg) for arg in obj._args)
+        kwds = {k: (copy(v) if k not in by_ref else v) for k, v in obj._kwds.items()}
         with debug_mode(False):
             return obj.__class__(*args, **kwds)
     elif isinstance(obj, list):
-        return [_deep_copy(v, ignore=ignore) for v in obj]
+        return [copy(v) for v in obj]
     elif isinstance(obj, dict):
-        return {
-            k: (_deep_copy(v, ignore=ignore) if k not in ignore else v)
-            for k, v in obj.items()
-        }
+        return {k: (copy(v) if k not in by_ref else v) for k, v in obj.items()}
     else:
         return obj
 
@@ -930,7 +921,7 @@ class SchemaBase:
             only stored by reference.
         """
         if deep is True:
-            return cast("Self", _deep_copy(self, ignore=ignore))
+            return cast("Self", _deep_copy(self, set(ignore) if ignore else set()))
         with debug_mode(False):
             copy = self.__class__(*self._args, **self._kwds)
         if _is_iterable(deep):

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -25,6 +25,7 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 from typing_extensions import TypeAlias
@@ -833,6 +834,49 @@ def is_undefined(obj: Any) -> TypeIs[UndefinedType]:
     return obj is Undefined
 
 
+@overload
+def _shallow_copy(obj: _CopyImpl) -> _CopyImpl: ...
+@overload
+def _shallow_copy(obj: Any) -> Any: ...
+def _shallow_copy(obj: _CopyImpl | Any) -> _CopyImpl | Any:
+    if isinstance(obj, SchemaBase):
+        return obj.copy(deep=False)
+    elif isinstance(obj, list):
+        return obj[:]
+    elif isinstance(obj, dict):
+        return obj.copy()
+    else:
+        return obj
+
+
+@overload
+def _deep_copy(obj: _CopyImpl, ignore: Any = ...) -> _CopyImpl: ...
+@overload
+def _deep_copy(obj: Any, ignore: Any = ...) -> Any: ...
+def _deep_copy(
+    obj: _CopyImpl | Any, ignore: list[str] | None = None
+) -> _CopyImpl | Any:
+    if ignore is None:
+        ignore = []
+    if isinstance(obj, SchemaBase):
+        args = tuple(_deep_copy(arg) for arg in obj._args)
+        kwds = {
+            k: (_deep_copy(v, ignore=ignore) if k not in ignore else v)
+            for k, v in obj._kwds.items()
+        }
+        with debug_mode(False):
+            return obj.__class__(*args, **kwds)
+    elif isinstance(obj, list):
+        return [_deep_copy(v, ignore=ignore) for v in obj]
+    elif isinstance(obj, dict):
+        return {
+            k: (_deep_copy(v, ignore=ignore) if k not in ignore else v)
+            for k, v in obj.items()
+        }
+    else:
+        return obj
+
+
 class SchemaBase:
     """
     Base class for schema wrappers.
@@ -870,7 +914,7 @@ class SchemaBase:
         if DEBUG_MODE and self._class_is_valid_at_instantiation:
             self.to_dict(validate=True)
 
-    def copy(  # noqa: C901
+    def copy(
         self, deep: bool | Iterable[Any] = True, ignore: list[str] | None = None
     ) -> Self:
         """
@@ -887,38 +931,6 @@ class SchemaBase:
             A list of keys for which the contents should not be copied, but
             only stored by reference.
         """
-
-        def _shallow_copy(obj):
-            if isinstance(obj, SchemaBase):
-                return obj.copy(deep=False)
-            elif isinstance(obj, list):
-                return obj[:]
-            elif isinstance(obj, dict):
-                return obj.copy()
-            else:
-                return obj
-
-        def _deep_copy(obj, ignore: list[str] | None = None):
-            if ignore is None:
-                ignore = []
-            if isinstance(obj, SchemaBase):
-                args = tuple(_deep_copy(arg) for arg in obj._args)
-                kwds = {
-                    k: (_deep_copy(v, ignore=ignore) if k not in ignore else v)
-                    for k, v in obj._kwds.items()
-                }
-                with debug_mode(False):
-                    return obj.__class__(*args, **kwds)
-            elif isinstance(obj, list):
-                return [_deep_copy(v, ignore=ignore) for v in obj]
-            elif isinstance(obj, dict):
-                return {
-                    k: (_deep_copy(v, ignore=ignore) if k not in ignore else v)
-                    for k, v in obj.items()
-                }
-            else:
-                return obj
-
         try:
             deep = list(deep)  # type: ignore[arg-type]
         except TypeError:
@@ -927,7 +939,7 @@ class SchemaBase:
             deep_is_list = True
 
         if deep and not deep_is_list:
-            return _deep_copy(self, ignore=ignore)
+            return cast("Self", _deep_copy(self, ignore=ignore))
 
         with debug_mode(False):
             copy = self.__class__(*self._args, **self._kwds)
@@ -1239,6 +1251,13 @@ class SchemaBase:
 
 
 TSchemaBase = TypeVar("TSchemaBase", bound=SchemaBase)
+
+_CopyImpl = TypeVar("_CopyImpl", SchemaBase, Dict[Any, Any], List[Any])
+"""
+Types which have an implementation in ``SchemaBase.copy()``.
+
+All other types are returned **by reference**.
+"""
 
 
 def _is_dict(obj: Any | dict[Any, Any]) -> TypeIs[dict[Any, Any]]:

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -929,21 +929,11 @@ class SchemaBase:
             A list of keys for which the contents should not be copied, but
             only stored by reference.
         """
-        try:
-            deep = list(deep)  # type: ignore[arg-type]
-        except TypeError:
-            deep_is_list = False
-        else:
-            deep_is_list = True
-
-        if deep and not deep_is_list:
+        if deep is True:
             return cast("Self", _deep_copy(self, ignore=ignore))
-
         with debug_mode(False):
             copy = self.__class__(*self._args, **self._kwds)
-        if deep_is_list:
-            # Assert statement is for the benefit of Mypy
-            assert isinstance(deep, list)
+        if _is_iterable(deep):
             for attr in deep:
                 copy[attr] = _shallow_copy(copy._get(attr))
         return copy

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -839,9 +839,7 @@ def _shallow_copy(obj: Any) -> Any: ...
 def _shallow_copy(obj: _CopyImpl | Any) -> _CopyImpl | Any:
     if isinstance(obj, SchemaBase):
         return obj.copy(deep=False)
-    elif isinstance(obj, list):
-        return obj[:]
-    elif isinstance(obj, dict):
+    elif isinstance(obj, (list, dict)):
         return obj.copy()
     else:
         return obj


### PR DESCRIPTION
# Related
- #3531 

# Description
This PR addresses one [complex-structure](https://docs.astral.sh/ruff/rules/complex-structure/) violation, adds some typing, and gives a little performance boost in `SchemaBase.copy`.

See [each commit message](https://github.com/vega/altair/pull/3543/commits) for more detail on specific changes.

### Last commit message (auto-added)
- Initialize an empty set **once** at origin, rather than creating a new list per iteration
  - Renamed to `by_ref` in the new private function, to better describe the operation.
  - No change to public API.
- Define a partial `copy` to reduce repetition
- Use a genexpr for `args`, to avoid unpacking twice