### PR TITLE
docs: bar chart with labels coloured by measured luminance

### DIFF
--- a/tests/examples_arguments_syntax/bar_chart_with_labels_measured_luminance.py
+++ b/tests/examples_arguments_syntax/bar_chart_with_labels_measured_luminance.py
@@ -1,0 +1,30 @@
+"""
+Bar Chart with Labels based on Measured Luminance
+=================================================
+This example shows a basic horizontal bar chart with labels where the measured luminance to decides if the text overlay is be colored ``black`` or ``white``.
+"""
+# category: bar charts
+import altair as alt
+from vega_datasets import data
+
+source = data.barley()
+
+base = alt.Chart(source).encode(
+    x=alt.X('sum(yield):Q', stack='zero'),
+    y=alt.Y('site:O', sort='-x'),
+    text=alt.Text('sum(yield):Q', format='.0f')
+)
+
+bars = base.mark_bar(
+    tooltip=alt.expr("luminance(scale('color', datum.sum_yield))")
+).encode(
+    color='sum(yield):Q'
+)
+
+text = base.mark_text(
+    align='right',
+    dx=-3,
+    color=alt.expr("luminance(scale('color', datum.sum_yield)) > 0.5 ? 'black' : 'white'")
+)
+
+bars + text

--- a/tests/examples_methods_syntax/bar_chart_with_labels_measured_luminance.py
+++ b/tests/examples_methods_syntax/bar_chart_with_labels_measured_luminance.py
@@ -1,0 +1,30 @@
+"""
+Bar Chart with Labels based on Measured Luminance
+=================================================
+This example shows a basic horizontal bar chart with labels where the measured luminance to decides if the text overlay is be colored ``black`` or ``white``.
+"""
+# category: bar charts
+import altair as alt
+from vega_datasets import data
+
+source = data.barley()
+
+base = alt.Chart(source).encode(
+    x=alt.X('sum(yield):Q').stack('zero'),
+    y=alt.Y('site:O').sort('-x'),
+    text=alt.Text('sum(yield):Q', format='.0f')
+)
+
+bars = base.mark_bar(
+    tooltip=alt.expr("luminance(scale('color', datum.sum_yield))")
+).encode(
+    color='sum(yield):Q'
+)
+
+text = base.mark_text(
+    align='right',
+    dx=-3,
+    color=alt.expr("luminance(scale('color', datum.sum_yield)) > 0.5 ? 'black' : 'white'")
+)
+
+bars + text


### PR DESCRIPTION
This PR adds an example that demonstrates how to change the color of text labels based on measured luminance. 

The example looks as such:

<img width="483" alt="image" src="https://github.com/user-attachments/assets/72097fa6-2d43-42f4-9eac-27718170573b">

Usage of luminance for the text color of the labels was created using the following code (method-based syntax):

```python
import altair as alt
from vega_datasets import data

source = data.barley()

base = alt.Chart(source).encode(
    x=alt.X('sum(yield):Q').stack('zero'),
    y=alt.Y('site:O').sort('-x'),
    text=alt.Text('sum(yield):Q', format='.0f')
)

bars = base.mark_bar(
    tooltip=alt.expr("luminance(scale('color', datum.sum_yield))")
).encode(
    color='sum(yield):Q'
)

text = base.mark_text(
    align='right',
    dx=-3,
    color=alt.expr("luminance(scale('color', datum.sum_yield)) > 0.5 ? 'black' : 'white'")
)

bars + text
```

Especially this line
```python
color=alt.expr("luminance(scale('color', datum.sum_yield)) > 0.5 ? 'black' : 'white'")
```

- The lighter the bar, the higher the luminance. If the bar is light we like the text overlay be black. 
- The darker the bar, the lower the luminance. If the bar is dark, we like the text overlay be white.

In the expression above this is written as a predicate. The text appears black if the luminance is above `0.5` and white when the luminance is below `0.5`. The luminance is computed using the `color` scale in combination with the internal computed data field `datum.sum_yield`. Inspecting the luminance can be done through the tooltip by hovering the bars.

Currently this expression is a `str` with plain Vega Expression syntax. It would be nice to use the equivalent python syntax instead.