### PR TITLE
test: Adds `test-(slow|fast)` options

### DIFF
--- a/altair/utils/execeval.py
+++ b/altair/utils/execeval.py
@@ -1,33 +1,70 @@
+from __future__ import annotations
+
 import ast
 import sys
+from typing import TYPE_CHECKING, Any, Callable, Literal, overload
+
+if TYPE_CHECKING:
+    from os import PathLike
+
+    from _typeshed import ReadableBuffer
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 
 class _CatchDisplay:
     """Class to temporarily catch sys.displayhook."""
 
-    def __init__(self):
-        self.output = None
+    def __init__(self) -> None:
+        self.output: Any | None = None
 
-    def __enter__(self):
-        self.old_hook = sys.displayhook
+    def __enter__(self) -> Self:
+        self.old_hook: Callable[[object], Any] = sys.displayhook
         sys.displayhook = self
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type, value, traceback) -> Literal[False]:
         sys.displayhook = self.old_hook
         # Returning False will cause exceptions to propagate
         return False
 
-    def __call__(self, output):
+    def __call__(self, output: Any) -> None:
         self.output = output
 
 
-def eval_block(code, namespace=None, filename="<string>"):
+@overload
+def eval_block(
+    code: str | Any,
+    namespace: dict[str, Any] | None = ...,
+    filename: str | ReadableBuffer | PathLike[Any] = ...,
+    *,
+    strict: Literal[False] = ...,
+) -> Any | None: ...
+@overload
+def eval_block(
+    code: str | Any,
+    namespace: dict[str, Any] | None = ...,
+    filename: str | ReadableBuffer | PathLike[Any] = ...,
+    *,
+    strict: Literal[True] = ...,
+) -> Any: ...
+def eval_block(
+    code: str | Any,
+    namespace: dict[str, Any] | None = None,
+    filename: str | ReadableBuffer | PathLike[Any] = "<string>",
+    *,
+    strict: bool = False,
+) -> Any | None:
     """
     Execute a multi-line block of code in the given namespace.
 
     If the final statement in the code is an expression, return
     the result of the expression.
+
+    If ``strict``, raise a ``TypeError`` when the return value would be ``None``.
     """
     tree = ast.parse(code, filename="<ast>", mode="exec")
     if namespace is None:
@@ -50,4 +87,12 @@ def eval_block(code, namespace=None, filename="<string>"):
             )
             exec(compiled, namespace)
 
-    return catch_display.output
+    if strict:
+        output = catch_display.output
+        if output is None:
+            msg = f"Expected a non-None value but got {output!r}"
+            raise TypeError(msg)
+        else:
+            return output
+    else:
+        return catch_display.output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,14 @@ update-init-file = [
     "ruff check .",
     "ruff format .",
 ]
+test-fast = [
+    "ruff check .", "ruff format .",
+    "pytest -p no:randomly -n logical --numprocesses=logical --doctest-modules tests altair -m \"not slow\" {args}"
+]
+test-slow = [
+    "ruff check .", "ruff format .",
+    "pytest -p no:randomly -n logical --numprocesses=logical --doctest-modules tests altair -m \"slow\" {args}"
+]
 
 [tool.hatch.envs.hatch-test]
 # https://hatch.pypa.io/latest/tutorials/testing/overview/
@@ -409,6 +417,10 @@ docstring-code-line-length = 88
 # test_examples tests.
 norecursedirs = ["tests/examples_arguments_syntax", "tests/examples_methods_syntax"]
 addopts = ["--numprocesses=logical"]
