### PR TITLE
ci: Bump `typing_extensions` python to `3.14`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "hatchling.build"
 name = "altair"
 authors = [{ name = "Vega-Altair Contributors" }]
 dependencies = [
-    "typing_extensions>=4.10.0; python_version<\"3.13\"",
+    "typing_extensions>=4.10.0; python_version<\"3.14\"",
     "jinja2",
     # If you update the minimum required jsonschema version, also update it in build.yml
     "jsonschema>=3.0",


### PR DESCRIPTION
# Related
- https://github.com/vega/altair/pull/3536#discussion_r1761310603
- https://github.com/vega/altair/discussions/3548#discussioncomment-10406087
- https://github.com/vega/altair/issues/3587
	- *This* PR contains **one** of the changes already planned there
	- However *that* PR is blocked until https://github.com/geopandas/pyogrio/issues/470

# Description
Updates `python_version<"3.13"` -> `python_version<"3.14"`.

This was already required due to multiple instances of importing `typing_extensions` without a version guard.
However, we are also using [PEP 728](https://peps.python.org/pep-0728/) which [hasn't landed in time](https://github.com/vega/altair/pull/3567/commits/9f49ef6003795e4d4a9b214941de203bbaa3b778) for `3.13`.

<details>
<summary>Existing usage on <code>main</code></summary>

https://github.com/vega/altair/blob/32990a597af7c09586904f40b3f5e6787f752fa5/altair/vegalite/v5/api.py#L639-L666

</details>

Updating this is now a higher priority due to [scheduled release](https://www.python.org/downloads/release/python-3130rc2/) of `3.13` on **2024-10-01** (14 days away)