### PR TITLE
ci: Use `breaking`, `deprecation` labels in changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,11 @@
 changelog:
   categories:
+    - title: Breaking
+      labels:
+        - breaking
+    - title: Deprecation
+      labels:
+        - deprecation
     - title: Enhancements
       labels:
         - enhancement


### PR DESCRIPTION
Related https://github.com/vega/altair/issues/3542

This PR resolves one part of #3542, as agreed in https://github.com/vega/altair/issues/3542#issuecomment-2313042916

https://github.com/vega/altair/pull/3618 will be the first PR to use one of the new labels.