### PR TITLE
fix(ruff): Resolve `SIM910` lint in `display.py`

### DIFF
--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -100,7 +100,7 @@ def jupyter_renderer(spec: dict, **metadata):
     JupyterChart.enable_offline(offline=offline)  # type: ignore[attr-defined]
 
     # propagate embed options
-    embed_options = metadata.get("embed_options", None)
+    embed_options = metadata.get("embed_options")
 
     # Need to ignore attr-defined mypy rule because mypy doesn't see _repr_mimebundle_
     # conditionally defined in AnyWidget


### PR DESCRIPTION
Discovered after [pushing](https://github.com/vega/altair/actions/runs/11052195855/job/30703733120?pr=3600) on an unrelated PR.

Simply applied an autofix

Due to https://github.com/astral-sh/ruff/releases/tag/0.6.8