+# https://docs.pytest.org/en/stable/how-to/mark.html#registering-marks
+markers = [
+    "slow: Label tests as slow (deselect with '-m \"not slow\"')"
+]
 
 [tool.mypy]
 warn_unused_ignores = true

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import pkgutil
+import re
+from importlib.util import find_spec
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests import examples_arguments_syntax, examples_methods_syntax
+
+if TYPE_CHECKING:
+    from re import Pattern
+    from typing import Any, Iterator
+
+slow: pytest.MarkDecorator = pytest.mark.slow()
+"""
+Custom ``pytest.mark`` decorator.
+
+By default **all** tests are run.
+
+Slow tests can be **excluded** using::
+
+    >>> hatch run test-fast  # doctest: +SKIP
+
+To run **only** slow tests use::
+
+    >>> hatch run test-slow  # doctest: +SKIP
+
+Either script can accept ``pytest`` args::
+
+    >>> hatch run test-slow --durations=25  # doctest: +SKIP
+"""
+
+VL_CONVERT_AVAILABLE = find_spec("vl_convert") is not None
+
+skip_requires_vl_convert: pytest.MarkDecorator = pytest.mark.skipif(
+    not VL_CONVERT_AVAILABLE, reason="`vl_convert` not importable."
+)
+"""
+``pytest.mark.skipif`` decorator.
+
+Applies when `vl-convert`_ import would fail.
+
+.. _vl-convert:
+   https://github.com/vega/vl-convert
+"""
+
+
+def id_func_str_only(val) -> str:
+    """
+    Ensures the generated test-id name uses only `filename` and not `source`.
+
+    Without this, the name is repr(source code)-filename
+    """
+    if not isinstance(val, str):
+        return ""
+    else:
+        return val
+
+
+def _distributed_examples(*exclude_prefixes: str) -> Iterator[tuple[Any, str]]:
+    RE_NAME: Pattern[str] = re.compile(r"^tests\.(.*)")
+
+    for pkg in [examples_arguments_syntax, examples_methods_syntax]:
+        pkg_name = pkg.__name__
+        if match := RE_NAME.match(pkg_name):
+            pkg_name_unqual: str = match.group(1)
+        else:
+            msg = f"Failed to match pattern {RE_NAME.pattern!r} against {pkg_name!r}"
+            raise ValueError(msg)
+        for _, mod_name, is_pkg in pkgutil.iter_modules(pkg.__path__):
+            if not (is_pkg or mod_name.startswith(exclude_prefixes)):
+                file_name = f"{mod_name}.py"
+                msg_name = f"{pkg_name_unqual}.{file_name}"
+                if source := pkgutil.get_data(pkg_name, file_name):
+                    yield source, msg_name
+                else:
+                    msg = (
+                        f"Failed to get source data from `{pkg_name}.{file_name}`.\n"
+                        f"pkgutil.get_data(...) returned: {pkgutil.get_data(pkg_name, file_name)!r}"
+                    )
+                    raise TypeError(msg)
+
+
+ignore_DataFrameGroupBy: pytest.MarkDecorator = pytest.mark.filterwarnings(
+    "ignore:DataFrameGroupBy.apply.*:DeprecationWarning"
+)
+"""
+``pytest.mark.filterwarnings`` decorator.
+
+Hides ``pandas`` warning(s)::
+
+    "ignore:DataFrameGroupBy.apply.*:DeprecationWarning"
+"""
+
+
+distributed_examples: pytest.MarkDecorator = pytest.mark.parametrize(
+    ("source", "filename"),
+    tuple(_distributed_examples("_", "interval_selection_map_quakes")),
+    ids=id_func_str_only,
+)
+"""
+``pytest.mark.parametrize`` decorator.
+
+Provides **all** examples, using both `arguments` & `methods` syntax.
+
+The decorated test can evaluate each resulting chart via::
+
+    from altair.utils.execeval import eval_block
+
+    @distributed_examples
+    def test_some_stuff(source: Any, filename: str) -> None:
+        chart: ChartType | None = eval_block(source)
+        ... # Perform any assertions
+
+Notes
+-----
+- See `#3431 comment`_ for performance benefit.
+- `interval_selection_map_quakes` requires `#3418`_ fix
+
+.. _#3431 comment:
+   https://github.com/vega/altair/pull/3431#issuecomment-2168508048
+.. _#3418:
+   https://github.com/vega/altair/issues/3418
+"""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,10 +32,9 @@ Either script can accept ``pytest`` args::
     >>> hatch run test-slow --durations=25  # doctest: +SKIP
 """
 
-VL_CONVERT_AVAILABLE = find_spec("vl_convert") is not None
 
 skip_requires_vl_convert: pytest.MarkDecorator = pytest.mark.skipif(
-    not VL_CONVERT_AVAILABLE, reason="`vl_convert` not importable."
+    find_spec("vl_convert") is None, reason="`vl_convert` not installed."
 )
 """
 ``pytest.mark.skipif`` decorator.
@@ -44,6 +43,19 @@ Applies when `vl-convert`_ import would fail.
 
 .. _vl-convert:
    https://github.com/vega/vl-convert
