### PR TITLE
docs: Unstack area to render cumulative chart correctly

### DIFF
--- a/tests/examples_methods_syntax/cumulative_count_chart.py
+++ b/tests/examples_methods_syntax/cumulative_count_chart.py
@@ -17,5 +17,5 @@ alt.Chart(source).transform_window(
     sort=[{"field": "IMDB_Rating"}],
 ).mark_area().encode(
     x="IMDB_Rating:Q",
-    y=alt.Y("cumulative_count:Q", stack=False)
+    y=alt.Y("cumulative_count:Q").stack(False)
 )


### PR DESCRIPTION
This has likely been broken since Vega-Lite changed the default behavior in
https://github.com/vega/vega-lite/releases/tag/v5.14.1

You can see the current broken chart here https://altair-viz.github.io/gallery/cumulative_count_chart.html

After this PR:
![image](https://github.com/user-attachments/assets/de20bb1f-2a43-4a5a-b30f-47e9a9b44595)
