### PR TITLE
ci(typing): fix support `pylance>=2024.9.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -444,14 +444,31 @@ module = [
 ignore_missing_imports = true
 
 [tool.pyright]
+enableExperimentalFeatures=true
 extraPaths=["./tools"]
 pythonPlatform="All"
 pythonVersion="3.8"
+reportTypedDictNotRequiredAccess="none"
+reportIncompatibleMethodOverride="none"
 reportUnusedExpression="none"
+reportUnsupportedDunderAll="none"
 include=[
     "./altair/**/*.py",
-    ".doc/*.py",
-	"./sphinxext/**/*.py",
+    "./doc/*.py",
 	"./tests/**/*.py",
 	"./tools/**/*.py",
+]
+ignore=[
+    "./altair/vegalite/v5/display.py",
+    "./altair/vegalite/v5/schema/",
+    "./altair/utils/core.py",
+    "./altair/utils/_dfi_types.py",
+    "./altair/_magics.py",
+    "./altair/jupyter/",
+    "./sphinxext/",
+    "./tests/test_jupyter_chart.py",
+    "./tests/utils/",
+    "./tests/test_magics.py",
+    "./tests/vegalite/v5/test_geo_interface.py",
+    "../../../**/Lib", # stdlib
 ]


### PR DESCRIPTION
Recent [versions](https://github.com/microsoft/pylance-release/releases) are producing warnings that cannot be silenced. 

See https://github.com/microsoft/pylance-release/wiki/Settings.json-overridden-by-Pyrightconfig.json-or-Pyproject.toml

Happy to remove in the future if this change gets reverted.
For now I've had to move personal config here sadly.