### PR TITLE
docs: Make plausible web analytics public and add link to maintainer notes

### DIFF
--- a/NOTES_FOR_MAINTAINERS.md
+++ b/NOTES_FOR_MAINTAINERS.md
@@ -81,4 +81,4 @@ To cut a new release of Altair, follow the steps outlined in
 
 ## Web analytics
 We use the privacy-friendly [plausible.io](https://plausible.io/) for tracking usage statistics of our documentation.
-It is hosted on [https://views.scientific-python.org](https://views.scientific-python.org). To view the stats, you need an account. Ask another maintainer to invite you.
+It is hosted on [https://views.scientific-python.org](https://views.scientific-python.org). You can view the stats [here](https://views.scientific-python.org/altair-viz.github.io). To get an account to edit the settings of the web tracking, ask another maintainer.


### PR DESCRIPTION
I made the web analytics public as it's heavily anonymized, no need to hide it: https://views.scientific-python.org/altair-viz.github.io. Matplotlib have also made theirs public at https://views.scientific-python.org/matplotlib.org.