### PR TITLE
feat: Add 'olli' renderer to generate accessible text structures for screen reader users

### DIFF
--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -161,7 +161,10 @@ HTML_TEMPLATE_UNIVERSAL = jinja2.Template(
         .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));
       {%- if use_olli %}
       olliAdapters.VegaLiteAdapter(spec).then(olliVisSpec => {
-        const olliRender = olli.olli(olliVisSpec);
+        // It's a function if it was loaded via maybeLoadScript below.
+        // If it comes from require, it's a module and we access olli.olli
+        const olliFunc = typeof olli === 'function' ? olli : olli.olli;
+        const olliRender = olliFunc(olliVisSpec);
         olliDiv.append(olliRender);
       });
       {%- endif %}
@@ -183,7 +186,11 @@ HTML_TEMPLATE_UNIVERSAL = jinja2.Template(
         .then(() => maybeLoadScript("olli-adapters", "{{olli_adapters_version}}"))
         {%- endif %}
         .catch(showError)
+        {%- if use_olli %}
+        .then(() => displayChart(vegaEmbed, olli, OlliAdapters));
+        {%- else %}
         .then(() => displayChart(vegaEmbed));
+        {%- endif %}
     }
   })({{ spec }}, {{ embed_options }});
 </script>

--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -7,7 +7,7 @@ import jinja2
 
 from altair.utils._importers import import_vl_convert, vl_version_for_vl_convert
 
