### PR TITLE
fix(typing): Improve `Then` annotations, autocompletion, docs

### DIFF
--- a/altair/utils/__init__.py
+++ b/altair/utils/__init__.py
@@ -12,7 +12,7 @@ from .core import (
 from .deprecation import AltairDeprecationWarning, deprecated, deprecated_warn
 from .html import spec_to_html
 from .plugin_registry import PluginRegistry
-from .schemapi import Optional, SchemaBase, Undefined, is_undefined
+from .schemapi import Optional, SchemaBase, SchemaLike, Undefined, is_undefined
 
 __all__ = (
     "SHORTHAND_KEYS",
@@ -20,6 +20,7 @@ __all__ = (
     "Optional",
     "PluginRegistry",
     "SchemaBase",
+    "SchemaLike",
     "Undefined",
     "deprecated",
     "deprecated_warn",

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -28,7 +28,7 @@ import narwhals.stable.v1 as nw
 from narwhals.dependencies import get_polars, is_pandas_dataframe
 from narwhals.typing import IntoDataFrame
 
-from altair.utils.schemapi import SchemaBase, Undefined
+from altair.utils.schemapi import SchemaBase, SchemaLike, Undefined
 
 if sys.version_info >= (3, 12):
     from typing import Protocol, TypeAliasType, runtime_checkable
@@ -869,6 +869,8 @@ class _ChannelCache:
             obj = {"shorthand": obj}
         elif isinstance(obj, (list, tuple)):
             return [self._wrap_in_channel(el, encoding) for el in obj]
+        elif isinstance(obj, SchemaLike):
+            obj = obj.to_dict()
         if channel := self.name_to_channel.get(encoding):
             tp = channel["value" if "value" in obj else "field"]
             try:

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -832,6 +832,29 @@ This may represent **one of**:
 
 @runtime_checkable
 class SchemaLike(Generic[_JSON_VT_co], Protocol):  # type: ignore[misc]
+    """
+    Represents ``altair`` classes which *may* not derive ``SchemaBase``.
+
+    Should be kept tightly defined to the **minimum** requirements for:
+    - Converting into a form that can be validated by `jsonschema`_.
+    - Avoiding calling ``.to_dict()`` on a class external to ``altair``.
+
+    Attributes
+    ----------
+    _schema
+        A single item JSON Schema using the `type`_ keyword.
+
+        .. note::
+            more accurately described as a ``ClassVar``, see `discussion`_ for blocking issue.
+
+    .. _jsonschema:
+        https://github.com/python-jsonschema/jsonschema
+    .. _type:
+        https://json-schema.org/understanding-json-schema/reference/type
+    .. _discussion:
+        https://github.com/python/typing/discussions/1424
+    """
+
     _schema: _TypeMap[_JSON_VT_co]
 
     def to_dict(self, *args, **kwds) -> Any: ...

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -835,17 +835,18 @@ class SchemaLike(Generic[_JSON_VT_co], Protocol):  # type: ignore[misc]
     """
     Represents ``altair`` classes which *may* not derive ``SchemaBase``.
 
-    Should be kept tightly defined to the **minimum** requirements for:
-    - Converting into a form that can be validated by `jsonschema`_.
-    - Avoiding calling ``.to_dict()`` on a class external to ``altair``.
-
     Attributes
     ----------
     _schema
         A single item JSON Schema using the `type`_ keyword.
 
-        .. note::
-            more accurately described as a ``ClassVar``, see `discussion`_ for blocking issue.
+    Notes
+    -----
+    Should be kept tightly defined to the **minimum** requirements for:
+        - Converting into a form that can be validated by `jsonschema`_.
+        - Avoiding calling ``.to_dict()`` on a class external to ``altair``.
+    - ``_schema`` is more accurately described as a ``ClassVar``
+        - See `discussion`_ for blocking issue.
 
     .. _jsonschema:
         https://github.com/python-jsonschema/jsonschema
@@ -862,6 +863,21 @@ class SchemaLike(Generic[_JSON_VT_co], Protocol):  # type: ignore[misc]
 
 @runtime_checkable
 class ConditionLike(SchemaLike[Literal["object"]], Protocol):
+    """
+    Represents the wrapped state of a conditional encoding or property.
+
+    Attributes
+    ----------
+    condition
+        One or more (predicate, statement) pairs which each form a condition.
+
+    Notes
+    -----
+    - Can be extended with additional conditions.
+    - *Does not* define a default value, but can be finalized with one.
+    """
+
+    condition: Any
     _schema: _TypeMap[Literal["object"]] = {"type": "object"}
 
 

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -18,10 +18,12 @@ from typing import (
     Any,
     Dict,
     Final,
+    Generic,
     Iterable,
     Iterator,
     List,
     Literal,
+    Mapping,
     Sequence,
     TypeVar,
     Union,
@@ -40,6 +42,11 @@ from packaging.version import Version
 # but be aware that when you access it in this script, the vegalite module might
 # not yet be fully instantiated in case your code is being executed during import time
 from altair import vegalite
+
+if sys.version_info >= (3, 12):
+    from typing import Protocol, TypeAliasType, runtime_checkable
+else:
+    from typing_extensions import Protocol, TypeAliasType, runtime_checkable
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -524,11 +531,7 @@ def _todict(obj: Any, context: dict[str, Any] | None, np_opt: Any, pd_opt: Any) 
             for k, v in obj.items()
             if v is not Undefined
         }
-    elif (
-        hasattr(obj, "to_dict")
-        and (module_name := obj.__module__)
-        and module_name.startswith("altair")
-    ):
+    elif isinstance(obj, SchemaLike):
         return obj.to_dict()
     elif pd_opt is not None and isinstance(obj, pd_opt.Timestamp):
         return pd_opt.Timestamp(obj).isoformat()
@@ -787,6 +790,56 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
         )
         message += "".join(it)
         return message
+
+
+_JSON_VT_co = TypeVar(
+    "_JSON_VT_co",
+    Literal["string"],
+    Literal["object"],
+    Literal["array"],
+    covariant=True,
+)
+"""
+One of a subset of JSON Schema `primitive types`_:
+
+    ["string", "object", "array"]
+
+.. _primitive types:
+    https://json-schema.org/draft-07/json-schema-validation#rfc.section.6.1.1
+"""
+
+_TypeMap = TypeAliasType(
+    "_TypeMap", Mapping[Literal["type"], _JSON_VT_co], type_params=(_JSON_VT_co,)
+)
+"""
+A single item JSON Schema using the `type`_ keyword.
+
+This may represent **one of**:
+
+    {"type": "string"}
+    {"type": "object"}
+    {"type": "array"}
+
+.. _type:
+    https://json-schema.org/understanding-json-schema/reference/type
+"""
+
+# NOTE: Type checkers want opposing things:
+# - `mypy`   : Covariant type variable "_JSON_VT_co" used in protocol where invariant one is expected  [misc]
+# - `pyright`: Type variable "_JSON_VT_co" used in generic protocol "SchemaLike" should be covariant [reportInvalidTypeVarUse]
+# Siding with `pyright` as this is consistent with https://github.com/python/typeshed/blob/9e506eb5e8fc2823db8c60ad561b1145ff114947/stdlib/typing.pyi#L690
+
+
+@runtime_checkable
+class SchemaLike(Generic[_JSON_VT_co], Protocol):  # type: ignore[misc]
+    _schema: _TypeMap[_JSON_VT_co]
+
+    def to_dict(self, *args, **kwds) -> Any: ...
+
+
+@runtime_checkable
+class ConditionLike(SchemaLike[Literal["object"]], Protocol):
+    _schema: _TypeMap[Literal["object"]] = {"type": "object"}
 
 
 class UndefinedType:

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -33,7 +33,7 @@ from .schema import SCHEMA_URL, channels, core, mixins
 from .schema._typing import Map
 from .theme import themes
 
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 14):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -24,7 +24,7 @@ from altair.utils._vegafusion_data import (
 from altair.utils._vegafusion_data import using_vegafusion as _using_vegafusion
 from altair.utils.data import DataType
 from altair.utils.data import is_data_type as _is_data_type
-from altair.utils.schemapi import ConditionLike
+from altair.utils.schemapi import ConditionLike, _TypeMap
 
 from .compiler import vegalite_compilers
 from .data import data_transformers
@@ -355,6 +355,7 @@ TOPLEVEL_ONLY_KEYS = {"background", "config", "autosize", "padding", "$schema"}
 class Parameter(_expr_core.OperatorMixin):
     """A Parameter object."""
 
+    _schema: t.ClassVar[_TypeMap[Literal["object"]]] = {"type": "object"}
     _counter: int = 0
 
     @classmethod
@@ -457,6 +458,8 @@ class SelectionPredicateComposition(core.PredicateComposition):
 
 
 class ParameterExpression(_expr_core.OperatorMixin):
+    _schema: t.ClassVar[_TypeMap[Literal["object"]]] = {"type": "object"}
+
     def __init__(self, expr: IntoExpression) -> None:
         self.expr = expr
 
@@ -471,6 +474,8 @@ class ParameterExpression(_expr_core.OperatorMixin):
 
 
 class SelectionExpression(_expr_core.OperatorMixin):
+    _schema: t.ClassVar[_TypeMap[Literal["object"]]] = {"type": "object"}
+
     def __init__(self, expr: IntoExpression) -> None:
         self.expr = expr
 

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -696,6 +696,7 @@ def _is_condition_extra(obj: Any, *objs: Any, kwds: Map) -> TypeIs[_Condition]:
 
 
 def _is_condition_closed(obj: Map) -> TypeIs[_ConditionClosed]:
+    """Return `True` if ``obj`` can be used in a chained condition."""
     return {"empty", "param", "test", "value"} >= obj.keys()
 
 

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -626,16 +626,6 @@ def _condition_to_selection(
     return selection
 
 
-class _ConditionClosed(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
-    # https://peps.python.org/pep-0728/
-    # Parameter {"param", "value", "empty"}
-    # Predicate {"test", "value"}
-    empty: Optional[bool]
-    param: Parameter | str
-    test: _TestPredicateType
-    value: Any
-
-
 class _ConditionExtra(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
     # https://peps.python.org/pep-0728/
     # Likely a Field predicate
@@ -648,6 +638,17 @@ class _ConditionExtra(TypedDict, closed=True, total=False):  # type: ignore[call
 
 _Condition: TypeAlias = _ConditionExtra
 """A singular, non-chainable condition produced by ``.when()``."""
+
+
+class _ConditionClosed(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
+    # https://peps.python.org/pep-0728/
+    # Parameter {"param", "value", "empty"}
+    # Predicate {"test", "value"}
+    empty: Optional[bool]
+    param: Parameter | str
+    test: _TestPredicateType
+    value: Any
+
 
 _Conditions: TypeAlias = t.List[_ConditionClosed]
 """Chainable conditions produced by ``.when()`` and ``Then.when()``."""

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1084,6 +1084,17 @@ class Then(ConditionLike, t.Generic[_C]):
     def __deepcopy__(self, memo: Any) -> Self:
         return type(self)(_Conditional(condition=_deepcopy(self.condition, memo)))
 
+    def __repr__(self) -> str:
+        name = type(self).__name__
+        COND = "condition: "
+        LB, RB = "{", "}"
+        if len(self.condition) == 1:
+            args = f"{COND}{self.condition!r}".replace("\n", "\n  ")
+        else:
+            conds = "\n    ".join(f"{c!r}" for c in self.condition)
+            args = f"{COND}[\n    " f"{conds}\n  ]"
+        return f"{name}({LB}\n  {args}\n{RB})"
+
 
 class ChainedWhen(_BaseWhen):
     """

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -660,6 +660,9 @@ class _Conditional(TypedDict, t.Generic[_C], total=False):
     value: Any
 
 
+IntoCondition: TypeAlias = Union[ConditionLike, _Conditional[Any]]
+
+
 class _Value(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
     # https://peps.python.org/pep-0728/
     value: Required[Any]

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -661,11 +661,29 @@ _C = TypeVar("_C", _Conditions, _Condition)
 
 
 class _Conditional(TypedDict, t.Generic[_C], total=False):
+    """
+    A dictionary representation of a conditional encoding or property.
+
+    Parameters
+    ----------
+    condition
+        One or more (predicate, statement) pairs which each form a condition.
+    value
+        An optional default value, used when no predicates were met.
+    """
+
     condition: Required[_C]
     value: Any
 
 
 IntoCondition: TypeAlias = Union[ConditionLike, _Conditional[Any]]
+"""
+Anything that can be converted into a conditional encoding or property.
+
+Notes
+-----
+Represents all outputs from `when-then-otherwise` conditions, which are not ``SchemaBase`` types.
+"""
 
 
 class _Value(TypedDict, closed=True, total=False):  # type: ignore[call-arg]

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -891,7 +891,7 @@ class Then(SchemaBase, t.Generic[_C]):
     `polars.when <https://docs.pola.rs/py-polars/html/reference/expressions/api/polars.when.html>`__
     """
 
-    _schema = {"type": "object"}
+    _schema: t.ClassVar[dict[Literal["type"], Literal["object"]]] = {"type": "object"}
 
     def __init__(self, conditions: _Conditional[_C], /) -> None:
         super().__init__(**conditions)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -636,7 +636,19 @@ class _ConditionExtra(TypedDict, closed=True, total=False):  # type: ignore[call
 
 
 _Condition: TypeAlias = _ConditionExtra
-"""A singular, non-chainable condition produced by ``.when()``."""
+"""
+A singular, *possibly* non-chainable condition produced by ``.when()``.
+
+The default **permissive** representation.
+
+Allows arbitrary additional keys that *may* be present in a `Conditional Field`_
+but not a `Conditional Value`_.
+
+.. _Conditional Field:
+    https://vega.github.io/vega-lite/docs/condition.html#field
+.. _Conditional Value:
+    https://vega.github.io/vega-lite/docs/condition.html#value
+"""
 
 
 class _ConditionClosed(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
@@ -650,7 +662,14 @@ class _ConditionClosed(TypedDict, closed=True, total=False):  # type: ignore[cal
 
 
 _Conditions: TypeAlias = t.List[_ConditionClosed]
-"""Chainable conditions produced by ``.when()`` and ``Then.when()``."""
+"""
+Chainable conditions produced by ``.when()`` and ``Then.when()``.
+
+All must be a `Conditional Value`_.
+
+.. _Conditional Value:
+    https://vega.github.io/vega-lite/docs/condition.html#value
+"""
 
 _C = TypeVar("_C", _Conditions, _Condition)
 

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1152,7 +1152,6 @@ class ChainedWhen(_BaseWhen):
             )
         """
         condition = self._when_then(statement, kwds)
-
         if _is_condition_closed(condition):
             conditions = self._conditions.copy()
             conditions["condition"].append(condition)
@@ -4925,7 +4924,7 @@ def _remove_layer_props(  # noqa: C901
             # or it must be Undefined or identical to proceed.
             output_dict[prop] = chart[prop]
         else:
-            msg = f"There are inconsistent values {values} for {prop}"
+            msg = f"There are inconsistent values {values} for {prop}"  # pyright: ignore[reportPossiblyUnboundVariable]
             raise ValueError(msg)
         subcharts = [remove_prop(c, prop) for c in subcharts]
 

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -24915,201 +24915,132 @@ class YOffsetValue(ValueChannelMixin, core.ValueDefnumber):
         super().__init__(value=value, **kwds)
 
 
-ChannelAngle: TypeAlias = Union[
-    str, Angle, Map, AngleDatum, AngleValue, "IntoCondition"
+AnyAngle: TypeAlias = Union[Angle, AngleDatum, AngleValue]
+AnyColor: TypeAlias = Union[Color, ColorDatum, ColorValue]
+AnyDescription: TypeAlias = Union[Description, DescriptionValue]
+AnyFill: TypeAlias = Union[Fill, FillDatum, FillValue]
+AnyFillOpacity: TypeAlias = Union[FillOpacity, FillOpacityDatum, FillOpacityValue]
+AnyHref: TypeAlias = Union[Href, HrefValue]
+AnyLatitude: TypeAlias = Union[Latitude, LatitudeDatum]
+AnyLatitude2: TypeAlias = Union[Latitude2, Latitude2Datum, Latitude2Value]
+AnyLongitude: TypeAlias = Union[Longitude, LongitudeDatum]
+AnyLongitude2: TypeAlias = Union[Longitude2, Longitude2Datum, Longitude2Value]
+AnyOpacity: TypeAlias = Union[Opacity, OpacityDatum, OpacityValue]
+AnyOrder: TypeAlias = Union[Order, OrderValue]
+AnyRadius: TypeAlias = Union[Radius, RadiusDatum, RadiusValue]
+AnyRadius2: TypeAlias = Union[Radius2, Radius2Datum, Radius2Value]
+AnyShape: TypeAlias = Union[Shape, ShapeDatum, ShapeValue]
+AnySize: TypeAlias = Union[Size, SizeDatum, SizeValue]
+AnyStroke: TypeAlias = Union[Stroke, StrokeDatum, StrokeValue]
+AnyStrokeDash: TypeAlias = Union[StrokeDash, StrokeDashDatum, StrokeDashValue]
+AnyStrokeOpacity: TypeAlias = Union[
+    StrokeOpacity, StrokeOpacityDatum, StrokeOpacityValue
 ]
-ChannelColor: TypeAlias = Union[
-    str, Color, Map, ColorDatum, ColorValue, "IntoCondition"
-]
-ChannelColumn: TypeAlias = Union[str, Column, Map, "IntoCondition"]
-ChannelDescription: TypeAlias = Union[
-    str, Description, Map, DescriptionValue, "IntoCondition"
-]
-ChannelDetail: TypeAlias = OneOrSeq[Union[str, Detail, Map, "IntoCondition"]]
-ChannelFacet: TypeAlias = Union[str, Facet, Map, "IntoCondition"]
-ChannelFill: TypeAlias = Union[str, Fill, Map, FillDatum, FillValue, "IntoCondition"]
-ChannelFillOpacity: TypeAlias = Union[
-    str, FillOpacity, Map, FillOpacityDatum, FillOpacityValue, "IntoCondition"
-]
-ChannelHref: TypeAlias = Union[str, Href, Map, HrefValue, "IntoCondition"]
-ChannelKey: TypeAlias = Union[str, Key, Map, "IntoCondition"]
-ChannelLatitude: TypeAlias = Union[str, Latitude, Map, LatitudeDatum, "IntoCondition"]
-ChannelLatitude2: TypeAlias = Union[
-    str, Latitude2, Map, Latitude2Datum, Latitude2Value, "IntoCondition"
-]
-ChannelLongitude: TypeAlias = Union[
-    str, Longitude, Map, LongitudeDatum, "IntoCondition"
-]
-ChannelLongitude2: TypeAlias = Union[
-    str, Longitude2, Map, Longitude2Datum, Longitude2Value, "IntoCondition"
-]
-ChannelOpacity: TypeAlias = Union[
-    str, Opacity, Map, OpacityDatum, OpacityValue, "IntoCondition"
-]
-ChannelOrder: TypeAlias = OneOrSeq[Union[str, Order, Map, OrderValue, "IntoCondition"]]
-ChannelRadius: TypeAlias = Union[
-    str, Radius, Map, RadiusDatum, RadiusValue, "IntoCondition"
-]
-ChannelRadius2: TypeAlias = Union[
-    str, Radius2, Map, Radius2Datum, Radius2Value, "IntoCondition"
-]
-ChannelRow: TypeAlias = Union[str, Row, Map, "IntoCondition"]
-ChannelShape: TypeAlias = Union[
-    str, Shape, Map, ShapeDatum, ShapeValue, "IntoCondition"
-]
-ChannelSize: TypeAlias = Union[str, Size, Map, SizeDatum, SizeValue, "IntoCondition"]
-ChannelStroke: TypeAlias = Union[
-    str, Stroke, Map, StrokeDatum, StrokeValue, "IntoCondition"
-]
-ChannelStrokeDash: TypeAlias = Union[
-    str, StrokeDash, Map, StrokeDashDatum, StrokeDashValue, "IntoCondition"
-]
-ChannelStrokeOpacity: TypeAlias = Union[
-    str, StrokeOpacity, Map, StrokeOpacityDatum, StrokeOpacityValue, "IntoCondition"
-]
-ChannelStrokeWidth: TypeAlias = Union[
-    str, StrokeWidth, Map, StrokeWidthDatum, StrokeWidthValue, "IntoCondition"
-]
-ChannelText: TypeAlias = Union[str, Text, Map, TextDatum, TextValue, "IntoCondition"]
-ChannelTheta: TypeAlias = Union[
-    str, Theta, Map, ThetaDatum, ThetaValue, "IntoCondition"
-]
-ChannelTheta2: TypeAlias = Union[
-    str, Theta2, Map, Theta2Datum, Theta2Value, "IntoCondition"
-]
-ChannelTooltip: TypeAlias = OneOrSeq[
-    Union[str, Tooltip, Map, TooltipValue, "IntoCondition"]
-]
-ChannelUrl: TypeAlias = Union[str, Url, Map, UrlValue, "IntoCondition"]
-ChannelX: TypeAlias = Union[str, X, Map, XDatum, XValue, "IntoCondition"]
-ChannelX2: TypeAlias = Union[str, X2, Map, X2Datum, X2Value, "IntoCondition"]
-ChannelXError: TypeAlias = Union[str, XError, Map, XErrorValue, "IntoCondition"]
-ChannelXError2: TypeAlias = Union[str, XError2, Map, XError2Value, "IntoCondition"]
-ChannelXOffset: TypeAlias = Union[
-    str, XOffset, Map, XOffsetDatum, XOffsetValue, "IntoCondition"
-]
-ChannelY: TypeAlias = Union[str, Y, Map, YDatum, YValue, "IntoCondition"]
-ChannelY2: TypeAlias = Union[str, Y2, Map, Y2Datum, Y2Value, "IntoCondition"]
-ChannelYError: TypeAlias = Union[str, YError, Map, YErrorValue, "IntoCondition"]
-ChannelYError2: TypeAlias = Union[str, YError2, Map, YError2Value, "IntoCondition"]
-ChannelYOffset: TypeAlias = Union[
-    str, YOffset, Map, YOffsetDatum, YOffsetValue, "IntoCondition"
-]
+AnyStrokeWidth: TypeAlias = Union[StrokeWidth, StrokeWidthDatum, StrokeWidthValue]
+AnyText: TypeAlias = Union[Text, TextDatum, TextValue]
+AnyTheta: TypeAlias = Union[Theta, ThetaDatum, ThetaValue]
+AnyTheta2: TypeAlias = Union[Theta2, Theta2Datum, Theta2Value]
+AnyTooltip: TypeAlias = Union[Tooltip, TooltipValue]
+AnyUrl: TypeAlias = Union[Url, UrlValue]
+AnyX: TypeAlias = Union[X, XDatum, XValue]
+AnyX2: TypeAlias = Union[X2, X2Datum, X2Value]
+AnyXError: TypeAlias = Union[XError, XErrorValue]
+AnyXError2: TypeAlias = Union[XError2, XError2Value]
+AnyXOffset: TypeAlias = Union[XOffset, XOffsetDatum, XOffsetValue]
+AnyY: TypeAlias = Union[Y, YDatum, YValue]
+AnyY2: TypeAlias = Union[Y2, Y2Datum, Y2Value]
+AnyYError: TypeAlias = Union[YError, YErrorValue]
+AnyYError2: TypeAlias = Union[YError2, YError2Value]
+AnyYOffset: TypeAlias = Union[YOffset, YOffsetDatum, YOffsetValue]
+
+ChannelAngle: TypeAlias = Union[str, AnyAngle, "IntoCondition", Map]
+ChannelColor: TypeAlias = Union[str, AnyColor, "IntoCondition", Map]
+ChannelColumn: TypeAlias = Union[str, Column, "IntoCondition", Map]
+ChannelDescription: TypeAlias = Union[str, AnyDescription, "IntoCondition", Map]
+ChannelDetail: TypeAlias = OneOrSeq[Union[str, Detail, "IntoCondition", Map]]
+ChannelFacet: TypeAlias = Union[str, Facet, "IntoCondition", Map]
+ChannelFill: TypeAlias = Union[str, AnyFill, "IntoCondition", Map]
+ChannelFillOpacity: TypeAlias = Union[str, AnyFillOpacity, "IntoCondition", Map]
+ChannelHref: TypeAlias = Union[str, AnyHref, "IntoCondition", Map]
+ChannelKey: TypeAlias = Union[str, Key, "IntoCondition", Map]
+ChannelLatitude: TypeAlias = Union[str, AnyLatitude, "IntoCondition", Map]
+ChannelLatitude2: TypeAlias = Union[str, AnyLatitude2, "IntoCondition", Map]
+ChannelLongitude: TypeAlias = Union[str, AnyLongitude, "IntoCondition", Map]
+ChannelLongitude2: TypeAlias = Union[str, AnyLongitude2, "IntoCondition", Map]
+ChannelOpacity: TypeAlias = Union[str, AnyOpacity, "IntoCondition", Map]
+ChannelOrder: TypeAlias = OneOrSeq[Union[str, AnyOrder, "IntoCondition", Map]]
+ChannelRadius: TypeAlias = Union[str, AnyRadius, "IntoCondition", Map]
+ChannelRadius2: TypeAlias = Union[str, AnyRadius2, "IntoCondition", Map]
+ChannelRow: TypeAlias = Union[str, Row, "IntoCondition", Map]
+ChannelShape: TypeAlias = Union[str, AnyShape, "IntoCondition", Map]
+ChannelSize: TypeAlias = Union[str, AnySize, "IntoCondition", Map]
+ChannelStroke: TypeAlias = Union[str, AnyStroke, "IntoCondition", Map]
+ChannelStrokeDash: TypeAlias = Union[str, AnyStrokeDash, "IntoCondition", Map]
+ChannelStrokeOpacity: TypeAlias = Union[str, AnyStrokeOpacity, "IntoCondition", Map]
+ChannelStrokeWidth: TypeAlias = Union[str, AnyStrokeWidth, "IntoCondition", Map]
+ChannelText: TypeAlias = Union[str, AnyText, "IntoCondition", Map]
+ChannelTheta: TypeAlias = Union[str, AnyTheta, "IntoCondition", Map]
+ChannelTheta2: TypeAlias = Union[str, AnyTheta2, "IntoCondition", Map]
+ChannelTooltip: TypeAlias = OneOrSeq[Union[str, AnyTooltip, "IntoCondition", Map]]
+ChannelUrl: TypeAlias = Union[str, AnyUrl, "IntoCondition", Map]
+ChannelX: TypeAlias = Union[str, AnyX, "IntoCondition", Map]
+ChannelX2: TypeAlias = Union[str, AnyX2, "IntoCondition", Map]
+ChannelXError: TypeAlias = Union[str, AnyXError, "IntoCondition", Map]
+ChannelXError2: TypeAlias = Union[str, AnyXError2, "IntoCondition", Map]
+ChannelXOffset: TypeAlias = Union[str, AnyXOffset, "IntoCondition", Map]
+ChannelY: TypeAlias = Union[str, AnyY, "IntoCondition", Map]
+ChannelY2: TypeAlias = Union[str, AnyY2, "IntoCondition", Map]
+ChannelYError: TypeAlias = Union[str, AnyYError, "IntoCondition", Map]
+ChannelYError2: TypeAlias = Union[str, AnyYError2, "IntoCondition", Map]
+ChannelYOffset: TypeAlias = Union[str, AnyYOffset, "IntoCondition", Map]
 
 
 class _EncodingMixin:
     def encode(
         self,
         *args: Any,
-        angle: Optional[
-            str | Angle | Map | AngleDatum | AngleValue | IntoCondition
-        ] = Undefined,
-        color: Optional[
-            str | Color | Map | ColorDatum | ColorValue | IntoCondition
-        ] = Undefined,
-        column: Optional[str | Column | Map | IntoCondition] = Undefined,
-        description: Optional[
-            str | Description | Map | DescriptionValue | IntoCondition
-        ] = Undefined,
-        detail: Optional[OneOrSeq[str | Detail | Map | IntoCondition]] = Undefined,
-        facet: Optional[str | Facet | Map | IntoCondition] = Undefined,
-        fill: Optional[
-            str | Fill | Map | FillDatum | FillValue | IntoCondition
-        ] = Undefined,
-        fillOpacity: Optional[
-            str
-            | FillOpacity
-            | Map
-            | FillOpacityDatum
-            | FillOpacityValue
-            | IntoCondition
-        ] = Undefined,
-        href: Optional[str | Href | Map | HrefValue | IntoCondition] = Undefined,
-        key: Optional[str | Key | Map | IntoCondition] = Undefined,
-        latitude: Optional[
-            str | Latitude | Map | LatitudeDatum | IntoCondition
-        ] = Undefined,
-        latitude2: Optional[
-            str | Latitude2 | Map | Latitude2Datum | Latitude2Value | IntoCondition
-        ] = Undefined,
-        longitude: Optional[
-            str | Longitude | Map | LongitudeDatum | IntoCondition
-        ] = Undefined,
-        longitude2: Optional[
-            str | Longitude2 | Map | Longitude2Datum | Longitude2Value | IntoCondition
-        ] = Undefined,
-        opacity: Optional[
-            str | Opacity | Map | OpacityDatum | OpacityValue | IntoCondition
-        ] = Undefined,
-        order: Optional[
-            OneOrSeq[str | Order | Map | OrderValue | IntoCondition]
-        ] = Undefined,
-        radius: Optional[
-            str | Radius | Map | RadiusDatum | RadiusValue | IntoCondition
-        ] = Undefined,
-        radius2: Optional[
-            str | Radius2 | Map | Radius2Datum | Radius2Value | IntoCondition
-        ] = Undefined,
-        row: Optional[str | Row | Map | IntoCondition] = Undefined,
-        shape: Optional[
-            str | Shape | Map | ShapeDatum | ShapeValue | IntoCondition
-        ] = Undefined,
-        size: Optional[
-            str | Size | Map | SizeDatum | SizeValue | IntoCondition
-        ] = Undefined,
-        stroke: Optional[
-            str | Stroke | Map | StrokeDatum | StrokeValue | IntoCondition
-        ] = Undefined,
-        strokeDash: Optional[
-            str | StrokeDash | Map | StrokeDashDatum | StrokeDashValue | IntoCondition
-        ] = Undefined,
+        angle: Optional[str | AnyAngle | IntoCondition | Map] = Undefined,
+        color: Optional[str | AnyColor | IntoCondition | Map] = Undefined,
+        column: Optional[str | Column | IntoCondition | Map] = Undefined,
+        description: Optional[str | AnyDescription | IntoCondition | Map] = Undefined,
+        detail: Optional[OneOrSeq[str | Detail | IntoCondition | Map]] = Undefined,
+        facet: Optional[str | Facet | IntoCondition | Map] = Undefined,
+        fill: Optional[str | AnyFill | IntoCondition | Map] = Undefined,
+        fillOpacity: Optional[str | AnyFillOpacity | IntoCondition | Map] = Undefined,
+        href: Optional[str | AnyHref | IntoCondition | Map] = Undefined,
+        key: Optional[str | Key | IntoCondition | Map] = Undefined,
+        latitude: Optional[str | AnyLatitude | IntoCondition | Map] = Undefined,
+        latitude2: Optional[str | AnyLatitude2 | IntoCondition | Map] = Undefined,
+        longitude: Optional[str | AnyLongitude | IntoCondition | Map] = Undefined,
+        longitude2: Optional[str | AnyLongitude2 | IntoCondition | Map] = Undefined,
+        opacity: Optional[str | AnyOpacity | IntoCondition | Map] = Undefined,
+        order: Optional[OneOrSeq[str | AnyOrder | IntoCondition | Map]] = Undefined,
+        radius: Optional[str | AnyRadius | IntoCondition | Map] = Undefined,
+        radius2: Optional[str | AnyRadius2 | IntoCondition | Map] = Undefined,
+        row: Optional[str | Row | IntoCondition | Map] = Undefined,
+        shape: Optional[str | AnyShape | IntoCondition | Map] = Undefined,
+        size: Optional[str | AnySize | IntoCondition | Map] = Undefined,
+        stroke: Optional[str | AnyStroke | IntoCondition | Map] = Undefined,
+        strokeDash: Optional[str | AnyStrokeDash | IntoCondition | Map] = Undefined,
         strokeOpacity: Optional[
-            str
-            | StrokeOpacity
-            | Map
-            | StrokeOpacityDatum
-            | StrokeOpacityValue
-            | IntoCondition
+            str | AnyStrokeOpacity | IntoCondition | Map
         ] = Undefined,
-        strokeWidth: Optional[
-            str
-            | StrokeWidth
-            | Map
-            | StrokeWidthDatum
-            | StrokeWidthValue
-            | IntoCondition
-        ] = Undefined,
-        text: Optional[
-            str | Text | Map | TextDatum | TextValue | IntoCondition
-        ] = Undefined,
-        theta: Optional[
-            str | Theta | Map | ThetaDatum | ThetaValue | IntoCondition
-        ] = Undefined,
-        theta2: Optional[
-            str | Theta2 | Map | Theta2Datum | Theta2Value | IntoCondition
-        ] = Undefined,
-        tooltip: Optional[
-            OneOrSeq[str | Tooltip | Map | TooltipValue | IntoCondition]
-        ] = Undefined,
-        url: Optional[str | Url | Map | UrlValue | IntoCondition] = Undefined,
-        x: Optional[str | X | Map | XDatum | XValue | IntoCondition] = Undefined,
-        x2: Optional[str | X2 | Map | X2Datum | X2Value | IntoCondition] = Undefined,
-        xError: Optional[str | XError | Map | XErrorValue | IntoCondition] = Undefined,
-        xError2: Optional[
-            str | XError2 | Map | XError2Value | IntoCondition
-        ] = Undefined,
-        xOffset: Optional[
-            str | XOffset | Map | XOffsetDatum | XOffsetValue | IntoCondition
-        ] = Undefined,
-        y: Optional[str | Y | Map | YDatum | YValue | IntoCondition] = Undefined,
-        y2: Optional[str | Y2 | Map | Y2Datum | Y2Value | IntoCondition] = Undefined,
-        yError: Optional[str | YError | Map | YErrorValue | IntoCondition] = Undefined,
-        yError2: Optional[
-            str | YError2 | Map | YError2Value | IntoCondition
-        ] = Undefined,
-        yOffset: Optional[
-            str | YOffset | Map | YOffsetDatum | YOffsetValue | IntoCondition
-        ] = Undefined,
+        strokeWidth: Optional[str | AnyStrokeWidth | IntoCondition | Map] = Undefined,
+        text: Optional[str | AnyText | IntoCondition | Map] = Undefined,
+        theta: Optional[str | AnyTheta | IntoCondition | Map] = Undefined,
+        theta2: Optional[str | AnyTheta2 | IntoCondition | Map] = Undefined,
+        tooltip: Optional[OneOrSeq[str | AnyTooltip | IntoCondition | Map]] = Undefined,
+        url: Optional[str | AnyUrl | IntoCondition | Map] = Undefined,
+        x: Optional[str | AnyX | IntoCondition | Map] = Undefined,
+        x2: Optional[str | AnyX2 | IntoCondition | Map] = Undefined,
+        xError: Optional[str | AnyXError | IntoCondition | Map] = Undefined,
+        xError2: Optional[str | AnyXError2 | IntoCondition | Map] = Undefined,
+        xOffset: Optional[str | AnyXOffset | IntoCondition | Map] = Undefined,
+        y: Optional[str | AnyY | IntoCondition | Map] = Undefined,
+        y2: Optional[str | AnyY2 | IntoCondition | Map] = Undefined,
+        yError: Optional[str | AnyYError | IntoCondition | Map] = Undefined,
+        yError2: Optional[str | AnyYError2 | IntoCondition | Map] = Undefined,
+        yOffset: Optional[str | AnyYOffset | IntoCondition | Map] = Undefined,
     ) -> Self:
         """
         Map properties of the data to visual properties of the chart (see :class:`FacetedEncoding`).
@@ -25540,58 +25471,43 @@ class EncodeKwds(TypedDict, total=False):
         Offset of y-position of the marks
     """
 
-    angle: str | Angle | Map | AngleDatum | AngleValue | IntoCondition
-    color: str | Color | Map | ColorDatum | ColorValue | IntoCondition
-    column: str | Column | Map | IntoCondition
-    description: str | Description | Map | DescriptionValue | IntoCondition
-    detail: OneOrSeq[str | Detail | Map | IntoCondition]
-    facet: str | Facet | Map | IntoCondition
-    fill: str | Fill | Map | FillDatum | FillValue | IntoCondition
-    fillOpacity: (
-        str | FillOpacity | Map | FillOpacityDatum | FillOpacityValue | IntoCondition
-    )
-    href: str | Href | Map | HrefValue | IntoCondition
-    key: str | Key | Map | IntoCondition
-    latitude: str | Latitude | Map | LatitudeDatum | IntoCondition
-    latitude2: str | Latitude2 | Map | Latitude2Datum | Latitude2Value | IntoCondition
-    longitude: str | Longitude | Map | LongitudeDatum | IntoCondition
-    longitude2: (
-        str | Longitude2 | Map | Longitude2Datum | Longitude2Value | IntoCondition
-    )
-    opacity: str | Opacity | Map | OpacityDatum | OpacityValue | IntoCondition
-    order: OneOrSeq[str | Order | Map | OrderValue | IntoCondition]
-    radius: str | Radius | Map | RadiusDatum | RadiusValue | IntoCondition
-    radius2: str | Radius2 | Map | Radius2Datum | Radius2Value | IntoCondition
-    row: str | Row | Map | IntoCondition
-    shape: str | Shape | Map | ShapeDatum | ShapeValue | IntoCondition
-    size: str | Size | Map | SizeDatum | SizeValue | IntoCondition
-    stroke: str | Stroke | Map | StrokeDatum | StrokeValue | IntoCondition
-    strokeDash: (
-        str | StrokeDash | Map | StrokeDashDatum | StrokeDashValue | IntoCondition
-    )
-    strokeOpacity: (
-        str
-        | StrokeOpacity
-        | Map
-        | StrokeOpacityDatum
-        | StrokeOpacityValue
-        | IntoCondition
-    )
-    strokeWidth: (
-        str | StrokeWidth | Map | StrokeWidthDatum | StrokeWidthValue | IntoCondition
-    )
-    text: str | Text | Map | TextDatum | TextValue | IntoCondition
-    theta: str | Theta | Map | ThetaDatum | ThetaValue | IntoCondition
-    theta2: str | Theta2 | Map | Theta2Datum | Theta2Value | IntoCondition
-    tooltip: OneOrSeq[str | Tooltip | Map | TooltipValue | IntoCondition]
-    url: str | Url | Map | UrlValue | IntoCondition
-    x: str | X | Map | XDatum | XValue | IntoCondition
-    x2: str | X2 | Map | X2Datum | X2Value | IntoCondition
-    xError: str | XError | Map | XErrorValue | IntoCondition
-    xError2: str | XError2 | Map | XError2Value | IntoCondition
-    xOffset: str | XOffset | Map | XOffsetDatum | XOffsetValue | IntoCondition
-    y: str | Y | Map | YDatum | YValue | IntoCondition
-    y2: str | Y2 | Map | Y2Datum | Y2Value | IntoCondition
-    yError: str | YError | Map | YErrorValue | IntoCondition
-    yError2: str | YError2 | Map | YError2Value | IntoCondition
-    yOffset: str | YOffset | Map | YOffsetDatum | YOffsetValue | IntoCondition
+    angle: str | AnyAngle | IntoCondition | Map
+    color: str | AnyColor | IntoCondition | Map
+    column: str | Column | IntoCondition | Map
+    description: str | AnyDescription | IntoCondition | Map
+    detail: OneOrSeq[str | Detail | IntoCondition | Map]
+    facet: str | Facet | IntoCondition | Map
+    fill: str | AnyFill | IntoCondition | Map
+    fillOpacity: str | AnyFillOpacity | IntoCondition | Map
+    href: str | AnyHref | IntoCondition | Map
+    key: str | Key | IntoCondition | Map
+    latitude: str | AnyLatitude | IntoCondition | Map
+    latitude2: str | AnyLatitude2 | IntoCondition | Map
+    longitude: str | AnyLongitude | IntoCondition | Map
+    longitude2: str | AnyLongitude2 | IntoCondition | Map
+    opacity: str | AnyOpacity | IntoCondition | Map
+    order: OneOrSeq[str | AnyOrder | IntoCondition | Map]
+    radius: str | AnyRadius | IntoCondition | Map
+    radius2: str | AnyRadius2 | IntoCondition | Map
+    row: str | Row | IntoCondition | Map
+    shape: str | AnyShape | IntoCondition | Map
+    size: str | AnySize | IntoCondition | Map
+    stroke: str | AnyStroke | IntoCondition | Map
+    strokeDash: str | AnyStrokeDash | IntoCondition | Map
+    strokeOpacity: str | AnyStrokeOpacity | IntoCondition | Map
+    strokeWidth: str | AnyStrokeWidth | IntoCondition | Map
+    text: str | AnyText | IntoCondition | Map
+    theta: str | AnyTheta | IntoCondition | Map
+    theta2: str | AnyTheta2 | IntoCondition | Map
+    tooltip: OneOrSeq[str | AnyTooltip | IntoCondition | Map]
+    url: str | AnyUrl | IntoCondition | Map
+    x: str | AnyX | IntoCondition | Map
+    x2: str | AnyX2 | IntoCondition | Map
+    xError: str | AnyXError | IntoCondition | Map
+    xError2: str | AnyXError2 | IntoCondition | Map
+    xOffset: str | AnyXOffset | IntoCondition | Map
+    y: str | AnyY | IntoCondition | Map
+    y2: str | AnyY2 | IntoCondition | Map
+    yError: str | AnyYError | IntoCondition | Map
+    yError2: str | AnyYError2 | IntoCondition | Map
+    yOffset: str | AnyYOffset | IntoCondition | Map

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
     from altair import Parameter, SchemaBase
     from altair.typing import Optional
+    from altair.vegalite.v5.api import IntoCondition
 
 
 __all__ = [
@@ -24914,121 +24915,200 @@ class YOffsetValue(ValueChannelMixin, core.ValueDefnumber):
         super().__init__(value=value, **kwds)
 
 
-ChannelAngle: TypeAlias = Union[str, Angle, Map, AngleDatum, AngleValue]
-ChannelColor: TypeAlias = Union[str, Color, Map, ColorDatum, ColorValue]
-ChannelColumn: TypeAlias = Union[str, Column, Map]
-ChannelDescription: TypeAlias = Union[str, Description, Map, DescriptionValue]
-ChannelDetail: TypeAlias = OneOrSeq[Union[str, Detail, Map]]
-ChannelFacet: TypeAlias = Union[str, Facet, Map]
-ChannelFill: TypeAlias = Union[str, Fill, Map, FillDatum, FillValue]
+ChannelAngle: TypeAlias = Union[
+    str, Angle, Map, AngleDatum, AngleValue, "IntoCondition"
+]
+ChannelColor: TypeAlias = Union[
+    str, Color, Map, ColorDatum, ColorValue, "IntoCondition"
+]
+ChannelColumn: TypeAlias = Union[str, Column, Map, "IntoCondition"]
+ChannelDescription: TypeAlias = Union[
+    str, Description, Map, DescriptionValue, "IntoCondition"
+]
+ChannelDetail: TypeAlias = OneOrSeq[Union[str, Detail, Map, "IntoCondition"]]
+ChannelFacet: TypeAlias = Union[str, Facet, Map, "IntoCondition"]
+ChannelFill: TypeAlias = Union[str, Fill, Map, FillDatum, FillValue, "IntoCondition"]
 ChannelFillOpacity: TypeAlias = Union[
-    str, FillOpacity, Map, FillOpacityDatum, FillOpacityValue
+    str, FillOpacity, Map, FillOpacityDatum, FillOpacityValue, "IntoCondition"
 ]
-ChannelHref: TypeAlias = Union[str, Href, Map, HrefValue]
-ChannelKey: TypeAlias = Union[str, Key, Map]
-ChannelLatitude: TypeAlias = Union[str, Latitude, Map, LatitudeDatum]
-ChannelLatitude2: TypeAlias = Union[str, Latitude2, Map, Latitude2Datum, Latitude2Value]
-ChannelLongitude: TypeAlias = Union[str, Longitude, Map, LongitudeDatum]
+ChannelHref: TypeAlias = Union[str, Href, Map, HrefValue, "IntoCondition"]
+ChannelKey: TypeAlias = Union[str, Key, Map, "IntoCondition"]
+ChannelLatitude: TypeAlias = Union[str, Latitude, Map, LatitudeDatum, "IntoCondition"]
+ChannelLatitude2: TypeAlias = Union[
+    str, Latitude2, Map, Latitude2Datum, Latitude2Value, "IntoCondition"
+]
+ChannelLongitude: TypeAlias = Union[
+    str, Longitude, Map, LongitudeDatum, "IntoCondition"
+]
 ChannelLongitude2: TypeAlias = Union[
-    str, Longitude2, Map, Longitude2Datum, Longitude2Value
+    str, Longitude2, Map, Longitude2Datum, Longitude2Value, "IntoCondition"
 ]
-ChannelOpacity: TypeAlias = Union[str, Opacity, Map, OpacityDatum, OpacityValue]
-ChannelOrder: TypeAlias = OneOrSeq[Union[str, Order, Map, OrderValue]]
-ChannelRadius: TypeAlias = Union[str, Radius, Map, RadiusDatum, RadiusValue]
-ChannelRadius2: TypeAlias = Union[str, Radius2, Map, Radius2Datum, Radius2Value]
-ChannelRow: TypeAlias = Union[str, Row, Map]
-ChannelShape: TypeAlias = Union[str, Shape, Map, ShapeDatum, ShapeValue]
-ChannelSize: TypeAlias = Union[str, Size, Map, SizeDatum, SizeValue]
-ChannelStroke: TypeAlias = Union[str, Stroke, Map, StrokeDatum, StrokeValue]
+ChannelOpacity: TypeAlias = Union[
+    str, Opacity, Map, OpacityDatum, OpacityValue, "IntoCondition"
+]
+ChannelOrder: TypeAlias = OneOrSeq[Union[str, Order, Map, OrderValue, "IntoCondition"]]
+ChannelRadius: TypeAlias = Union[
+    str, Radius, Map, RadiusDatum, RadiusValue, "IntoCondition"
+]
+ChannelRadius2: TypeAlias = Union[
+    str, Radius2, Map, Radius2Datum, Radius2Value, "IntoCondition"
+]
+ChannelRow: TypeAlias = Union[str, Row, Map, "IntoCondition"]
+ChannelShape: TypeAlias = Union[
+    str, Shape, Map, ShapeDatum, ShapeValue, "IntoCondition"
+]
+ChannelSize: TypeAlias = Union[str, Size, Map, SizeDatum, SizeValue, "IntoCondition"]
+ChannelStroke: TypeAlias = Union[
+    str, Stroke, Map, StrokeDatum, StrokeValue, "IntoCondition"
+]
 ChannelStrokeDash: TypeAlias = Union[
-    str, StrokeDash, Map, StrokeDashDatum, StrokeDashValue
+    str, StrokeDash, Map, StrokeDashDatum, StrokeDashValue, "IntoCondition"
 ]
 ChannelStrokeOpacity: TypeAlias = Union[
-    str, StrokeOpacity, Map, StrokeOpacityDatum, StrokeOpacityValue
+    str, StrokeOpacity, Map, StrokeOpacityDatum, StrokeOpacityValue, "IntoCondition"
 ]
 ChannelStrokeWidth: TypeAlias = Union[
-    str, StrokeWidth, Map, StrokeWidthDatum, StrokeWidthValue
+    str, StrokeWidth, Map, StrokeWidthDatum, StrokeWidthValue, "IntoCondition"
 ]
-ChannelText: TypeAlias = Union[str, Text, Map, TextDatum, TextValue]
-ChannelTheta: TypeAlias = Union[str, Theta, Map, ThetaDatum, ThetaValue]
-ChannelTheta2: TypeAlias = Union[str, Theta2, Map, Theta2Datum, Theta2Value]
-ChannelTooltip: TypeAlias = OneOrSeq[Union[str, Tooltip, Map, TooltipValue]]
-ChannelUrl: TypeAlias = Union[str, Url, Map, UrlValue]
-ChannelX: TypeAlias = Union[str, X, Map, XDatum, XValue]
-ChannelX2: TypeAlias = Union[str, X2, Map, X2Datum, X2Value]
-ChannelXError: TypeAlias = Union[str, XError, Map, XErrorValue]
-ChannelXError2: TypeAlias = Union[str, XError2, Map, XError2Value]
-ChannelXOffset: TypeAlias = Union[str, XOffset, Map, XOffsetDatum, XOffsetValue]
-ChannelY: TypeAlias = Union[str, Y, Map, YDatum, YValue]
-ChannelY2: TypeAlias = Union[str, Y2, Map, Y2Datum, Y2Value]
-ChannelYError: TypeAlias = Union[str, YError, Map, YErrorValue]
-ChannelYError2: TypeAlias = Union[str, YError2, Map, YError2Value]
-ChannelYOffset: TypeAlias = Union[str, YOffset, Map, YOffsetDatum, YOffsetValue]
+ChannelText: TypeAlias = Union[str, Text, Map, TextDatum, TextValue, "IntoCondition"]
+ChannelTheta: TypeAlias = Union[
+    str, Theta, Map, ThetaDatum, ThetaValue, "IntoCondition"
+]
+ChannelTheta2: TypeAlias = Union[
+    str, Theta2, Map, Theta2Datum, Theta2Value, "IntoCondition"
+]
+ChannelTooltip: TypeAlias = OneOrSeq[
+    Union[str, Tooltip, Map, TooltipValue, "IntoCondition"]
+]
+ChannelUrl: TypeAlias = Union[str, Url, Map, UrlValue, "IntoCondition"]
+ChannelX: TypeAlias = Union[str, X, Map, XDatum, XValue, "IntoCondition"]
+ChannelX2: TypeAlias = Union[str, X2, Map, X2Datum, X2Value, "IntoCondition"]
+ChannelXError: TypeAlias = Union[str, XError, Map, XErrorValue, "IntoCondition"]
+ChannelXError2: TypeAlias = Union[str, XError2, Map, XError2Value, "IntoCondition"]
+ChannelXOffset: TypeAlias = Union[
+    str, XOffset, Map, XOffsetDatum, XOffsetValue, "IntoCondition"
+]
+ChannelY: TypeAlias = Union[str, Y, Map, YDatum, YValue, "IntoCondition"]
+ChannelY2: TypeAlias = Union[str, Y2, Map, Y2Datum, Y2Value, "IntoCondition"]
+ChannelYError: TypeAlias = Union[str, YError, Map, YErrorValue, "IntoCondition"]
+ChannelYError2: TypeAlias = Union[str, YError2, Map, YError2Value, "IntoCondition"]
+ChannelYOffset: TypeAlias = Union[
+    str, YOffset, Map, YOffsetDatum, YOffsetValue, "IntoCondition"
+]
 
 
 class _EncodingMixin:
     def encode(
         self,
         *args: Any,
-        angle: Optional[str | Angle | Map | AngleDatum | AngleValue] = Undefined,
-        color: Optional[str | Color | Map | ColorDatum | ColorValue] = Undefined,
-        column: Optional[str | Column | Map] = Undefined,
-        description: Optional[str | Description | Map | DescriptionValue] = Undefined,
-        detail: Optional[OneOrSeq[str | Detail | Map]] = Undefined,
-        facet: Optional[str | Facet | Map] = Undefined,
-        fill: Optional[str | Fill | Map | FillDatum | FillValue] = Undefined,
+        angle: Optional[
+            str | Angle | Map | AngleDatum | AngleValue | IntoCondition
+        ] = Undefined,
+        color: Optional[
+            str | Color | Map | ColorDatum | ColorValue | IntoCondition
+        ] = Undefined,
+        column: Optional[str | Column | Map | IntoCondition] = Undefined,
+        description: Optional[
+            str | Description | Map | DescriptionValue | IntoCondition
+        ] = Undefined,
+        detail: Optional[OneOrSeq[str | Detail | Map | IntoCondition]] = Undefined,
+        facet: Optional[str | Facet | Map | IntoCondition] = Undefined,
+        fill: Optional[
+            str | Fill | Map | FillDatum | FillValue | IntoCondition
+        ] = Undefined,
         fillOpacity: Optional[
-            str | FillOpacity | Map | FillOpacityDatum | FillOpacityValue
+            str
+            | FillOpacity
+            | Map
+            | FillOpacityDatum
+            | FillOpacityValue
+            | IntoCondition
         ] = Undefined,
-        href: Optional[str | Href | Map | HrefValue] = Undefined,
-        key: Optional[str | Key | Map] = Undefined,
-        latitude: Optional[str | Latitude | Map | LatitudeDatum] = Undefined,
+        href: Optional[str | Href | Map | HrefValue | IntoCondition] = Undefined,
+        key: Optional[str | Key | Map | IntoCondition] = Undefined,
+        latitude: Optional[
+            str | Latitude | Map | LatitudeDatum | IntoCondition
+        ] = Undefined,
         latitude2: Optional[
-            str | Latitude2 | Map | Latitude2Datum | Latitude2Value
+            str | Latitude2 | Map | Latitude2Datum | Latitude2Value | IntoCondition
         ] = Undefined,
-        longitude: Optional[str | Longitude | Map | LongitudeDatum] = Undefined,
+        longitude: Optional[
+            str | Longitude | Map | LongitudeDatum | IntoCondition
+        ] = Undefined,
         longitude2: Optional[
-            str | Longitude2 | Map | Longitude2Datum | Longitude2Value
+            str | Longitude2 | Map | Longitude2Datum | Longitude2Value | IntoCondition
         ] = Undefined,
         opacity: Optional[
-            str | Opacity | Map | OpacityDatum | OpacityValue
+            str | Opacity | Map | OpacityDatum | OpacityValue | IntoCondition
         ] = Undefined,
-        order: Optional[OneOrSeq[str | Order | Map | OrderValue]] = Undefined,
-        radius: Optional[str | Radius | Map | RadiusDatum | RadiusValue] = Undefined,
+        order: Optional[
+            OneOrSeq[str | Order | Map | OrderValue | IntoCondition]
+        ] = Undefined,
+        radius: Optional[
+            str | Radius | Map | RadiusDatum | RadiusValue | IntoCondition
+        ] = Undefined,
         radius2: Optional[
-            str | Radius2 | Map | Radius2Datum | Radius2Value
+            str | Radius2 | Map | Radius2Datum | Radius2Value | IntoCondition
         ] = Undefined,
-        row: Optional[str | Row | Map] = Undefined,
-        shape: Optional[str | Shape | Map | ShapeDatum | ShapeValue] = Undefined,
-        size: Optional[str | Size | Map | SizeDatum | SizeValue] = Undefined,
-        stroke: Optional[str | Stroke | Map | StrokeDatum | StrokeValue] = Undefined,
+        row: Optional[str | Row | Map | IntoCondition] = Undefined,
+        shape: Optional[
+            str | Shape | Map | ShapeDatum | ShapeValue | IntoCondition
+        ] = Undefined,
+        size: Optional[
+            str | Size | Map | SizeDatum | SizeValue | IntoCondition
+        ] = Undefined,
+        stroke: Optional[
+            str | Stroke | Map | StrokeDatum | StrokeValue | IntoCondition
+        ] = Undefined,
         strokeDash: Optional[
-            str | StrokeDash | Map | StrokeDashDatum | StrokeDashValue
+            str | StrokeDash | Map | StrokeDashDatum | StrokeDashValue | IntoCondition
         ] = Undefined,
         strokeOpacity: Optional[
-            str | StrokeOpacity | Map | StrokeOpacityDatum | StrokeOpacityValue
+            str
+            | StrokeOpacity
+            | Map
+            | StrokeOpacityDatum
+            | StrokeOpacityValue
+            | IntoCondition
         ] = Undefined,
         strokeWidth: Optional[
-            str | StrokeWidth | Map | StrokeWidthDatum | StrokeWidthValue
+            str
+            | StrokeWidth
+            | Map
+            | StrokeWidthDatum
+            | StrokeWidthValue
+            | IntoCondition
         ] = Undefined,
-        text: Optional[str | Text | Map | TextDatum | TextValue] = Undefined,
-        theta: Optional[str | Theta | Map | ThetaDatum | ThetaValue] = Undefined,
-        theta2: Optional[str | Theta2 | Map | Theta2Datum | Theta2Value] = Undefined,
-        tooltip: Optional[OneOrSeq[str | Tooltip | Map | TooltipValue]] = Undefined,
-        url: Optional[str | Url | Map | UrlValue] = Undefined,
-        x: Optional[str | X | Map | XDatum | XValue] = Undefined,
-        x2: Optional[str | X2 | Map | X2Datum | X2Value] = Undefined,
-        xError: Optional[str | XError | Map | XErrorValue] = Undefined,
-        xError2: Optional[str | XError2 | Map | XError2Value] = Undefined,
+        text: Optional[
+            str | Text | Map | TextDatum | TextValue | IntoCondition
+        ] = Undefined,
+        theta: Optional[
+            str | Theta | Map | ThetaDatum | ThetaValue | IntoCondition
+        ] = Undefined,
+        theta2: Optional[
+            str | Theta2 | Map | Theta2Datum | Theta2Value | IntoCondition
+        ] = Undefined,
+        tooltip: Optional[
+            OneOrSeq[str | Tooltip | Map | TooltipValue | IntoCondition]
+        ] = Undefined,
+        url: Optional[str | Url | Map | UrlValue | IntoCondition] = Undefined,
+        x: Optional[str | X | Map | XDatum | XValue | IntoCondition] = Undefined,
+        x2: Optional[str | X2 | Map | X2Datum | X2Value | IntoCondition] = Undefined,
+        xError: Optional[str | XError | Map | XErrorValue | IntoCondition] = Undefined,
+        xError2: Optional[
+            str | XError2 | Map | XError2Value | IntoCondition
+        ] = Undefined,
         xOffset: Optional[
-            str | XOffset | Map | XOffsetDatum | XOffsetValue
+            str | XOffset | Map | XOffsetDatum | XOffsetValue | IntoCondition
         ] = Undefined,
-        y: Optional[str | Y | Map | YDatum | YValue] = Undefined,
-        y2: Optional[str | Y2 | Map | Y2Datum | Y2Value] = Undefined,
-        yError: Optional[str | YError | Map | YErrorValue] = Undefined,
-        yError2: Optional[str | YError2 | Map | YError2Value] = Undefined,
+        y: Optional[str | Y | Map | YDatum | YValue | IntoCondition] = Undefined,
+        y2: Optional[str | Y2 | Map | Y2Datum | Y2Value | IntoCondition] = Undefined,
+        yError: Optional[str | YError | Map | YErrorValue | IntoCondition] = Undefined,
+        yError2: Optional[
+            str | YError2 | Map | YError2Value | IntoCondition
+        ] = Undefined,
         yOffset: Optional[
-            str | YOffset | Map | YOffsetDatum | YOffsetValue
+            str | YOffset | Map | YOffsetDatum | YOffsetValue | IntoCondition
         ] = Undefined,
     ) -> Self:
         """
@@ -25460,43 +25540,58 @@ class EncodeKwds(TypedDict, total=False):
         Offset of y-position of the marks
     """
 
-    angle: str | Angle | Map | AngleDatum | AngleValue
-    color: str | Color | Map | ColorDatum | ColorValue
-    column: str | Column | Map
-    description: str | Description | Map | DescriptionValue
-    detail: OneOrSeq[str | Detail | Map]
-    facet: str | Facet | Map
-    fill: str | Fill | Map | FillDatum | FillValue
-    fillOpacity: str | FillOpacity | Map | FillOpacityDatum | FillOpacityValue
-    href: str | Href | Map | HrefValue
-    key: str | Key | Map
-    latitude: str | Latitude | Map | LatitudeDatum
-    latitude2: str | Latitude2 | Map | Latitude2Datum | Latitude2Value
-    longitude: str | Longitude | Map | LongitudeDatum
-    longitude2: str | Longitude2 | Map | Longitude2Datum | Longitude2Value
-    opacity: str | Opacity | Map | OpacityDatum | OpacityValue
-    order: OneOrSeq[str | Order | Map | OrderValue]
-    radius: str | Radius | Map | RadiusDatum | RadiusValue
-    radius2: str | Radius2 | Map | Radius2Datum | Radius2Value
-    row: str | Row | Map
-    shape: str | Shape | Map | ShapeDatum | ShapeValue
-    size: str | Size | Map | SizeDatum | SizeValue
-    stroke: str | Stroke | Map | StrokeDatum | StrokeValue
-    strokeDash: str | StrokeDash | Map | StrokeDashDatum | StrokeDashValue
-    strokeOpacity: str | StrokeOpacity | Map | StrokeOpacityDatum | StrokeOpacityValue
-    strokeWidth: str | StrokeWidth | Map | StrokeWidthDatum | StrokeWidthValue
-    text: str | Text | Map | TextDatum | TextValue
-    theta: str | Theta | Map | ThetaDatum | ThetaValue
-    theta2: str | Theta2 | Map | Theta2Datum | Theta2Value
-    tooltip: OneOrSeq[str | Tooltip | Map | TooltipValue]
-    url: str | Url | Map | UrlValue
-    x: str | X | Map | XDatum | XValue
-    x2: str | X2 | Map | X2Datum | X2Value
-    xError: str | XError | Map | XErrorValue
-    xError2: str | XError2 | Map | XError2Value
-    xOffset: str | XOffset | Map | XOffsetDatum | XOffsetValue
-    y: str | Y | Map | YDatum | YValue
-    y2: str | Y2 | Map | Y2Datum | Y2Value
-    yError: str | YError | Map | YErrorValue
-    yError2: str | YError2 | Map | YError2Value
-    yOffset: str | YOffset | Map | YOffsetDatum | YOffsetValue
+    angle: str | Angle | Map | AngleDatum | AngleValue | IntoCondition
+    color: str | Color | Map | ColorDatum | ColorValue | IntoCondition
+    column: str | Column | Map | IntoCondition
+    description: str | Description | Map | DescriptionValue | IntoCondition
+    detail: OneOrSeq[str | Detail | Map | IntoCondition]
+    facet: str | Facet | Map | IntoCondition
+    fill: str | Fill | Map | FillDatum | FillValue | IntoCondition
+    fillOpacity: (
+        str | FillOpacity | Map | FillOpacityDatum | FillOpacityValue | IntoCondition
+    )
+    href: str | Href | Map | HrefValue | IntoCondition
+    key: str | Key | Map | IntoCondition
+    latitude: str | Latitude | Map | LatitudeDatum | IntoCondition
+    latitude2: str | Latitude2 | Map | Latitude2Datum | Latitude2Value | IntoCondition
+    longitude: str | Longitude | Map | LongitudeDatum | IntoCondition
+    longitude2: (
+        str | Longitude2 | Map | Longitude2Datum | Longitude2Value | IntoCondition
+    )
+    opacity: str | Opacity | Map | OpacityDatum | OpacityValue | IntoCondition
+    order: OneOrSeq[str | Order | Map | OrderValue | IntoCondition]
+    radius: str | Radius | Map | RadiusDatum | RadiusValue | IntoCondition
+    radius2: str | Radius2 | Map | Radius2Datum | Radius2Value | IntoCondition
+    row: str | Row | Map | IntoCondition
+    shape: str | Shape | Map | ShapeDatum | ShapeValue | IntoCondition
+    size: str | Size | Map | SizeDatum | SizeValue | IntoCondition
+    stroke: str | Stroke | Map | StrokeDatum | StrokeValue | IntoCondition
+    strokeDash: (
+        str | StrokeDash | Map | StrokeDashDatum | StrokeDashValue | IntoCondition
+    )
+    strokeOpacity: (
+        str
+        | StrokeOpacity
+        | Map
+        | StrokeOpacityDatum
+        | StrokeOpacityValue
+        | IntoCondition
+    )
+    strokeWidth: (
+        str | StrokeWidth | Map | StrokeWidthDatum | StrokeWidthValue | IntoCondition
+    )
+    text: str | Text | Map | TextDatum | TextValue | IntoCondition
+    theta: str | Theta | Map | ThetaDatum | ThetaValue | IntoCondition
+    theta2: str | Theta2 | Map | Theta2Datum | Theta2Value | IntoCondition
+    tooltip: OneOrSeq[str | Tooltip | Map | TooltipValue | IntoCondition]
+    url: str | Url | Map | UrlValue | IntoCondition
+    x: str | X | Map | XDatum | XValue | IntoCondition
+    x2: str | X2 | Map | X2Datum | X2Value | IntoCondition
+    xError: str | XError | Map | XErrorValue | IntoCondition
+    xError2: str | XError2 | Map | XError2Value | IntoCondition
+    xOffset: str | XOffset | Map | XOffsetDatum | XOffsetValue | IntoCondition
+    y: str | Y | Map | YDatum | YValue | IntoCondition
+    y2: str | Y2 | Map | Y2Datum | Y2Value | IntoCondition
+    yError: str | YError | Map | YErrorValue | IntoCondition
+    yError2: str | YError2 | Map | YError2Value | IntoCondition
+    yOffset: str | YOffset | Map | YOffsetDatum | YOffsetValue | IntoCondition

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -795,7 +795,7 @@ def test_when_then_interactive() -> None:
         .encode(
             x="IMDB_Rating:Q",
             y="Rotten_Tomatoes_Rating:Q",
-            color=alt.when(predicate).then(alt.value("grey")),  # type: ignore[arg-type]
+            color=alt.when(predicate).then(alt.value("grey")),
         )
     )
     assert chart.interactive()

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -635,14 +635,24 @@ def test_when_multiple_fields():
     with pytest.raises(TypeError, match=chain_mixed_msg):
         when.then("field_1:Q").when(Genre="pop")
 
+    chained_when = when.then(alt.value(5)).when(
+        alt.selection_point(fields=["b"]) | brush, empty=False, b=63812
+    )
+
+    chain_then_msg = re.compile(
+        r"Chained.+mixed.+field.+min\(foo\):Q.+'aggregate': 'min', 'field': 'foo', 'type': 'quantitative'",
+        flags=re.DOTALL,
+    )
+
+    with pytest.raises(TypeError, match=chain_then_msg):
+        chained_when.then("min(foo):Q")
+
     chain_otherwise_msg = re.compile(
         r"Chained.+mixed.+field.+AggregatedFieldDef.+'this_field_here'",
         flags=re.DOTALL,
     )
     with pytest.raises(TypeError, match=chain_otherwise_msg):
-        when.then(alt.value(5)).when(
-            alt.selection_point(fields=["b"]) | brush, empty=False, b=63812
-        ).then("min(foo):Q").otherwise(
+        chained_when.then(alt.value(2)).otherwise(
             alt.AggregatedFieldDef(
                 "argmax", field="field_9", **{"as": "this_field_here"}
             )

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -12,8 +12,7 @@ import sys
 import tempfile
 from datetime import date, datetime
 from importlib.metadata import version as importlib_version
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
-from typing_extensions import Protocol, TypeAlias, runtime_checkable
+from typing import TYPE_CHECKING
 
 import ibis
 import jsonschema
@@ -24,7 +23,6 @@ import pytest
 from packaging.version import Version
 
 import altair as alt
-from altair import SchemaBase
 from altair.utils.schemapi import Optional, SchemaValidationError, Undefined
 from tests import skip_requires_vl_convert, slow
 
@@ -34,7 +32,6 @@ except ImportError:
     vlc = None
 
 if TYPE_CHECKING:
-    from altair import Color, ColorDatum, ColorValue, Then
     from altair.vegalite.v5.api import _Conditional, _Conditions
     from altair.vegalite.v5.schema._typing import Map
 
@@ -745,41 +742,6 @@ def test_when_condition_parity(
         assert input_condition == input_when
     else:
         assert chart_condition == chart_when
-
-
-@runtime_checkable
-class SchemaLike(Protocol):
-    _schema: ClassVar[dict[Literal["type"], Literal["object"]]] = {"type": "object"}
-
-    def to_dict(self, *args, **kwds) -> Any: ...
-
-
-# New alias def
-Schema_3: TypeAlias = "Map | SchemaBase"
-
-# How we'd use `SchemaLike` in annotations
-Schema_4: TypeAlias = "SchemaBase | SchemaLike"
-
-# Combining 4 & 5 essentially
-Schema_5: TypeAlias = "Map | SchemaBase | SchemaLike"
-
-# Excluding `SchemaBase` from the alias
-Schema_6: TypeAlias = "Map | SchemaLike"
-
-
-def chart_encode(
-    col_0: Optional[str | Color | Map | ColorDatum | ColorValue] = Undefined,
-    col_1: Optional[
-        str | Color | Map | SchemaBase | ColorDatum | ColorValue
-    ] = Undefined,
-    col_2: Optional[
-        str | Color | Map | Then[Any] | ColorDatum | ColorValue
-    ] = Undefined,
-    col_3: Optional[str | Color | Schema_3 | ColorDatum | ColorValue] = Undefined,
-    col_4: Optional[str | Color | Map | Schema_4 | ColorDatum | ColorValue] = Undefined,
-    col_5: Optional[str | Color | Schema_5 | ColorDatum | ColorValue] = Undefined,
-    col_6: Optional[str | Color | Schema_6 | ColorDatum | ColorValue] = Undefined,
-): ...
 
 
 def test_when_then_interactive() -> None:

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -425,7 +425,7 @@ def test_when_then_otherwise() -> None:
     when_then = alt.when(select).then(alt.value(2, empty=False))
     when_then_otherwise = when_then.otherwise(alt.value(0))
 
-    expected = alt.condition(select, alt.value(2, empty=False), alt.value(0))
+    expected = dict(alt.condition(select, alt.value(2, empty=False), alt.value(0)))
     with pytest.raises(TypeError, match="list"):
         when_then.otherwise([1, 2, 3])  # type: ignore
 

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -772,7 +772,7 @@ def test_when_then_interactive() -> None:
     # NOTE: A stand-in for a `SchemaBase` that we don't want to accept
     then_fail: alt.Chart = alt.Chart(source)
 
-    result_pass = chart_encode(
+    result_pass = chart_encode(  # noqa: F841
         col_0=then_pass,
         col_1=then_pass,
         col_2=then_pass,
@@ -782,7 +782,7 @@ def test_when_then_interactive() -> None:
         col_6=then_pass,
     )
 
-    result_fail = chart_encode(
+    result_fail = chart_encode(  # noqa: F841
         col_0=then_fail,
         col_1=then_fail,
         col_2=then_fail,

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -652,20 +652,28 @@ def test_when_multiple_fields():
 
 
 def test_when_typing(cars) -> None:
-    color = (
-        alt.when(alt.datum.Weight_in_lbs >= 3500)
-        .then(alt.value("black"))
-        .otherwise(alt.value("white"))
+    chart = alt.Chart(cars).mark_rect()
+
+    color_then = alt.when(alt.datum.Weight_in_lbs >= 3500).then(alt.value("black"))
+    color = color_then.otherwise(alt.value("white"))
+    color_condition = alt.condition(
+        alt.datum.Weight_in_lbs >= 3500, alt.value("black"), alt.value("white")
     )
-    source = cars
-    chart = (  # noqa: F841
-        alt.Chart(source)
-        .mark_rect()
-        .encode(
-            x=alt.X("Cylinders:N").axis(labelColor=color),
-            y=alt.Y("Origin:N", axis=alt.Axis(tickColor=color)),
-            color=color,
-        )
+
+    chart_condition = chart.encode(  # noqa: F841
+        x=alt.X("Cylinders:N").axis(labelColor=color_condition),
+        y=alt.Y("Origin:N", axis=alt.Axis(tickColor=color_condition)),
+        color=color_condition,
+    )
+    chart_otherwise = chart.encode(  # noqa: F841
+        x=alt.X("Cylinders:N").axis(labelColor=color),
+        y=alt.Y("Origin:N", axis=alt.Axis(tickColor=color)),
+        color=color,
+    )
+    chart_then = chart.encode(  # noqa: F841
+        x=alt.X("Cylinders:N").axis(labelColor=color_then),
+        y=alt.Y("Origin:N", axis=alt.Axis(tickColor=color_then)),
+        color=color_then,
     )
 
 

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -12,8 +12,8 @@ import sys
 import tempfile
 from datetime import date, datetime
 from importlib.metadata import version as importlib_version
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Literal
-from typing_extensions import Protocol, TypeAlias, TypeIs, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing_extensions import Protocol, TypeAlias, runtime_checkable
 
 import ibis
 import jsonschema
@@ -724,12 +724,9 @@ def test_when_condition_parity(
         assert chart_condition == chart_when
 
 
-_SchemaLikeDict: TypeAlias = Dict[Literal["type"], Literal["object"]]
-
-
 @runtime_checkable
 class SchemaLike(Protocol):
-    _schema: ClassVar[_SchemaLikeDict] = {"type": "object"}
+    _schema: ClassVar[dict[Literal["type"], Literal["object"]]] = {"type": "object"}
 
     def to_dict(self, *args, **kwds) -> Any: ...
 
@@ -762,10 +759,6 @@ def chart_encode(
 ): ...
 
 
-def is_schema_like(obj: SchemaLike) -> TypeIs[SchemaLike]:
-    return isinstance(obj, SchemaLike)
-
-
 def test_when_then_interactive() -> None:
     """Copy-related regression found in https://github.com/vega/altair/pull/3394#issuecomment-2302995453."""
     source = "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/movies.json"
@@ -785,33 +778,6 @@ def test_when_then_interactive() -> None:
     assert chart.interactive()
     assert chart.copy()
     assert chart.to_dict()
-
-    then_pass = alt.when(predicate).then(alt.value("grey"))
-    # NOTE: A stand-in for a `SchemaBase` that we don't want to accept
-    then_fail: alt.Chart = alt.Chart(source)
-
-    result_pass = chart_encode(  # noqa: F841
-        col_0=then_pass,
-        col_1=then_pass,
-        col_2=then_pass,
-        col_3=then_pass,
-        col_4=then_pass,
-        col_5=then_pass,
-        col_6=then_pass,
-    )
-
-    result_fail = chart_encode(  # noqa: F841
-        col_0=then_fail,
-        col_1=then_fail,
-        col_2=then_fail,
-        col_3=then_fail,
-        col_4=then_fail,
-        col_5=then_fail,
-        col_6=then_fail,
-    )
-
-    is_schema_like(then_pass)
-    is_schema_like(then_fail)
 
 
 def test_selection_to_dict():

--- a/tools/generate_api_docs.py
+++ b/tools/generate_api_docs.py
@@ -121,7 +121,14 @@ def api_functions() -> list[str]:
         obj_name
         for obj_name in iter_objects(alt.api, restrict_to_type=types.FunctionType)  # type: ignore[attr-defined]
         if obj_name
-        not in {"cast", "overload", "NamedTuple", "TypedDict", "is_chart_type"}
+        not in {
+            "cast",
+            "overload",
+            "NamedTuple",
+            "TypedDict",
+            "is_chart_type",
+            "runtime_checkable",
+        }
     ]
     return sorted(altair_api_functions)
 

--- a/tools/generate_api_docs.py
+++ b/tools/generate_api_docs.py
@@ -112,25 +112,17 @@ def toplevel_charts() -> list[str]:
 
 
 def encoding_wrappers() -> list[str]:
-    return sorted(iter_objects(alt.channels, restrict_to_subclass=alt.SchemaBase))
+    return sorted(iter_objects(alt.channels, restrict_to_subclass=alt.SchemaBase))  # type: ignore[attr-defined]
 
 
 def api_functions() -> list[str]:
     # Exclude `typing` functions/SpecialForm(s)
-    altair_api_functions = [
-        obj_name
-        for obj_name in iter_objects(alt.api, restrict_to_type=types.FunctionType)  # type: ignore[attr-defined]
-        if obj_name
-        not in {
-            "cast",
-            "overload",
-            "NamedTuple",
-            "TypedDict",
-            "is_chart_type",
-            "runtime_checkable",
-        }
-    ]
-    return sorted(altair_api_functions)
+    KEEP = set(alt.api.__all__) - set(alt.typing.__all__)  # type: ignore[attr-defined]
+    return sorted(
+        name
+        for name in iter_objects(alt.api, restrict_to_type=types.FunctionType)  # type: ignore[attr-defined]
+        if name in KEEP
+    )
 
 
 def api_classes() -> list[str]:
@@ -139,7 +131,7 @@ def api_classes() -> list[str]:
 
 
 def type_hints() -> list[str]:
-    return [s for s in sorted(iter_objects(alt.typing)) if s != "annotations"]
+    return sorted(s for s in iter_objects(alt.typing) if s in alt.typing.__all__)
 
 
 def lowlevel_wrappers() -> list[str]:

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -266,6 +266,8 @@ The parameters ``short``, ``long`` accept the same range of types::
 """
 '''
 
+INTO_CONDITION: Literal["IntoCondition"] = "IntoCondition"
+
 
 class SchemaGenerator(codegen.SchemaGenerator):
     schema_class_template = textwrap.dedent(
@@ -693,6 +695,7 @@ def generate_vegalite_channel_wrappers(
             "from altair import Parameter, SchemaBase",
             "from altair.typing import Optional",
             "from typing_extensions import Self",
+            f"from altair.vegalite.v5.api import {INTO_CONDITION}",
         ),
         "\n" f"__all__ = {sorted(all_)}\n",
         CHANNEL_MIXINS,
@@ -913,7 +916,9 @@ def generate_encoding_artifacts(
         it_rst_names: Iterator[str] = (rst_syntax_for_class(c) for c in info.all_names)
 
         docstring_types: list[str] = ["str", next(it_rst_names), "Dict"]
-        tp_inner: str = ", ".join(chain(("str", next(it), "Map"), it))
+        tp_inner: str = ", ".join(
+            chain(("str", next(it), "Map"), it, [f"{INTO_CONDITION!r}"])
+        )
         tp_inner = f"Union[{tp_inner}]"
 
         if info.supports_arrays:

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -903,22 +903,33 @@ def generate_encoding_artifacts(
         - but this translates poorly to an IDE
         - `info.supports_arrays`
     """
+    PREFIX_INTERNAL = "Any"
+    PREFIX_EXPORT = "Channel"
     signature_args: list[str] = ["self", "*args: Any"]
-    type_aliases: list[str] = []
+    internal_aliases: list[str] = []
+    export_aliases: list[str] = []
     typed_dict_args: list[str] = []
     signature_doc_params: list[str] = ["", "Parameters", "----------"]
     typed_dict_doc_params: list[str] = ["", "Parameters", "----------"]
 
     for channel, info in channel_infos.items():
-        alias_name: str = f"Channel{channel[0].upper()}{channel[1:]}"
+        channel_name = f"{channel[0].upper()}{channel[1:]}"
 
-        it: Iterator[str] = info.all_names
+        names = list(info.all_names)
         it_rst_names: Iterator[str] = (rst_syntax_for_class(c) for c in info.all_names)
 
         docstring_types: list[str] = ["str", next(it_rst_names), "Dict"]
-        tp_inner: str = ", ".join(
-            chain(("str", next(it), "Map"), it, [f"{INTO_CONDITION!r}"])
-        )
+        if len(names) > 1:
+            # NOTE: Another level of internal aliases are generated, for channels w/ 2-3 types.
+            # These are represent only types defined in `channels.py` and not the full range accepted.
+            any_name = f"{PREFIX_INTERNAL}{channel_name}"
+            internal_aliases.append(
+                f"{any_name}: TypeAlias = Union[{', '.join(names)}]"
+            )
+            tp_inner: str = ", ".join(("str", any_name, f"{INTO_CONDITION!r}", "Map"))
+        else:
+            tp_inner = ", ".join(("str", names[0], f"{INTO_CONDITION!r}", "Map"))
+
         tp_inner = f"Union[{tp_inner}]"
 
         if info.supports_arrays:
@@ -927,7 +938,7 @@ def generate_encoding_artifacts(
 
         doc_types_flat: str = ", ".join(chain(docstring_types, it_rst_names))
 
-        type_aliases.append(f"{alias_name}: TypeAlias = {tp_inner}")
+        export_aliases.append(f"{PREFIX_EXPORT}{channel_name}: TypeAlias = {tp_inner}")
         # We use the full type hints instead of the alias in the signatures below
         # as IDEs such as VS Code would else show the name of the alias instead
         # of the expanded full type hints. The later are more useful to users.
@@ -947,7 +958,13 @@ def generate_encoding_artifacts(
         channels="\n    ".join(typed_dict_args),
         docstring=indent_docstring(typed_dict_doc_params, indent_level=4, lstrip=False),
     )
-    artifacts: Iterable[str] = *type_aliases, method, typed_dict
+    artifacts: Iterable[str] = (
+        *internal_aliases,
+        "",
+        *export_aliases,
+        method,
+        typed_dict,
+    )
     yield from artifacts
 
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -830,6 +830,29 @@ This may represent **one of**:
 
 @runtime_checkable
 class SchemaLike(Generic[_JSON_VT_co], Protocol):  # type: ignore[misc]
+    """
+    Represents ``altair`` classes which *may* not derive ``SchemaBase``.
+
+    Should be kept tightly defined to the **minimum** requirements for:
+    - Converting into a form that can be validated by `jsonschema`_.
+    - Avoiding calling ``.to_dict()`` on a class external to ``altair``.
+
+    Attributes
+    ----------
+    _schema
+        A single item JSON Schema using the `type`_ keyword.
+
+        .. note::
+            more accurately described as a ``ClassVar``, see `discussion`_ for blocking issue.
+
+    .. _jsonschema:
+        https://github.com/python-jsonschema/jsonschema
+    .. _type:
+        https://json-schema.org/understanding-json-schema/reference/type
+    .. _discussion:
+        https://github.com/python/typing/discussions/1424
+    """
+
     _schema: _TypeMap[_JSON_VT_co]
 
     def to_dict(self, *args, **kwds) -> Any: ...

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -833,17 +833,18 @@ class SchemaLike(Generic[_JSON_VT_co], Protocol):  # type: ignore[misc]
     """
     Represents ``altair`` classes which *may* not derive ``SchemaBase``.
 
-    Should be kept tightly defined to the **minimum** requirements for:
-    - Converting into a form that can be validated by `jsonschema`_.
-    - Avoiding calling ``.to_dict()`` on a class external to ``altair``.
-
     Attributes
     ----------
     _schema
         A single item JSON Schema using the `type`_ keyword.
 
-        .. note::
-            more accurately described as a ``ClassVar``, see `discussion`_ for blocking issue.
+    Notes
+    -----
+    Should be kept tightly defined to the **minimum** requirements for:
+        - Converting into a form that can be validated by `jsonschema`_.
+        - Avoiding calling ``.to_dict()`` on a class external to ``altair``.
+    - ``_schema`` is more accurately described as a ``ClassVar``
+        - See `discussion`_ for blocking issue.
 
     .. _jsonschema:
         https://github.com/python-jsonschema/jsonschema
@@ -860,6 +861,21 @@ class SchemaLike(Generic[_JSON_VT_co], Protocol):  # type: ignore[misc]
 
 @runtime_checkable
 class ConditionLike(SchemaLike[Literal["object"]], Protocol):
+    """
+    Represents the wrapped state of a conditional encoding or property.
+
+    Attributes
+    ----------
+    condition
+        One or more (predicate, statement) pairs which each form a condition.
+
+    Notes
+    -----
+    - Can be extended with additional conditions.
+    - *Does not* define a default value, but can be finalized with one.
+    """
+
+    condition: Any
     _schema: _TypeMap[Literal["object"]] = {"type": "object"}
 
 


### PR DESCRIPTION
Fixes #3552

<details>
<summary><i>Overview of issues by @binste in <a href="https://github.com/vega/altair/issues/3552#issuecomment-2333898482">comment</a></i></summary>

The draft PR is very helpful! Trying to summarise/reword it for myself:
* `Then` should not inherit from `SchemaBase` as it muddies autocompletion
* We need a type hint which lets a `SchemaBase` pass due to `alt.condition` and `alt.when().then().otherwise()`. Can be `SchemaBase` or a protocol
* It's unclear to me when, as a developer, I'd use `SchemaLike`. If I understand it correctly, we mainly introduce it now to make these types work.
* Purpose:
  * Fix type errors users might get right now, keeping types as narrow as possible so they are more useful
  * Improving UX: keep/improve autocompletion + provide a good visual indication that we mean conditions can be passed

How about
```python
@runtime_checkable
class Condition(Protocol):
   """We use this protocol to signal to a user that they can pass any condition created by either `alt.condition` or `alt.when`.

   Other SchemaBase instances will pass as `Condition` as well and so for type checkers it won't matter but using this protocol when only conditions are expected at least gives a better visual indication to users.
   """
    _schema: ClassVar[_SchemaLikeDict] = {"type": "object"}

    def to_dict(self, *args, **kwds) -> Any: ...


def chart_encode(
   col_7: Optional[str | Color | Condition | Map | ColorDatum | ColorValue] = Undefined,
)
```
`Condition` is not yet used anywhere in the codebase and it makes it clearer what we intend to do with the protocol. What do you think?

</details>
            

# Tasks
- [x] Allow `Then` in `Chart.encode()`, without subclassing `SchemaBase`
	- See [comment](https://github.com/vega/altair/pull/3427#discussion_r1668638763) for screenshots of old autocomplete
- [x] Experiment with simplifying `Chart.encode()` annotations
	- [comment](https://github.com/vega/altair/pull/3567#discussion_r1760113802)
	- [`08bf16e` (#3567)](https://github.com/vega/altair/pull/3567/commits/08bf16e6da1af9934f6a6394c9f41399b1978f91)
- [x] Standardise user-facing (but non-public) aliases & documentation
	- [x] `(Condition|Schema)Like`
		- [`d20109e` (#3567)](https://github.com/vega/altair/pull/3567/commits/d20109e60d40f9062a55d189ccb8869d1916f892)
	- [x] Various `TypeAlias|TypedDict` in `api.py`
		- [`0a6d599` (#3567)](https://github.com/vega/altair/pull/3567/commits/0a6d5991cc246d4fc3c4425037977d6328a4813e)
		- [`0a93309` (#3567)](https://github.com/vega/altair/pull/3567/commits/0a93309474dcbb794206da49760fc501fec3c018)


# Related
- https://github.com/vega/altair/pull/3427#discussion_r1668638763
- https://github.com/vega/altair/commit/d12a74117ec201fc096f5e27328d4e50ea493f84
- [`0bdfa72` (#3536)](https://github.com/vega/altair/pull/3536/commits/0bdfa72470551b2bc39e4adc76b7e989ccdf259b)


# Note
This PR started as a draft proposal for addressing multiple related issues.
See https://github.com/vega/altair/issues/3552#issuecomment-2328935056 for further info


<details>
<summary>Draft PR Demo</summary>

Purely demonstrating type checking behavior for https://github.com/vega/altair/issues/3552#issuecomment-2328229310

<details><summary>Extended chart_encode</summary>
<p>

![image](https://github.com/user-attachments/assets/28d2eb7f-04cd-4139-a463-74bc3ccbdedd)


</p>
</details> 

![image](https://github.com/user-attachments/assets/eb36e5ff-6eaa-49b2-ae57-77f1c2d53cdd)



# Note

`mypy` failing is expected and part of the demonstration

</details>