### PR TITLE
docs: Update releasing notes to reflect that main branch is now protected

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,7 +41,7 @@
 
 9. On main, build source & wheel distributions. If you work on a fork, replace `origin` with `upstream`:
 
-       git checkout main
+       git switch main
        git pull origin main
        hatch clean  # clean old builds & distributions
        hatch build  # create a source distribution and universal wheel

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@
    
        hatch env prune
 
-2. Make certain your branch is in sync with head:
+2. Make certain your branch is in sync with head. If you work on a fork, replace `origin` with `upstream`:
  
        git pull origin main
 
@@ -17,48 +17,67 @@
    Navigate to http://localhost:8000 and ensure it looks OK (particularly
    do a visual scan of the gallery thumbnails).
 
-4. Update version to, e.g. 5.0.0:
+4. Create a new release branch:
+       
+       git switch -c version_5.0.0
+
+5. Update version to, e.g. 5.0.0:
 
    - in ``altair/__init__.py``
    - in ``doc/conf.py``
 
-5. Commit change and push to main:
+6. Commit changes and push:
 
        git add . -u
        git commit -m "chore: Bump version to 5.0.0"
-       git push origin main
+       git push
 
-6. Tag the release:
+7. Merge release branch into main, make sure that all required checks pass
+
+8. Tag the release:
 
        git tag -a v5.0.0 -m "version 5.0.0 release"
        git push origin v5.0.0
 
-7. Build source & wheel distributions:
+9. On main, build source & wheel distributions. If you work on a fork, replace `origin` with `upstream`:
 
+       git checkout main
+       git pull origin main
        hatch clean  # clean old builds & distributions
        hatch build  # create a source distribution and universal wheel
 
-8. publish to PyPI (Requires correct PyPI owner permissions):
+10. publish to PyPI (Requires correct PyPI owner permissions):
 
         hatch publish
 
-9. build and publish docs (Requires write-access to altair-viz/altair-viz.github.io):
+11. build and publish docs (Requires write-access to altair-viz/altair-viz.github.io):
 
         hatch run doc:publish-clean-build
 
-10. update version to, e.g. 5.1.0dev:
+12. On main, tag the release. If you work on a fork, replace `origin` with `upstream`:
+
+        git tag -a v5.0.0 -m "Version 5.0.0 release"
+        git push origin v5.0.0
+
+13. Create a new branch:
+       
+       git switch -c maint_5.1.0dev
+
+14. Update version and add 'dev' suffix, e.g. 5.1.0dev:
 
     - in ``altair/__init__.py``
     - in ``doc/conf.py``
 
-11. Commit change and push to main:
+15. Commit changes and push:
 
         git add . -u
         git commit -m "chore: Bump version to 5.1.0dev"
-        git push origin main
+        git push
+        
+16. Merge maintenance branch into main
 
-12. Double-check that a conda-forge pull request is generated from the updated
+17. Double-check that a conda-forge pull request is generated from the updated
     pip package by the conda-forge bot (may take up to several hours):
     https://github.com/conda-forge/altair-feedstock/pulls
 
-13. Publish a new release in https://github.com/vega/altair/releases/
+18. Publish a new release in https://github.com/vega/altair/releases/


### PR DESCRIPTION
I think protecting our main branch is a great idea:
* to prevent accidental pushes to main
* while tests are still running for a PR, you can now use the auto-merge feature. I find this very convenient in other repos as you don't have to check back in a few minutes and then merge but instead, if you click it, it merges automatically once all checks have passed:
![image](https://github.com/user-attachments/assets/ac64fc8f-0c3d-4c8b-bb22-cae303bb8483)


I took the liberty to already enable it in [the repo settings](https://github.com/vega/altair/settings) based on https://github.com/vega/altair/pull/3559#issuecomment-2313254486. This PR updates the RELEASING.md file to reflect it.

We can still merge without review which I think is useful for minor changes (typos, minor changes in pyproject.toml, etc.)

Happy to discuss! We can also try it out for a while and always revert back. Tagging for visibility in case you want to weigh in: @dangotbanned @joelostblom @mattijn @jonmmease 