### PR TITLE
ci: Add include patterns for `pyright`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -448,3 +448,10 @@ extraPaths=["./tools"]
 pythonPlatform="All"
 pythonVersion="3.8"
 reportUnusedExpression="none"
+include=[
+    "./altair/**/*.py",
+    ".doc/*.py",
+	"./sphinxext/**/*.py",
+	"./tests/**/*.py",
+	"./tools/**/*.py",
+]


### PR DESCRIPTION
Fixes:
- https://github.com/vega/altair/pull/3536#discussion_r1748968002
- https://github.com/vega/altair/commit/c594e55e76613d0363e3b419a00cb2f920547755

No impact when not using `pylance`, but the default settings don't play nicely with virtual environments.

Any time you do something like "Find all references", it searches > 8000 files - but with this change it is reduced to 300ish.
Results in much faster and more useful language server behavior

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/fe3c1bf1-fa98-48fb-8511-2b987be954be)


</details>