### PR TITLE
fix: Resolve `Then` copy `TypeError`

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -854,6 +854,9 @@ def _deep_copy(obj: Any, by_ref: set[str]) -> Any: ...
 def _deep_copy(obj: _CopyImpl | Any, by_ref: set[str]) -> _CopyImpl | Any:
     copy = partial(_deep_copy, by_ref=by_ref)
     if isinstance(obj, SchemaBase):
+        if copier := getattr(obj, "__deepcopy__", None):
+            with debug_mode(False):
+                return copier(obj)
         args = (copy(arg) for arg in obj._args)
         kwds = {k: (copy(v) if k not in by_ref else v) for k, v in obj._kwds.items()}
         with debug_mode(False):

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1061,6 +1061,9 @@ class Then(core.SchemaBase, t.Generic[_C]):
         m = super().to_dict(*args, **kwds)
         return _Conditional(condition=m["condition"])
 
+    def __deepcopy__(self, memo: Any) -> Self:
+        return type(self)(_Conditional(condition=_deepcopy(self.condition)))
+
 
 class ChainedWhen(_BaseWhen):
     """

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -698,6 +698,27 @@ def test_when_condition_parity(
         assert chart_condition == chart_when
 
 
+def test_when_then_interactive() -> None:
+    """Copy-related regression found in https://github.com/vega/altair/pull/3394#issuecomment-2302995453."""
+    source = "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/movies.json"
+    predicate = (alt.datum.IMDB_Rating == None) | (  # noqa: E711
+        alt.datum.Rotten_Tomatoes_Rating == None  # noqa: E711
+    )
+
+    chart = (
+        alt.Chart(source)
+        .mark_point(invalid=None)
+        .encode(
+            x="IMDB_Rating:Q",
+            y="Rotten_Tomatoes_Rating:Q",
+            color=alt.when(predicate).then(alt.value("grey")),  # type: ignore[arg-type]
+        )
+    )
+    assert chart.interactive()
+    assert chart.copy()
+    assert chart.to_dict()
+
+
 def test_selection_to_dict():
     brush = alt.selection_interval()
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -852,6 +852,9 @@ def _deep_copy(obj: Any, by_ref: set[str]) -> Any: ...
 def _deep_copy(obj: _CopyImpl | Any, by_ref: set[str]) -> _CopyImpl | Any:
     copy = partial(_deep_copy, by_ref=by_ref)
     if isinstance(obj, SchemaBase):
+        if copier := getattr(obj, "__deepcopy__", None):
+            with debug_mode(False):
+                return copier(obj)
         args = (copy(arg) for arg in obj._args)
         kwds = {k: (copy(v) if k not in by_ref else v) for k, v in obj._kwds.items()}
         with debug_mode(False):


### PR DESCRIPTION
Fixes 
- https://github.com/vega/altair/pull/3394#issuecomment-2302995453
- https://github.com/vega/altair/pull/3394#issuecomment-2303028521
- https://github.com/vega/altair/actions/runs/10497592890/job/29080773958?pr=3394

---

I originally thought https://github.com/vega/altair/pull/3543 introduced this regression.

Haven't tested on earlier branches, but @mattijn can you check if you can repro on `v5.4.0`?
I think it would be present on there as well