-TemplateName = Literal["standard", "universal", "inline"]
+TemplateName = Literal["standard", "universal", "inline", "olli"]
 RenderMode = Literal["vega", "vega-lite"]
 
 HTML_TEMPLATE = jinja2.Template(
@@ -116,11 +116,22 @@ HTML_TEMPLATE_UNIVERSAL = jinja2.Template(
     if (outputDiv.id !== "{{ output_div }}") {
       outputDiv = document.getElementById("{{ output_div }}");
     }
+    {%- if use_olli %}
+    const olliDiv = document.createElement("div");
+    const vegaDiv = document.createElement("div");
+    outputDiv.appendChild(vegaDiv);
+    outputDiv.appendChild(olliDiv);
+    outputDiv = vegaDiv;
+    {%- endif %}
     const paths = {
       "vega": "{{ base_url }}/vega@{{ vega_version }}?noext",
       "vega-lib": "{{ base_url }}/vega-lib?noext",
       "vega-lite": "{{ base_url }}/vega-lite@{{ vegalite_version }}?noext",
       "vega-embed": "{{ base_url }}/vega-embed@{{ vegaembed_version }}?noext",
+      {%- if use_olli %}
+      "olli": "{{ base_url }}/olli@{{ olli_version }}?noext",
+      "olli-adapters": "{{ base_url }}/olli-adapters@{{ olli_adapters_version }}?noext",
+      {%- endif %}
     };
 
     function maybeLoadScript(lib, version) {
@@ -145,18 +156,32 @@ HTML_TEMPLATE_UNIVERSAL = jinja2.Template(
       throw err;
     }
 
-    function displayChart(vegaEmbed) {
+    function displayChart(vegaEmbed, olli, olliAdapters) {
       vegaEmbed(outputDiv, spec, embedOpt)
         .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));
+      {%- if use_olli %}
+      olliAdapters.VegaLiteAdapter(spec).then(olliVisSpec => {
+        const olliRender = olli.olli(olliVisSpec);
+        olliDiv.append(olliRender);
+      });
+      {%- endif %}
     }
 
     if(typeof define === "function" && define.amd) {
       requirejs.config({paths});
-      require(["vega-embed"], displayChart, err => showError(`Error loading script: ${err.message}`));
+      let deps = ["vega-embed"];
+      {%- if use_olli %}
+      deps.push("olli", "olli-adapters");
+      {%- endif %}
+      require(deps, displayChart, err => showError(`Error loading script: ${err.message}`));
     } else {
       maybeLoadScript("vega", "{{vega_version}}")
         .then(() => maybeLoadScript("vega-lite", "{{vegalite_version}}"))
         .then(() => maybeLoadScript("vega-embed", "{{vegaembed_version}}"))
+        {%- if use_olli %}
+        .then(() => maybeLoadScript("olli", "{{olli_version}}"))
+        .then(() => maybeLoadScript("olli-adapters", "{{olli_adapters_version}}"))
+        {%- endif %}
         .catch(showError)
         .then(() => displayChart(vegaEmbed));
     }
@@ -209,6 +234,7 @@ TEMPLATES: dict[TemplateName, jinja2.Template] = {
     "standard": HTML_TEMPLATE,
     "universal": HTML_TEMPLATE_UNIVERSAL,
     "inline": INLINE_HTML_TEMPLATE,
+    "olli": HTML_TEMPLATE_UNIVERSAL,
 }
 
 
@@ -293,6 +319,12 @@ def spec_to_html(
         vlc = import_vl_convert()
         vl_version = vl_version_for_vl_convert()
         render_kwargs["vegaembed_script"] = vlc.javascript_bundle(vl_version=vl_version)
+    elif template == "olli":
+        olli_version = "2"
+        olli_adapters_version = "2"
+        render_kwargs["olli_version"] = olli_version
+        render_kwargs["olli_adapters_version"] = olli_adapters_version
+        render_kwargs["use_olli"] = True
 
     jinja_template = TEMPLATES.get(template, template)  # type: ignore[arg-type]
     if not hasattr(jinja_template, "render"):

--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -327,10 +327,10 @@ def spec_to_html(
         vl_version = vl_version_for_vl_convert()
         render_kwargs["vegaembed_script"] = vlc.javascript_bundle(vl_version=vl_version)
     elif template == "olli":
-        olli_version = "2"
-        olli_adapters_version = "2"
-        render_kwargs["olli_version"] = olli_version
-        render_kwargs["olli_adapters_version"] = olli_adapters_version
+        OLLI_VERSION = "2"
+        OLLI_ADAPTERS_VERSION = "2"
+        render_kwargs["olli_version"] = OLLI_VERSION
+        render_kwargs["olli_adapters_version"] = OLLI_ADAPTERS_VERSION
         render_kwargs["use_olli"] = True
 
     jinja_template = TEMPLATES.get(template, template)  # type: ignore[arg-type]

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -142,6 +142,15 @@ html_renderer = HTMLRenderer(
     vegalite_version=VEGALITE_VERSION,
 )
 
+
+olli_renderer = HTMLRenderer(
+    mode="vega-lite",
+    template="olli",
+    vega_version=VEGA_VERSION,
+    vegaembed_version=VEGAEMBED_VERSION,
+    vegalite_version=VEGALITE_VERSION,
+)
+
 renderers.register("default", html_renderer)
 renderers.register("html", html_renderer)
 renderers.register("colab", html_renderer)
@@ -155,6 +164,7 @@ renderers.register("png", png_renderer)
 renderers.register("svg", svg_renderer)
 renderers.register("jupyter", jupyter_renderer)
 renderers.register("browser", browser_renderer)
+renderers.register("olli", olli_renderer)
 renderers.enable("default")
 
 

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -68,6 +68,7 @@ In addition, Altair includes the following renderers:
   using the ``"image/png"`` MIME type.
 - ``"svg"``: renderer that renders and converts the chart to an SVG image,
   outputting it using the ``"image/svg+xml"`` MIME type.
+- ``"olli"``: renderer that uses `Olli`_ to generate accessible text structures for screen reader users.
 - ``"json"``: renderer that outputs the raw JSON chart specification, using the
   ``"application/json"`` MIME type.
 
@@ -713,3 +714,4 @@ see :ref:`display-general`.
 .. _Spyder: https://www.spyder-ide.org/
 .. _IPython QtConsole: https://qtconsole.readthedocs.io/en/stable/
 .. _webbrowser module: https://docs.python.org/3/library/webbrowser.html#webbrowser.register
+.. _Olli: https://mitvis.github.io/olli/


### PR DESCRIPTION
> [Olli](https://mitvis.github.io/olli/) is an open-source library for converting data visualizations into accessible text structures for screen reader users. Starting with an existing visualization specification created with a supported toolkit, Olli produces a keyboard-navigable tree view with descriptions at varying levels of detail. Users can explore these structures both to get an initial overview, and to dive into the data in more detail.

Closes #3575. A possible use case of this is that in a university course where Altair is used in a Jupyter notebook, with a single line of code, `alt.renderer.enable("olli")`, all charts in a notebook can be made accessible for screen reader users.

I've tested this in JupyterLab and VS Code. In JupyterLab, all [Olli controls](https://mitvis.github.io/olli/tutorial) worked, in VS Code, the following do not:
- T: Open table
- O: Jump to Olli tree
- F: Data filters

This might be an issue with how VS Code intercepts those key strokes. Might be configurable in VS Code but for now, I'm happy if it works in JupyterLab.