### PR TITLE
fix(typing): Resolve multiple `@utils.use_signature` issues

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -12,7 +12,16 @@ from collections.abc import Mapping, MutableMapping
 from copy import deepcopy
 from itertools import groupby
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterator,
+    Literal,
+    TypeVar,
+    cast,
+    overload,
+)
 
 import jsonschema
 import narwhals.stable.v1 as nw
@@ -26,9 +35,9 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import Protocol, runtime_checkable
 if sys.version_info >= (3, 10):
-    from typing import ParamSpec
+    from typing import Concatenate, ParamSpec
 else:
-    from typing_extensions import ParamSpec
+    from typing_extensions import Concatenate, ParamSpec
 
 
 if TYPE_CHECKING:
@@ -41,9 +50,10 @@ if TYPE_CHECKING:
     from altair.utils._dfi_types import DataFrame as DfiDataFrame
     from altair.vegalite.v5.schema._typing import StandardType_T as InferredVegaLiteType
 
-V = TypeVar("V")
 P = ParamSpec("P")
 TIntoDataFrame = TypeVar("TIntoDataFrame", bound=IntoDataFrame)
+T = TypeVar("T")
+R = TypeVar("R")
 
 
 @runtime_checkable
@@ -709,31 +719,41 @@ def infer_vegalite_type_for_narwhals(
         raise ValueError(msg)
 
 
-def use_signature(obj: Callable[P, Any]):  # -> Callable[..., Callable[P, V]]:
-    """Apply call signature and documentation of `obj` to the decorated method."""
+def use_signature(tp: Callable[P, Any], /):
+    """
+    Use the signature and doc of ``tp`` for the decorated callable ``cb``.
 
-    def decorate(func: Callable[..., V]) -> Callable[P, V]:
-        # call-signature of func is exposed via __wrapped__.
-        # we want it to mimic obj.__init__
+    - **Overload 1**: Decorating method
+    - **Overload 2**: Decorating function
+    """
 
-        # error: Accessing "__init__" on an instance is unsound,
-        # since instance.__init__ could be from an incompatible subclass  [misc]
-        wrapped = (
-            obj.__init__ if (isinstance(obj, type) and issubclass(obj, object)) else obj  # type: ignore [misc]
-        )
-        func.__wrapped__ = wrapped  # type: ignore[attr-defined]
-        func._uses_signature = obj  # type: ignore[attr-defined]
+    @overload
+    def decorate(
+        cb: Callable[Concatenate[T, ...], R], /
+    ) -> Callable[Concatenate[T, P], R]: ...
 
-        # Supplement the docstring of func with information from obj
-        if doc_in := obj.__doc__:
-            doc_lines = doc_in.splitlines(keepends=True)[1:]
-            # Patch in a reference to the class this docstring is copied from,
-            # to generate a hyperlink.
-            line_1 = f"{func.__doc__ or f'Refer to :class:`{obj.__name__}`'}\n"
-            func.__doc__ = "".join((line_1, *doc_lines))
-            return func
+    @overload
+    def decorate(cb: Callable[..., R], /) -> Callable[P, R]: ...
+
+    def decorate(
+        cb: Callable[..., R], /
+    ) -> Callable[Concatenate[T, P], R] | Callable[P, R]:
+        """
+        Raises when no doc was found.
+
+        Notes
+        -----
+        - Reference to ``tp`` is stored in ``cb.__wrapped__``.
+        - The doc for ``cb`` will have a ``.rst`` link added, referring  to ``tp``.
+        """
+        cb.__wrapped__ = getattr(tp, "__init__", tp)  # type: ignore[attr-defined]
+
+        if doc_in := tp.__doc__:
+            line_1 = f"{cb.__doc__ or f'Refer to :class:`{tp.__name__}`'}\n"
+            cb.__doc__ = "".join((line_1, *doc_in.splitlines(keepends=True)[1:]))
+            return cb
         else:
-            msg = f"Found no doc for {obj!r}"
+            msg = f"Found no doc for {tp!r}"
             raise AttributeError(msg)
 
     return decorate

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -57,8 +57,10 @@ R = TypeVar("R")
 
 WrapsFunc = TypeAliasType("WrapsFunc", Callable[..., R], type_params=(R,))
 WrappedFunc = TypeAliasType("WrappedFunc", Callable[P, R], type_params=(P, R))
+# NOTE: Requires stringized form to avoid `< (3, 11)` issues
+# See: https://github.com/vega/altair/actions/runs/10667859416/job/29567290871?pr=3565
 WrapsMethod = TypeAliasType(
-    "WrapsMethod", Callable[Concatenate[T, ...], R], type_params=(T, R)
+    "WrapsMethod", "Callable[Concatenate[T, ...], R]", type_params=(T, R)
 )
 WrappedMethod = TypeAliasType(
     "WrappedMethod", Callable[Concatenate[T, P], R], type_params=(T, P, R)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -311,11 +311,26 @@ class LookupData(core.LookupData):
 
 
 class FacetMapping(core.FacetMapping):
+    """
+    FacetMapping schema wrapper.
+
+    Parameters
+    ----------
+    column : str, :class:`FacetFieldDef`, :class:`Column`
+        A field definition for the horizontal facet of trellis plots.
+    row : str, :class:`FacetFieldDef`, :class:`Row`
+        A field definition for the vertical facet of trellis plots.
+    """
+
     _class_is_valid_at_instantiation = False
 
-    @utils.use_signature(core.FacetMapping)
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        column: Optional[str | FacetFieldDef | Column] = Undefined,
+        row: Optional[str | FacetFieldDef | Row] = Undefined,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(column=column, row=row, **kwargs)  # type: ignore[arg-type]
 
     def to_dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         copy = self.copy(deep=False)
@@ -3609,13 +3624,14 @@ class _EncodingMixin(channels._EncodingMixin):
             self = _top_schema_base(self).copy(deep=False)
             data, self.data = self.data, Undefined
 
-        if facet_specified:
+        f: Facet | FacetMapping
+        if not utils.is_undefined(facet):
             f = channels.Facet(facet) if isinstance(facet, str) else facet
         else:
             r: Any = row
             f = FacetMapping(row=r, column=column)
 
-        return FacetChart(spec=self, facet=f, data=data, columns=columns, **kwargs)
+        return FacetChart(spec=self, facet=f, data=data, columns=columns, **kwargs)  # pyright: ignore[reportArgumentType]
 
 
 class Chart(

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -4165,7 +4165,7 @@ class ConcatChart(TopLevelMixin, core.TopLevelConcatSpec):
 
 def concat(*charts: ConcatType, **kwargs: Any) -> ConcatChart:
     """Concatenate charts horizontally."""
-    return ConcatChart(concat=charts, **kwargs)  # pyright: ignore
+    return ConcatChart(concat=charts, **kwargs)
 
 
 class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
@@ -4269,7 +4269,7 @@ class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
 
 def hconcat(*charts: ConcatType, **kwargs: Any) -> HConcatChart:
     """Concatenate charts horizontally."""
-    return HConcatChart(hconcat=charts, **kwargs)  # pyright: ignore
+    return HConcatChart(hconcat=charts, **kwargs)
 
 
 class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
@@ -4375,7 +4375,7 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
 
 def vconcat(*charts: ConcatType, **kwargs: Any) -> VConcatChart:
     """Concatenate charts vertically."""
-    return VConcatChart(vconcat=charts, **kwargs)  # pyright: ignore
+    return VConcatChart(vconcat=charts, **kwargs)
 
 
 class LayerChart(TopLevelMixin, _EncodingMixin, core.TopLevelLayerSpec):
@@ -4501,7 +4501,7 @@ class LayerChart(TopLevelMixin, _EncodingMixin, core.TopLevelLayerSpec):
 
 def layer(*charts: LayerType, **kwargs: Any) -> LayerChart:
     """Layer multiple charts."""
-    return LayerChart(layer=charts, **kwargs)  # pyright: ignore
+    return LayerChart(layer=charts, **kwargs)
 
 
 class FacetChart(TopLevelMixin, core.TopLevelFacetSpec):

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -158,7 +158,6 @@ __all__ = [
     "ExtentTransform",
     "FacetEncodingFieldDef",
     "FacetFieldDef",
-    "FacetMapping",
     "FacetSpec",
     "FacetedEncoding",
     "FacetedUnitSpec",

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -537,7 +537,7 @@ def generate_vegalite_schema_wrapper(schema_file: Path) -> str:
     # of exported classes which are also defined in the channels or api modules which takes
     # precedent in the generated __init__.py files one and two levels up.
     # Importing these classes from multiple modules confuses type checkers.
-    EXCLUDE = {"Color", "Text", "LookupData", "Dict"}
+    EXCLUDE = {"Color", "Text", "LookupData", "Dict", "FacetMapping"}
     it = (c for c in definitions.keys() - EXCLUDE if not c.startswith("_"))
     all_ = [*sorted(it), "Root", "VegaLiteSchema", "SchemaBase", "load_schema"]
 


### PR DESCRIPTION
# Description
This PR addresses problems with this decorator that cause the wrong arguments to bind in some cases.

I've tried (and failed) to fix this multiple times over the past 1-2 months, but until now, hadn't come up with a solution that:
- fixed **all** of the cases
- satisfied both `mypy` and `pyright`

After one signature fails in a chain of methods - an IDE (*not `ipython`*) can't understand much that follows. 

Therefore, I consider the issue quite signficant.

# Tasks
- [x] Handle methods & functions correctly in `use_signature` (https://github.com/vega/altair/pull/3565/commits/53057b781ca47349e361a52df50fd322c86a7b32)
- [x] Add a repro for all the call sites this fixes
- [x] Update `use_signature` return type
	- `pyright` is inferring `Overload[...]`, which isn't a form I've seen before
	- `Overload[(cb: (T@decorate, ...) -> R@decorate, /) -> ((T@decorate, **P@use_signature) -> R@decorate), (cb: (...) -> R@decorate, /) -> ((**P@use_signature) -> R@decorate)]`
	- ~~Whatever the solution is, will most likely be a comment~~
	- *Inserted into docstring to avoid breakage*
- [x] Fix bug w/ `Concatenate[T, ...]` inside `TypeAliasType` on `< (3, 11)`
	- `typing.Concatenate` for `3.10`
	- `typing_extensions.Concatenate` for `3.8`, `3.9`

# Repro

```py
from typing_extensions import reveal_type
import altair as alt

# Would also include the function equivalent(s),
# if they did not already have `# pyright: ignore`(s)
concat = alt.ConcatChart()
hconcat = alt.HConcatChart()
vconcat = alt.VConcatChart()
layer = alt.LayerChart()

conf_facet = alt.Chart().configure_facet()
conf_concat = alt.Chart().configure_concat()
conf_tooltip_format = alt.Chart().configure_tooltipFormat()
conf_view = alt.Chart().configure_view()

reveal_type(conf_facet)
reveal_type(conf_concat)
reveal_type(conf_tooltip_format)
reveal_type(conf_view)

chained = conf_facet.configure_arc()
reveal_type(chained)
```

<details>
<summary>Warnings on <code>main</code></summary>

![image](https://github.com/user-attachments/assets/b44d1d93-dcbb-41b3-9dc3-73d0db160457)

</details>

<details><summary>Fixed on <code>fix-use-signature-2</code></summary>
<p>

![image](https://github.com/user-attachments/assets/6deb5d99-b7f8-4ca9-9484-b6af95d3ec6c)

</p>

</details> 

# Examples that fail type checking on `main`
- https://github.com/vega/altair/blob/5b5877903bce55392c66d9dd08b21e0da58a5fda/tests/examples_methods_syntax/ridgeline_plot.py
- https://github.com/vega/altair/blob/5b5877903bce55392c66d9dd08b21e0da58a5fda/tests/examples_methods_syntax/us_population_over_time.py
- https://github.com/vega/altair/blob/5b5877903bce55392c66d9dd08b21e0da58a5fda/tests/examples_methods_syntax/airport_connections.py

## Screenshots

<details>
<summary>Issues in <code>api.py</code></summary>

I added these ignore comments in response to this issue during https://github.com/vega/altair/commit/72bd84df76b405e2e6fc96f2c323470b0cf4bd02

https://github.com/vega/altair/blob/5b5877903bce55392c66d9dd08b21e0da58a5fda/altair/vegalite/v5/api.py#L4168

https://github.com/vega/altair/blob/5b5877903bce55392c66d9dd08b21e0da58a5fda/altair/vegalite/v5/api.py#L4272

https://github.com/vega/altair/blob/5b5877903bce55392c66d9dd08b21e0da58a5fda/altair/vegalite/v5/api.py#L4378

https://github.com/vega/altair/blob/5b5877903bce55392c66d9dd08b21e0da58a5fda/altair/vegalite/v5/api.py#L4504

![image](https://github.com/user-attachments/assets/49ec5550-cb26-4611-8210-abbc85860716)
</details>

<details><summary>Enabling type checking for <code>tests/</code></summary>
<p>

![image](https://github.com/user-attachments/assets/503e7198-9566-4516-9f8e-52b8c67f79f8)

</p>
</details> 