+"""
+
+
+skip_requires_pyarrow: pytest.MarkDecorator = pytest.mark.skipif(
+    find_spec("pyarrow") is None, reason="`pyarrow` not installed."
+)
+"""
+``pytest.mark.skipif`` decorator.
+
+Applies when `pyarrow`_ import would fail.
+
+.. _pyarrow:
+   https://pypi.org/project/pyarrow/
 """
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -20,72 +20,21 @@ Cache the calls to `compile` in `altair.utils.execeval`
 from __future__ import annotations
 
 import io
-import pkgutil
-import re
-import sys
-from typing import Any, Iterable, Iterator
-
-import pytest
+from typing import Any
 
 import altair as alt
 from altair.utils.execeval import eval_block
-from tests import examples_arguments_syntax, examples_methods_syntax
-
-try:
-    import vl_convert as vlc  # noqa: F401, RUF100
-except ImportError:
-    vlc = None
-
-
-VL_CONVERT_AVAILABLE = "vl_convert" in sys.modules
-
-
-def iter_examples_filenames(syntax_module) -> Iterator[str]:
-    for _importer, modname, ispkg in pkgutil.iter_modules(syntax_module.__path__):
-        if not (
-            ispkg
-            or modname.startswith("_")
-            # Temporarily skip this test until https://github.com/vega/altair/issues/3418
-            # is fixed
-            or modname == "interval_selection_map_quakes"
-        ):
-            yield f"{modname}.py"
-
-
-def _distributed_examples() -> Iterator[tuple[Any, str]]:
-    # `pytest.mark.parametrize` over 2 modules produces 2x workers
-    # - This raises the total jobs from 400 -> 1200
-    # - Preventing the three tests from blocking everything else
-    RE_NAME: re.Pattern[str] = re.compile(r"^tests\.(.*)")
-
-    for module in [examples_arguments_syntax, examples_methods_syntax]:
-        for filename in iter_examples_filenames(module):
-            name = module.__name__
-            source = pkgutil.get_data(name, filename)
-            yield source, f"{RE_NAME.match(name).group(1)}.{filename}"  # type: ignore[union-attr]
-
-
-distributed_examples: Iterable[tuple[Any, str]] = tuple(_distributed_examples())
-"""Tried using as a `fixture`, but wasn't able to combine with `@pytest.mark.parametrize`."""
-
-
-def id_func(val) -> str:
-    """
-    Ensures the generated test-id name uses only `filename` and not `source`.
-
-    Without this, the name is repr(source code)-filename
-    """
-    if not isinstance(val, str):
-        return ""
-    else:
-        return val
-
-
-@pytest.mark.filterwarnings(
-    "ignore:DataFrameGroupBy.apply.*:DeprecationWarning",
+from tests import (
+    distributed_examples,
+    ignore_DataFrameGroupBy,
+    skip_requires_vl_convert,
+    slow,
 )
-@pytest.mark.parametrize(("source", "filename"), distributed_examples, ids=id_func)
-def test_render_examples_to_chart(source, filename) -> None:
+
+
+@ignore_DataFrameGroupBy
+@distributed_examples
+def test_render_examples_to_chart(source: Any, filename: str) -> None:
     chart = eval_block(source)
     if chart is None:
         msg = f"Example file {filename} should define chart in its final statement."
@@ -100,11 +49,9 @@ def test_render_examples_to_chart(source, filename) -> None:
         raise AssertionError(msg) from err
 
 
-@pytest.mark.filterwarnings(
-    "ignore:DataFrameGroupBy.apply.*:DeprecationWarning",
-)
-@pytest.mark.parametrize(("source", "filename"), distributed_examples, ids=id_func)
-def test_from_and_to_json_roundtrip(source, filename) -> None:
+@ignore_DataFrameGroupBy
+@distributed_examples
+def test_from_and_to_json_roundtrip(source: Any, filename: str) -> None:
     """
     Tests if the to_json and from_json work for all examples in the Example Gallery.
 
@@ -131,19 +78,17 @@ def test_from_and_to_json_roundtrip(source, filename) -> None:
         raise AssertionError(msg) from err
 
 
-@pytest.mark.filterwarnings(
-    "ignore:DataFrameGroupBy.apply.*:DeprecationWarning",
-)
-@pytest.mark.parametrize(("source", "filename"), distributed_examples, ids=id_func)
-@pytest.mark.skipif(
-    not VL_CONVERT_AVAILABLE,
-    reason="vl_convert not importable; cannot run mimebundle tests",
-)
-def test_render_examples_to_png(source, filename) -> None:
+@slow
+@ignore_DataFrameGroupBy
+@distributed_examples
+@skip_requires_vl_convert
+def test_render_examples_to_png(source: Any, filename: str) -> None:
     chart = eval_block(source)
     if chart is None:
         msg = f"Example file {filename} should define chart in its final statement."
         raise ValueError(msg)
     out = io.BytesIO()
     chart.save(out, format="png", engine="vl-convert")
-    assert out.getvalue().startswith(b"\x89PNG")
+    buf = out.getbuffer()
+    prefix = buf[:4].tobytes()
+    assert prefix == b"\x89PNG"

--- a/tests/test_transformed_data.py
+++ b/tests/test_transformed_data.py
@@ -6,7 +6,7 @@ from vega_datasets import data
 
 import altair as alt
 from altair.utils.execeval import eval_block
-from tests import examples_methods_syntax
+from tests import examples_methods_syntax, slow, ignore_DataFrameGroupBy
 
 try:
     import vegafusion as vf  # type: ignore
@@ -16,9 +16,7 @@ except ImportError:
 XDIST_ENABLED: bool = "xdist" in sys.modules
 """Use as an `xfail` condition, if running in parallel may cause the test to fail."""
 
-@pytest.mark.filterwarnings(
-    "ignore:DataFrameGroupBy.apply.*:DeprecationWarning"
-)
+@ignore_DataFrameGroupBy
 @pytest.mark.skipif(vf is None, reason="vegafusion not installed")
 # fmt: off
 @pytest.mark.parametrize("filename,rows,cols", [
@@ -35,9 +33,9 @@ XDIST_ENABLED: bool = "xdist" in sys.modules
     ("gapminder_bubble_plot.py", 187, ["income", "population"]),
     ("grouped_bar_chart2.py", 9, ["Group", "Value_start"]),
     ("hexbins.py", 84, ["xFeaturePos", "mean_temp_max"]),
-    ("histogram_heatmap.py", 378, ["bin_maxbins_40_Rotten_Tomatoes_Rating", "__count"]),
+    pytest.param("histogram_heatmap.py", 378, ["bin_maxbins_40_Rotten_Tomatoes_Rating", "__count"], marks=slow),
     ("histogram_scatterplot.py", 64, ["bin_maxbins_10_Rotten_Tomatoes_Rating", "__count"]),
-    ("interactive_legend.py", 1708, ["sum_count_start", "series"]),
+    pytest.param("interactive_legend.py", 1708, ["sum_count_start", "series"], marks=slow),
     ("iowa_electricity.py", 51, ["net_generation_start", "year"]),
     ("isotype.py", 37, ["animal", "x"]),
     ("isotype_grid.py", 100, ["row", "col"]),
@@ -47,7 +45,7 @@ XDIST_ENABLED: bool = "xdist" in sys.modules
     ("layered_histogram.py", 113, ["bin_maxbins_100_Measurement"]),
     ("line_chart_with_cumsum.py", 52, ["cumulative_wheat"]),
     ("line_custom_order.py", 55, ["miles", "gas"]),
-    ("line_percent.py", 30, ["sex", "perc"]),
+    pytest.param("line_percent.py", 30, ["sex", "perc"], marks=slow),
     ("line_with_log_scale.py", 15, ["year", "sum_people"]),
     ("multifeature_scatter_plot.py", 150, ["petalWidth", "species"]),
     ("natural_disasters.py", 686, ["Deaths", "Year"]),
@@ -59,10 +57,10 @@ XDIST_ENABLED: bool = "xdist" in sys.modules
     ("pyramid.py", 3, ["category", "value_start"]),
     ("stacked_bar_chart_sorted_segments.py", 60, ["variety", "site"]),
     ("stem_and_leaf.py", 100, ["stem", "leaf"]),
-    ("streamgraph.py", 1708, ["series", "sum_count"]),
+    pytest.param("streamgraph.py", 1708, ["series", "sum_count"], marks=slow),
     ("top_k_items.py", 10, ["rank", "IMDB_Rating_start"]),
     ("top_k_letters.py", 9, ["rank", "letters"]),
-    ("top_k_with_others.py", 10, ["ranked_director", "mean_aggregate_gross"]),
+    pytest.param("top_k_with_others.py", 10, ["ranked_director", "mean_aggregate_gross"], marks=slow),
     ("area_faceted.py", 492, ["date", "price"]),
     ("distributions_faceted_histogram.py", 20, ["Origin", "__count"]),
     ("us_population_over_time.py", 38, ["sex", "people_start"]),
@@ -97,7 +95,7 @@ def test_primitive_chart_examples(filename, rows, cols, to_reconstruct):
     ("histogram_responsive.py", [20, 20], [["__count"], ["__count"]]),
     ("histogram_with_a_global_mean_overlay.py", [9, 1], [["__count"], ["mean_IMDB_Rating"]]),
     ("horizon_graph.py", [20, 20], [["x"], ["ny"]]),
-    ("interactive_cross_highlight.py", [64, 64, 13], [["__count"], ["__count"], ["Major_Genre"]]),
+    pytest.param("interactive_cross_highlight.py", [64, 64, 13], [["__count"], ["__count"], ["Major_Genre"]], marks=slow),
     ("interval_selection.py", [123, 123], [["price_start"], ["date"]]),
     ("layered_chart_with_dual_axis.py", [12, 12], [["month_date"], ["average_precipitation"]]),
     ("layered_heatmap_text.py", [9, 9], [["Cylinders"], ["mean_horsepower"]]),
@@ -111,11 +109,11 @@ def test_primitive_chart_examples(filename, rows, cols, to_reconstruct):
         "scatter_with_layered_histogram.py",
         [2, 19],
         [["gender"], ["__count"]],
-        marks=pytest.mark.xfail(
+        marks=(slow, pytest.mark.xfail(
             XDIST_ENABLED,
             reason="Possibly `numpy` conflict with `xdist`.\n"
             "Very intermittent, but only affects `to_reconstruct=False`."
-        ),
+        )),
     ),
     ("scatter_with_minimap.py", [1461, 1461], [["date"], ["date"]]),
     ("scatter_with_rolling_mean.py", [1461, 1461], [["date"], ["rolling_mean"]]),

--- a/tests/test_transformed_data.py
+++ b/tests/test_transformed_data.py
@@ -80,8 +80,8 @@ def test_primitive_chart_examples(filename, rows, cols, to_reconstruct):
         chart = alt.Chart.from_dict(chart.to_dict())
     df = chart.transformed_data()
 
-    assert len(df) == rows
-    assert set(cols).issubset(set(df.columns))
+    assert len(df) == rows # pyright: ignore[reportArgumentType]
+    assert set(cols).issubset(set(df.columns)) # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
 
 
 @pytest.mark.skipif(vf is None, reason="vegafusion not installed")
@@ -140,8 +140,8 @@ def test_compound_chart_examples(filename, all_rows, all_cols, to_reconstruct):
         # Only run assert statements if the chart is not reconstructed. Reason
         # is that for some charts, the original chart contained duplicated datasets
         # which disappear when reconstructing the chart.
-        assert len(dfs) == len(all_rows)
-        for df, rows, cols in zip(dfs, all_rows, all_cols):
+        assert len(dfs) == len(all_rows) # pyright: ignore[reportArgumentType]
+        for df, rows, cols in zip(dfs, all_rows, all_cols): # pyright: ignore[reportArgumentType]
             assert len(df) == rows
             assert set(cols).issubset(set(df.columns))
 
@@ -166,8 +166,8 @@ def test_transformed_data_exclude(to_reconstruct):
         chart = alt.Chart.from_dict(chart.to_dict())
     datasets = chart.transformed_data(exclude=["some_annotation"])
 
-    assert len(datasets) == 2
-    assert len(datasets[0]) == 52
-    assert "wheat_start" in datasets[0]
-    assert len(datasets[1]) == 1
-    assert "mean_wheat" in datasets[1]
+    assert len(datasets) == 2 # pyright: ignore[reportArgumentType]
+    assert len(datasets[0]) == 52 # pyright: ignore[reportArgumentType, reportIndexIssue, reportOptionalSubscript]
+    assert "wheat_start" in datasets[0] # pyright: ignore[reportIndexIssue, reportOptionalSubscript, reportOperatorIssue]
+    assert len(datasets[1]) == 1 # pyright: ignore[reportArgumentType, reportIndexIssue, reportOptionalSubscript]
+    assert "mean_wheat" in datasets[1] # pyright: ignore[reportIndexIssue, reportOptionalSubscript, reportOperatorIssue]

--- a/tests/test_transformed_data.py
+++ b/tests/test_transformed_data.py
@@ -72,7 +72,7 @@ XDIST_ENABLED: bool = "xdist" in sys.modules
 @pytest.mark.parametrize("to_reconstruct", [True, False])
 def test_primitive_chart_examples(filename, rows, cols, to_reconstruct):
     source = pkgutil.get_data(examples_methods_syntax.__name__, filename)
-    chart = eval_block(source)
+    chart = eval_block(source, strict=True)
     if to_reconstruct:
         # When reconstructing a Chart, Altair uses different classes
         # then what might have been originally used. See
@@ -128,7 +128,7 @@ def test_primitive_chart_examples(filename, rows, cols, to_reconstruct):
 @pytest.mark.parametrize("to_reconstruct", [True, False])
 def test_compound_chart_examples(filename, all_rows, all_cols, to_reconstruct):
     source = pkgutil.get_data(examples_methods_syntax.__name__, filename)
-    chart = eval_block(source)
+    chart = eval_block(source, strict=True)
     if to_reconstruct:
         # When reconstructing a Chart, Altair uses different classes
         # then what might have been originally used. See

--- a/tests/utils/test_core.py
+++ b/tests/utils/test_core.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import types
 from importlib.metadata import version as importlib_version
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -9,14 +12,11 @@ from pandas.api.types import infer_dtype
 
 import altair as alt
 from altair.utils.core import infer_encoding_types, parse_shorthand, update_nested
+from tests import skip_requires_pyarrow
 
 json_schema_specification = alt.load_schema()["$schema"]
 json_schema_dict_str = f'{{"$schema": "{json_schema_specification}"}}'
 
-try:
-    import pyarrow as pa
-except ImportError:
-    pa = None
 
 PANDAS_VERSION = Version(importlib_version("pandas"))
 
@@ -70,6 +70,22 @@ class StrokeWidthValue(ValueChannel, schemapi.SchemaBase):
 '''
 
 
+@pytest.fixture(params=[False, True])
+def pd_data(request) -> pd.DataFrame:
+    data = pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4, 5],
+            "y": ["A", "B", "C", "D", "E"],
+            "z": pd.date_range("2018-01-01", periods=5, freq="D"),
+            "t": pd.date_range("2018-01-01", periods=5, freq="D").tz_localize("UTC"),
+        }
+    )
+    object_dtype = request.param
+    if object_dtype:
+        data = data.astype("object")
+    return data
+
+
 @pytest.mark.parametrize(
     ("value", "expected_type"),
     [
@@ -84,93 +100,94 @@ def test_infer_dtype(value, expected_type):
     assert infer_dtype(value, skipna=False) == expected_type
 
 
-def test_parse_shorthand():
-    def check(s, **kwargs):
-        assert parse_shorthand(s) == kwargs
-
-    check("")
-
-    # Fields alone
-    check("foobar", field="foobar")
-    check(r"blah\:(fd ", field=r"blah\:(fd ")
-
-    # Fields with type
-    check("foobar:quantitative", type="quantitative", field="foobar")
-    check("foobar:nominal", type="nominal", field="foobar")
-    check("foobar:ordinal", type="ordinal", field="foobar")
-    check("foobar:temporal", type="temporal", field="foobar")
-    check("foobar:geojson", type="geojson", field="foobar")
-
-    check("foobar:Q", type="quantitative", field="foobar")
-    check("foobar:N", type="nominal", field="foobar")
-    check("foobar:O", type="ordinal", field="foobar")
-    check("foobar:T", type="temporal", field="foobar")
-    check("foobar:G", type="geojson", field="foobar")
-
-    # Fields with aggregate and/or type
-    check("average(foobar)", field="foobar", aggregate="average")
-    check("min(foobar):temporal", type="temporal", field="foobar", aggregate="min")
-    check("sum(foobar):Q", type="quantitative", field="foobar", aggregate="sum")
-
-    # check that invalid arguments are not split-out
-    check("invalid(blah)", field="invalid(blah)")
-    check(r"blah\:invalid", field=r"blah\:invalid")
-    check(r"invalid(blah)\:invalid", field=r"invalid(blah)\:invalid")
-
-    # check parsing in presence of strange characters
-    check(
-        r"average(a b\:(c\nd):Q",
-        aggregate="average",
-        field=r"a b\:(c\nd",
-        type="quantitative",
-    )
-
-    # special case: count doesn't need an argument
-    check("count()", aggregate="count", type="quantitative")
-    check("count():O", aggregate="count", type="ordinal")
-
-    # time units:
-    check("month(x)", field="x", timeUnit="month", type="temporal")
-    check("year(foo):O", field="foo", timeUnit="year", type="ordinal")
-    check("date(date):quantitative", field="date", timeUnit="date", type="quantitative")
-    check(
-        "yearmonthdate(field)", field="field", timeUnit="yearmonthdate", type="temporal"
-    )
+# ruff: noqa: C408
 
 
-@pytest.mark.parametrize("object_dtype", [False, True])
-def test_parse_shorthand_with_data(object_dtype):
-    def check(s, data, **kwargs):
-        assert parse_shorthand(s, data) == kwargs
+@pytest.mark.parametrize(
+    ("shorthand", "expected"),
+    [
+        ("", {}),
+        # Fields alone
+        ("foobar", dict(field="foobar")),
+        (r"blah\:(fd ", dict(field=r"blah\:(fd ")),
+        # Fields with type
+        ("foobar:quantitative", dict(type="quantitative", field="foobar")),
+        ("foobar:nominal", dict(type="nominal", field="foobar")),
+        ("foobar:ordinal", dict(type="ordinal", field="foobar")),
+        ("foobar:temporal", dict(type="temporal", field="foobar")),
+        ("foobar:geojson", dict(type="geojson", field="foobar")),
+        ("foobar:Q", dict(type="quantitative", field="foobar")),
+        ("foobar:N", dict(type="nominal", field="foobar")),
+        ("foobar:O", dict(type="ordinal", field="foobar")),
+        ("foobar:T", dict(type="temporal", field="foobar")),
+        ("foobar:G", dict(type="geojson", field="foobar")),
+        # Fields with aggregate and/or type
+        ("average(foobar)", dict(field="foobar", aggregate="average")),
+        (
+            "min(foobar):temporal",
+            dict(type="temporal", field="foobar", aggregate="min"),
+        ),
+        ("sum(foobar):Q", dict(type="quantitative", field="foobar", aggregate="sum")),
+        # check that invalid arguments are not split-out
+        ("invalid(blah)", dict(field="invalid(blah)")),
+        (r"blah\:invalid", dict(field=r"blah\:invalid")),
+        (r"invalid(blah)\:invalid", dict(field=r"invalid(blah)\:invalid")),
+        # check parsing in presence of strange characters
+        (
+            r"average(a b\:(c\nd):Q",
+            dict(aggregate="average", field=r"a b\:(c\nd", type="quantitative"),
+        ),
+        # special case: count doesn't need an argument
+        ("count()", dict(aggregate="count", type="quantitative")),
+        ("count():O", dict(aggregate="count", type="ordinal")),
+        # time units:
+        ("month(x)", dict(field="x", timeUnit="month", type="temporal")),
+        ("year(foo):O", dict(field="foo", timeUnit="year", type="ordinal")),
+        (
+            "date(date):quantitative",
+            dict(field="date", timeUnit="date", type="quantitative"),
+        ),
+        (
+            "yearmonthdate(field)",
+            dict(field="field", timeUnit="yearmonthdate", type="temporal"),
+        ),
+    ],
+)
+def test_parse_shorthand(shorthand: str, expected: dict[str, Any]) -> None:
+    assert parse_shorthand(shorthand) == expected
 
-    data = pd.DataFrame(
-        {
-            "x": [1, 2, 3, 4, 5],
-            "y": ["A", "B", "C", "D", "E"],
-            "z": pd.date_range("2018-01-01", periods=5, freq="D"),
-            "t": pd.date_range("2018-01-01", periods=5, freq="D").tz_localize("UTC"),
-        }
-    )
 
-    if object_dtype:
-        data = data.astype("object")
-
-    check("x", data, field="x", type="quantitative")
-    check("y", data, field="y", type="nominal")
-    check("z", data, field="z", type="temporal")
-    check("t", data, field="t", type="temporal")
-    check("count(x)", data, field="x", aggregate="count", type="quantitative")
-    check("count()", data, aggregate="count", type="quantitative")
-    check("month(z)", data, timeUnit="month", field="z", type="temporal")
-    check("month(t)", data, timeUnit="month", field="t", type="temporal")
-
-    if Version("1.0.0") <= PANDAS_VERSION:
-        data["b"] = pd.Series([True, False, True, False, None], dtype="boolean")
-        check("b", data, field="b", type="nominal")
+@pytest.mark.parametrize(
+    ("shorthand", "expected"),
+    [
+        ("x", dict(field="x", type="quantitative")),
+        ("y", dict(field="y", type="nominal")),
+        ("z", dict(field="z", type="temporal")),
+        ("t", dict(field="t", type="temporal")),
+        ("count(x)", dict(field="x", aggregate="count", type="quantitative")),
+        ("count()", dict(aggregate="count", type="quantitative")),
+        ("month(z)", dict(timeUnit="month", field="z", type="temporal")),
+        ("month(t)", dict(timeUnit="month", field="t", type="temporal")),
+    ],
+)
+def test_parse_shorthand_with_data(
+    pd_data, shorthand: str, expected: dict[str, Any]
+) -> None:
+    assert parse_shorthand(shorthand, pd_data) == expected
 
 
-@pytest.mark.skipif(pa is None, reason="pyarrow not installed")
+@pytest.mark.skipif(Version("1.0.0") > PANDAS_VERSION, reason="dtype unavailable")
+def test_parse_shorthand_with_data_pandas_v1(pd_data) -> None:
+    pd_data["b"] = pd.Series([True, False, True, False, None], dtype="boolean")
+    shorthand = "b"
+    expected = dict(field="b", type="nominal")
+    assert parse_shorthand(shorthand, pd_data) == expected
+
+
+@skip_requires_pyarrow
 def test_parse_shorthand_for_arrow_timestamp():
+    import pyarrow as pa
+
     data = pd.DataFrame(
         {
             "z": pd.date_range("2018-01-01", periods=5, freq="D"),

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -1,8 +1,10 @@
 """Test http server."""
 
 from altair.utils.server import MockServer, serve
+from tests import slow
 
 
+@slow
 def test_serve():
     html = "<html><title>Title</title><body><p>Content</p></body></html>"
     serve(html, open_browser=False, http_server=MockServer)

--- a/tests/utils/test_to_values_narwhals.py
+++ b/tests/utils/test_to_values_narwhals.py
@@ -6,12 +6,8 @@ import narwhals.stable.v1 as nw
 import pandas as pd
 import pytest
 
-try:
-    import pyarrow as pa
-except ImportError:
-    pa = None
-
 from altair.utils.data import to_values
+from tests import skip_requires_pyarrow
 
 
 def windows_has_tzdata():
@@ -30,9 +26,11 @@ def windows_has_tzdata():
     sys.platform == "win32" and not windows_has_tzdata(),
     reason="Timezone database is not installed on Windows",
 )
-@pytest.mark.skipif(pa is None, reason="pyarrow not installed")
+@skip_requires_pyarrow
 def test_arrow_timestamp_conversion():
     """Test that arrow timestamp values are converted to ISO-8601 strings."""
+    import pyarrow as pa
+
     data = {
         "date": [datetime(2004, 8, 1), datetime(2004, 9, 1), None],
         "value": [102, 129, 139],
@@ -51,8 +49,10 @@ def test_arrow_timestamp_conversion():
     assert values == expected_values
 
 
-@pytest.mark.skipif(pa is None, reason="pyarrow not installed")
+@skip_requires_pyarrow
 def test_duration_raises():
+    import pyarrow as pa
+
     td = pd.timedelta_range(0, periods=3, freq="h")
     df = pd.DataFrame(td).reset_index()
     df.columns = ["id", "timedelta"]

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -23,6 +23,7 @@ from packaging.version import Version
 
 import altair as alt
 from altair.utils.schemapi import Optional, Undefined
+from tests import skip_requires_vl_convert, slow
 
 try:
     import vl_convert as vlc
@@ -786,11 +787,9 @@ def test_save(format, engine, basic_chart):
             pathlib.Path(fp).unlink()
 
 
-@pytest.mark.parametrize("inline", [False, True])
+@pytest.mark.parametrize("inline", [False, pytest.param(True, marks=slow)])
+@skip_requires_vl_convert
 def test_save_html(basic_chart, inline):
-    if vlc is None:
-        pytest.skip("vl_convert not importable; cannot run this test")
-
     out = io.StringIO()
     basic_chart.save(out, format="html", inline=inline)
     out.seek(0)
@@ -806,10 +805,8 @@ def test_save_html(basic_chart, inline):
         assert 'src="https://cdn.jsdelivr.net/npm/vega-embed@6' in content
 
 
+@skip_requires_vl_convert
 def test_to_url(basic_chart):
-    if vlc is None:
-        pytest.skip("vl_convert is not installed")
-
     share_url = basic_chart.to_url()
 
     assert share_url.startswith("https://vega.github.io/editor/#/url/vega-lite/")


### PR DESCRIPTION
While working on #3547, I've been running the test suite a bunch to identify bottlenecks.

## This PR provides
- tools to identify, skip or run only slow tests
- some new, previously repeated mark decorators
- misc refactoring of tests using the above
- docs explaining intended usage

## Impact?
- Locally, this covers most tests that take 2-10 secs.
- In total, **354**/1671 tests are skipped
- reduced runtime 40  -> 20 secs

## Important
The **default** behaviour is **unchanged**:

```bash
# Runs all tests
>>> hatch test 

# Runs only slow tests
>>> hatch run test-slow

# Runs all tests (that are not marked @slow)
>>> hatch run test-fast
```