### PR TITLE
chore: Future-proof Duration type error message test

### DIFF
--- a/tests/utils/test_to_values_narwhals.py
+++ b/tests/utils/test_to_values_narwhals.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -63,7 +64,8 @@ def test_duration_raises():
 
     # Check that exception mentions the duration[ns] type,
     # which is what the pandas timedelta is converted into
-    assert (
-        'Field "timedelta" has type "Duration" which is not supported by Altair'
-        in e.value.args[0]
+
+    assert re.match(
+        r'^Field "timedelta" has type "Duration.*" which is not supported by Altair',
+        e.value.args[0],
     )


### PR DESCRIPTION
<!-- Click "Preview" to read this message; then delete it. -->

In Narwhals we'd like to [change the dtype repr to show the time unit](https://github.com/narwhals-dev/narwhals/pull/960) (and, for Datetimes, the time zone)

This doesn't really have an impact on users, they'd just see
```
Field "timedelta" has type "Duration(time_unit='ns')" which is not supported by Altair
```
instead of
```
Field "timedelta" has type "Duration" which is not supported by Altair
```

This PR just future-proofs the Altair test 