### PR TITLE
refactor: Replace an indirect `SchemaBase` import

### DIFF
--- a/altair/utils/__init__.py
+++ b/altair/utils/__init__.py
@@ -1,6 +1,5 @@
 from .core import (
     SHORTHAND_KEYS,
-    SchemaBase,
     display_traceback,
     infer_encoding_types,
     infer_vegalite_type_for_pandas,
@@ -13,7 +12,7 @@ from .core import (
 from .deprecation import AltairDeprecationWarning, deprecated, deprecated_warn
 from .html import spec_to_html
 from .plugin_registry import PluginRegistry
-from .schemapi import Optional, Undefined, is_undefined
+from .schemapi import Optional, SchemaBase, Undefined, is_undefined
 
 __all__ = (
     "SHORTHAND_KEYS",


### PR DESCRIPTION
Spotted while writing an `__all__` for `schemapi.py` in #3547