### PR TITLE
docs: add example with overlapping bars in a grouped bar chart

### DIFF
--- a/tests/examples_arguments_syntax/grouped_bar_chart_overlapping_bars.py
+++ b/tests/examples_arguments_syntax/grouped_bar_chart_overlapping_bars.py
@@ -1,0 +1,27 @@
+"""
+Grouped Bar Chart with xOffset and overlapping bars
+---------------------------------------------------
+Like :ref:`gallery_grouped_bar_chart2`, this example shows a grouped bar chart using the ``xOffset`` encoding channel, but in this example the bars are partly overlapping within each group.
+"""
+# category: bar charts
+import altair as alt
+import pandas as pd
+
+source = pd.DataFrame(
+    {
+        "category": list("AABBCC"),
+        "group": list("xyxyxy"),
+        "value": [0.1, 0.6, 0.7, 0.2, 0.6, 0.1],
+    }
+)
+
+base = alt.Chart(source, width=alt.Step(12)).encode(
+    x="category:N",
+    y="value:Q",
+    xOffset=alt.XOffset("group:N", scale=alt.Scale(paddingOuter=0.5)),
+)
+
+alt.layer(
+    base.mark_bar(size=20, stroke="white", fillOpacity=0.9).encode(fill="group:N"),
+    base.mark_text(dy=-5).encode(text="value:Q"),
+)

--- a/tests/examples_methods_syntax/grouped_bar_chart_overlapping_bars.py
+++ b/tests/examples_methods_syntax/grouped_bar_chart_overlapping_bars.py
@@ -1,0 +1,27 @@
+"""
+Grouped Bar Chart with xOffset and overlapping bars
+---------------------------------------------------
+Like :ref:`gallery_grouped_bar_chart2`, this example shows a grouped bar chart using the ``xOffset`` encoding channel, but in this example the bars are partly overlapping within each group.
+"""
+# category: bar charts
+import altair as alt
+import pandas as pd
+
+source = pd.DataFrame(
+    {
+        "category": list("AABBCC"),
+        "group": list("xyxyxy"),
+        "value": [0.1, 0.6, 0.7, 0.2, 0.6, 0.1],
+    }
+)
+
+base = alt.Chart(source, width=alt.Step(12)).encode(
+    x="category:N",
+    y="value:Q",
+    xOffset=alt.XOffset("group:N").scale(paddingOuter=0.5),
+)
+
+alt.layer(
+    base.mark_bar(size=20, stroke="white", fillOpacity=0.9).encode(fill="group:N"),
+    base.mark_text(dy=-5).encode(text="value:Q"),
+)


### PR DESCRIPTION
This PR adds an example that demonstrates how to create partially overlapping bars in a grouped bar chart.

The example looks as such:
<img width="235" alt="image" src="https://github.com/user-attachments/assets/edf24fbb-5b7c-46f0-a16c-ca4709107684">

The overlapping effect was created using the following code (method-based syntax):

```python
import altair as alt
import pandas as pd

source = pd.DataFrame(
    {
        "category": list("AABBCC"),
        "group": list("xyxyxy"),
        "value": [0.1, 0.6, 0.7, 0.2, 0.6, 0.1],
    }
)

base = alt.Chart(source, width=alt.Step(12)).encode(
    x="category:N",
    y="value:Q",
    xOffset=alt.XOffset("group:N").scale(paddingOuter=0.5),
)

alt.layer(
    base.mark_bar(size=20, stroke="white", fillOpacity=0.9).encode(fill="group:N"),
    base.mark_text(dy=-5).encode(text="value:Q"),
)
```

Explanation:
- The partial overlap is achieved by controlling the allocated space for each bar and its actual size.
- `width=alt.Step(12)` in `alt.Chart()` defines the space allocated for each bar and thus defines the amount of overlap.
- `mark_bar(size=20)` sets the actual width of the bars.
- The `paddingOuter=0.5` parameter in the `xOffset` scale creates spacing between the categories along the x-axis, to make sure the groups are distinct