### PR TITLE
fix(typing): Resolve misc type ignores in `schemapi.py`

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -114,7 +114,7 @@ def validate_jsonschema(
     rootschema: dict[str, Any] | None = ...,
     *,
     raise_error: Literal[True] = ...,
-) -> None: ...
+) -> Never: ...
 
 
 @overload
@@ -129,11 +129,11 @@ def validate_jsonschema(
 
 def validate_jsonschema(
     spec,
-    schema,
-    rootschema=None,
+    schema: dict[str, Any],
+    rootschema: dict[str, Any] | None = None,
     *,
-    raise_error=True,
-):
+    raise_error: bool = True,
+) -> jsonschema.exceptions.ValidationError | None:
     """
     Validates the passed in spec against the schema in the context of the rootschema.
 
@@ -150,7 +150,7 @@ def validate_jsonschema(
 
         # Nothing special about this first error but we need to choose one
         # which can be raised
-        main_error = next(iter(grouped_errors.values()))[0]
+        main_error: Any = next(iter(grouped_errors.values()))[0]
         # All errors are then attached as a new attribute to ValidationError so that
         # they can be used in SchemaValidationError to craft a more helpful
         # error message. Setting a new attribute like this is not ideal as
@@ -944,7 +944,7 @@ class SchemaBase:
             return self._kwds[attr]
         else:
             try:
-                _getattr = super().__getattr__
+                _getattr = super().__getattr__  # pyright: ignore[reportAttributeAccessIssue]
             except AttributeError:
                 _getattr = super().__getattribute__
             return _getattr(attr)
@@ -1193,9 +1193,7 @@ class SchemaBase:
             schema = cls._schema
         # For the benefit of mypy
         assert schema is not None
-        return validate_jsonschema(
-            instance, schema, rootschema=cls._rootschema or cls._schema
-        )
+        validate_jsonschema(instance, schema, rootschema=cls._rootschema or cls._schema)
 
     @classmethod
     def resolve_references(cls, schema: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -1221,7 +1219,7 @@ class SchemaBase:
         np_opt = sys.modules.get("numpy")
         value = _todict(value, context={}, np_opt=np_opt, pd_opt=pd_opt)
         props = cls.resolve_references(schema or cls._schema).get("properties", {})
-        return validate_jsonschema(
+        validate_jsonschema(
             value, props.get(name, {}), rootschema=cls._rootschema or cls._schema
         )
 
@@ -1323,11 +1321,11 @@ class _FromDict:
     @overload
     def from_dict(
         self,
-        dct: dict[str, Any],
-        tp: None = ...,
+        dct: dict[str, Any] | list[dict[str, Any]],
+        tp: Any = ...,
         schema: Any = ...,
-        rootschema: None = ...,
-        default_class: type[TSchemaBase] = ...,
+        rootschema: Any = ...,
+        default_class: type[TSchemaBase] = ...,  # pyright: ignore[reportInvalidTypeVarUse]
     ) -> TSchemaBase: ...
     @overload
     def from_dict(
@@ -1363,15 +1361,15 @@ class _FromDict:
         schema: dict[str, Any] | None = None,
         rootschema: dict[str, Any] | None = None,
         default_class: Any = _passthrough,
-    ) -> TSchemaBase:
+    ) -> TSchemaBase | SchemaBase:
         """Construct an object from a dict representation."""
-        target_tp: type[TSchemaBase]
+        target_tp: Any
         current_schema: dict[str, Any]
         if isinstance(dct, SchemaBase):
-            return dct  # type: ignore[return-value]
+            return dct
         elif tp is not None:
             current_schema = tp._schema
-            root_schema = rootschema or tp._rootschema or current_schema
+            root_schema: dict[str, Any] = rootschema or tp._rootschema or current_schema
             target_tp = tp
         elif schema is not None:
             # If there are multiple matches, we use the first one in the dict.

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -942,7 +942,7 @@ class SchemaBase:
             return self._kwds[attr]
         else:
             try:
-                _getattr = super().__getattr__
+                _getattr = super().__getattr__  # pyright: ignore[reportAttributeAccessIssue]
             except AttributeError:
                 _getattr = super().__getattribute__
             return _getattr(attr)

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -154,7 +154,7 @@ def validate_jsonschema(
         # error message. Setting a new attribute like this is not ideal as
         # it then no longer matches the type ValidationError. It would be better
         # to refactor this function to never raise but only return errors.
-        main_error._all_errors = grouped_errors
+        main_error._all_errors = grouped_errors  # pyright: ignore[reportAttributeAccessIssue]
         if raise_error:
             raise main_error
         else:

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -1325,7 +1325,7 @@ class _FromDict:
         tp: None = ...,
         schema: Any = ...,
         rootschema: None = ...,
-        default_class: type[TSchemaBase] = ...,
+        default_class: type[TSchemaBase] = ...,  # pyright: ignore[reportInvalidTypeVarUse]
     ) -> TSchemaBase: ...
     @overload
     def from_dict(
@@ -1378,7 +1378,7 @@ class _FromDict:
             current_schema = schema
             root_schema = rootschema or current_schema
             matches = self.class_dict[self.hash_schema(current_schema)]
-            target_tp = matches[0] if matches else default_class
+            target_tp = matches[0] if matches else default_class  # pyright: ignore[reportAssignmentType]
         else:
             msg = "Must provide either `tp` or `schema`, but not both."
             raise ValueError(msg)
@@ -1400,13 +1400,13 @@ class _FromDict:
             # TODO: handle schemas for additionalProperties/patternProperties
             props: dict[str, Any] = resolved.get("properties", {})
             kwds = {
-                k: (from_dict(v, schema=props[k]) if k in props else v)
+                k: (from_dict(v, schema=props[k]) if k in props else v)  # pyright: ignore[reportCallIssue]
                 for k, v in dct.items()
             }
             return target_tp(**kwds)
         elif _is_list(dct):
             item_schema: dict[str, Any] = resolved.get("items", {})
-            return target_tp([from_dict(k, schema=item_schema) for k in dct])
+            return target_tp([from_dict(k, schema=item_schema) for k in dct])  # pyright: ignore[reportCallIssue]
         else:
             # NOTE: Unsure what is valid here
             return target_tp(dct)


### PR DESCRIPTION
These are all very low-priority, but allows using `"python.analysis.typeCheckingMode": "basic"` in this module, without any warnings.

Planning to investigate improving the peformance of validation, which will be much easier with a live type checker 