### PR TITLE
ci: Add `typings/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ Untitled*.ipynb
 
 # hatch, doc generation
 data.json
+
+# type stubs
+typings/


### PR DESCRIPTION
Related https://github.com/vega/vl-convert/issues/184

Using this directory for type stubs, which is a temporary solve for the `vl_convert` issue

![image](https://github.com/user-attachments/assets/66396adb-02b6-46ac-b5b8-93e7aa61c73e)
