### PR TITLE
ci: Moved `vl-convert-python` to `save` dependency group

### DIFF
--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -24,6 +24,12 @@ and non-notebook IDEs, see :ref:`displaying-charts`.
 If you wish to install Altair with only the required dependencies,
 you can omit the ``[all]``/``-all`` suffix.
 
+Altair can also be installed with only the dependencies necessary for saving charts to PNG, SVG, or PDF formats, using:
+
+.. code-block:: bash
+
+    pip install "altair[save]"
+
 Development Installation
 ========================
 

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -24,7 +24,7 @@ and non-notebook IDEs, see :ref:`displaying-charts`.
 If you wish to install Altair with only the required dependencies,
 you can omit the ``[all]``/``-all`` suffix.
 
-Altair can also be installed with only the dependencies necessary for saving charts to PNG, SVG, or PDF formats, using:
+Altair can also be installed with just the dependencies necessary for saving charts to offline HTML files or PNG/SVG/PDF formats, using:
 
 .. code-block:: bash
 

--- a/doc/user_guide/saving_charts.rst
+++ b/doc/user_guide/saving_charts.rst
@@ -157,7 +157,7 @@ As an alternative, the ``inline=True`` keyword argument may be provided to ``cha
 
 .. note::
 
-   Calling ``chart.save`` with ``inline=True`` requires the :ref:`install-vl-convert` package.
+   Calling ``chart.save`` with ``inline=True`` requires installation via ``pip install "altair[save]"`` or ``pip install "altair[all]"``.
 
 
 .. _saving-png:
@@ -172,25 +172,9 @@ To save an Altair chart object as a PNG, SVG, or PDF image, you can use
     chart.save('chart.svg')
     chart.save('chart.pdf')
 
-Saving these images requires an additional extension vl-convert_ to run the
-javascript code necessary to interpret the Vega-Lite specification and output
-it in the form of an image.
+.. note::
 
-.. _install-vl-convert:
-
-vl-convert
-^^^^^^^^^^
-The vl-convert_ package can be installed with::
-
-    conda install -c conda-forge vl-convert-python
-
-or::
-
-    pip install vl-convert-python
-
-vl-convert_ does not require any external dependencies.
-See the vl-convert documentation for information and for known
-`limitations <https://github.com/vega/vl-convert#limitations>`_.
+   Saving these images requires installation via ``pip install "altair[save]"`` or ``pip install "altair[all]"``.
 
 altair_saver
 ^^^^^^^^^^^^

--- a/doc/user_guide/saving_charts.rst
+++ b/doc/user_guide/saving_charts.rst
@@ -157,7 +157,7 @@ As an alternative, the ``inline=True`` keyword argument may be provided to ``cha
 
 .. note::
 
-   Calling ``chart.save`` with ``inline=True`` requires installation via ``pip install "altair[save]"`` or ``pip install "altair[all]"``.
+   Calling ``chart.save`` with ``inline=True`` requires :ref:`additional-dependencies`.
 
 
 .. _saving-png:
@@ -174,7 +174,9 @@ To save an Altair chart object as a PNG, SVG, or PDF image, you can use
 
 .. note::
 
-   Saving these images requires installation via ``pip install "altair[save]"`` or ``pip install "altair[all]"``.
+   :ref:`additional-dependencies` are required to save charts as images by running the javascript
+   code necessary to interpret the Vega-Lite specification and output it in the form of an image.
+
 
 altair_saver
 ^^^^^^^^^^^^
@@ -199,6 +201,22 @@ To change the physical size of the resulting image while preserving the resoluti
 size at the default resolution of 72 ppi::
 
     chart.save('chart.png', scale_factor=2)
+
+.. _additional-dependencies:
+
+Additional Dependencies
+~~~~~~~~~~~~~~~~~~~~~~~
+Saving charts to images or offline HTML files requires the vl-convert_ package::
+
+    conda install -c conda-forge vl-convert-python
+
+or::
+
+    pip install vl-convert-python
+
+vl-convert_ does not require any external dependencies.
+See the vl-convert documentation for information and for known
+`limitations <https://github.com/vega/vl-convert#limitations>`_.
 
 Sharable URL
 ~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,12 @@ Documentation = "https://altair-viz.github.io"
 Source = "https://github.com/vega/altair"
 
 [project.optional-dependencies]
-all = [
-    "vega_datasets>=0.9.0",
+save = [
     "vl-convert-python>=1.6.0",
+]
+all = [
+    "altair[save]",
+    "vega_datasets>=0.9.0",
     "pandas>=0.25.3",
     "numpy",
     "pyarrow>=11",


### PR DESCRIPTION
Simple PR! As in title: proposing `altair[save]` optional dependency group to enable saving to static files (without installing `altair[all]`).

Fixes #3608