### PR TITLE
test: Correct nested `expr` equivalence

### DIFF
--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -548,7 +548,7 @@ def test_when_labels_position_based_on_condition() -> None:
         expr=alt.expr.if_(param_width_lt_200, "red", "black")
     )
     when = (
-        alt.when(param_width_lt_200)
+        alt.when(param_width_lt_200.expr)
         .then(alt.value("red"))
         .otherwise(alt.value("black"))
     )
@@ -560,7 +560,11 @@ def test_when_labels_position_based_on_condition() -> None:
     param_color_py_when = alt.param(
         expr=alt.expr.if_(cond["test"], cond["value"], otherwise)
     )
-    assert param_color_py_expr.expr == param_color_py_when.expr
+    lhs_param = param_color_py_expr.param
+    rhs_param = param_color_py_when.param
+    assert isinstance(lhs_param, alt.VariableParameter)
+    assert isinstance(rhs_param, alt.VariableParameter)
+    assert repr(lhs_param.expr) == repr(rhs_param.expr)
 
     chart = (
         alt.Chart(df)


### PR DESCRIPTION
Spotted while investigating https://github.com/vega/altair/issues/3616#issuecomment-2386948880

When I originally wrote this test, I didn't realise I was comparing:

```py
GetAttrExpression(Parameter.name, "expr") == GetAttrExpression(Parameter.name, "expr")
```

The intention was to check the contents were the same.
But due to `OperatorMixin.__eq__`, the previous assertion would always return `True`.
