### PR TITLE
fix(typing): Add missing `float` to `IntoExpression` alias

### DIFF
--- a/altair/expr/core.py
+++ b/altair/expr/core.py
@@ -237,4 +237,4 @@ class GetItemExpression(Expression):
         return f"{self.group}[{self.name!r}]"
 
 
-IntoExpression: TypeAlias = Union[bool, None, str, OperatorMixin, Dict[str, Any]]
+IntoExpression: TypeAlias = Union[bool, None, str, float, OperatorMixin, Dict[str, Any]]


### PR DESCRIPTION
Discovered during #3600

https://github.com/vega/altair/pull/3600/commits/21d13e722a4bb466c572710f9171fc15484d5f7a

Will fix these false positives
```py
cmd [3] | mypy altair tests
tests\vegalite\v5\test_api.py:602: error: Argument 2 to "if_" of "expr" has incompatible type "int"; expected "bool | str | OperatorMixin | dict[str, Any] | None"  [arg-type]
        expected = alt.expr.if_(alt.datum.b >= 0, 10, -20)
                                                  ^~
tests\vegalite\v5\test_api.py:602: error: Argument 3 to "if_" of "expr" has incompatible type "int"; expected "bool | str | OperatorMixin | dict[str, Any] | None"  [arg-type]
        expected = alt.expr.if_(alt.datum.b >= 0, 10, -20)
                                                      ^~~
tests\examples_arguments_syntax\one_dot_per_zipcode.py:14: error: Argument 2 to "substring" of "expr" has incompatible type "int"; expected "bool | str | OperatorMixin | dict[str, Any] | None"  [arg-type]
        "leading digit", alt.expr.substring(alt.datum.zip_code, 0, 1)
                                                                ^
tests\examples_arguments_syntax\one_dot_per_zipcode.py:14: error: Argument 3 to "substring" of "expr" has incompatible type "int"; expected "bool | str | OperatorMixin | dict[str, Any] | None"  [arg-type]
        "leading digit", alt.expr.substring(alt.datum.zip_code, 0, 1)
                                                                   ^
Found 4 errors in 2 files (checked 374 source files)
```