### PR TITLE
docs: Adds example Calculate Residuals

### DIFF
--- a/tests/examples_arguments_syntax/calculate_residuals.py
+++ b/tests/examples_arguments_syntax/calculate_residuals.py
@@ -1,0 +1,35 @@
+"""
+Calculate Residuals
+-------------------
+A dot plot showing each movie in the database, and the difference from the average movie rating.
+The display is sorted by year to visualize everything in sequential order. 
+The graph is for all Movies before 2019.
+
+Adapted from `Calculate Residuals <https://vega.github.io/vega-lite/examples/joinaggregate_residual_graph.html>`_.
+"""
+# category: advanced calculations
+
+import altair as alt
+
+imdb_rating = alt.datum["IMDB Rating"]
+
+chart = (
+    alt.Chart("https://vega.github.io/vega-lite/data/movies.json")
+    .mark_point()
+    .transform_filter(imdb_rating != None)
+    .transform_filter(
+        alt.FieldRangePredicate("Release Date", [None, 2019], timeUnit="year")
+    )
+    .transform_joinaggregate(AverageRating="mean(IMDB Rating)")
+    .transform_calculate(RatingDelta=imdb_rating - alt.datum.AverageRating)
+    .encode(
+        x="Release Date:T",
+        y=alt.Y("RatingDelta:Q", title="Rating Delta"),
+        color=alt.Color(
+            "RatingDelta:Q",
+            title="Rating Delta",
+            scale=alt.Scale(domainMid=0),
+        ),
+    )
+)
+chart

--- a/tests/examples_arguments_syntax/calculate_residuals.py
+++ b/tests/examples_arguments_syntax/calculate_residuals.py
@@ -10,23 +10,25 @@ Adapted from `Calculate Residuals <https://vega.github.io/vega-lite/examples/joi
 # category: advanced calculations
 
 import altair as alt
+from vega_datasets import data
 
-imdb_rating = alt.datum["IMDB Rating"]
+imdb_rating = alt.datum["IMDB_Rating"]
+source = data.movies.url
 
 chart = (
-    alt.Chart("https://vega.github.io/vega-lite/data/movies.json")
+    alt.Chart(source)
     .mark_point()
     .transform_filter(imdb_rating != None)
     .transform_filter(
-        alt.FieldRangePredicate("Release Date", [None, 2019], timeUnit="year")
+        alt.FieldRangePredicate("Release_Date", [None, 2019], timeUnit="year")
     )
-    .transform_joinaggregate(AverageRating="mean(IMDB Rating)")
-    .transform_calculate(RatingDelta=imdb_rating - alt.datum.AverageRating)
+    .transform_joinaggregate(Average_Rating="mean(IMDB_Rating)")
+    .transform_calculate(Rating_Delta=imdb_rating - alt.datum.Average_Rating)
     .encode(
-        x="Release Date:T",
-        y=alt.Y("RatingDelta:Q", title="Rating Delta"),
+        x=alt.X("Release_Date:T", title="Release Date"),
+        y=alt.Y("Rating_Delta:Q", title="Rating Delta"),
         color=alt.Color(
-            "RatingDelta:Q",
+            "Rating_Delta:Q",
             title="Rating Delta",
             scale=alt.Scale(domainMid=0),
         ),

--- a/tests/examples_methods_syntax/calculate_residuals.py
+++ b/tests/examples_methods_syntax/calculate_residuals.py
@@ -10,22 +10,24 @@ Adapted from `Calculate Residuals <https://vega.github.io/vega-lite/examples/joi
 # category: advanced calculations
 
 import altair as alt
+from vega_datasets import data
 
-imdb_rating = alt.datum["IMDB Rating"]
+imdb_rating = alt.datum["IMDB_Rating"]
+source = data.movies.url
 
 chart = (
-    alt.Chart("https://vega.github.io/vega-lite/data/movies.json")
+    alt.Chart(source)
     .mark_point()
     .transform_filter(imdb_rating != None)
     .transform_filter(
-        alt.FieldRangePredicate("Release Date", [None, 2019], timeUnit="year")
+        alt.FieldRangePredicate("Release_Date", [None, 2019], timeUnit="year")
     )
-    .transform_joinaggregate(AverageRating="mean(IMDB Rating)")
-    .transform_calculate(RatingDelta=imdb_rating - alt.datum.AverageRating)
+    .transform_joinaggregate(Average_Rating="mean(IMDB_Rating)")
+    .transform_calculate(Rating_Delta=imdb_rating - alt.datum.Average_Rating)
     .encode(
-        x="Release Date:T",
-        y=alt.Y("RatingDelta:Q").title("Rating Delta"),
-        color=alt.Color("RatingDelta:Q").title("Rating Delta").scale(domainMid=0),
+        x=alt.X("Release_Date:T").title("Release Date"),
+        y=alt.Y("Rating_Delta:Q").title("Rating Delta"),
+        color=alt.Color("Rating_Delta:Q").title("Rating Delta").scale(domainMid=0),
     )
 )
 chart

--- a/tests/examples_methods_syntax/calculate_residuals.py
+++ b/tests/examples_methods_syntax/calculate_residuals.py
@@ -1,0 +1,31 @@
+"""
+Calculate Residuals
+-------------------
+A dot plot showing each movie in the database, and the difference from the average movie rating.
+The display is sorted by year to visualize everything in sequential order. 
+The graph is for all Movies before 2019.
+
+Adapted from `Calculate Residuals <https://vega.github.io/vega-lite/examples/joinaggregate_residual_graph.html>`_.
+"""
+# category: advanced calculations
+
+import altair as alt
+
+imdb_rating = alt.datum["IMDB Rating"]
+
+chart = (
+    alt.Chart("https://vega.github.io/vega-lite/data/movies.json")
+    .mark_point()
+    .transform_filter(imdb_rating != None)
+    .transform_filter(
+        alt.FieldRangePredicate("Release Date", [None, 2019], timeUnit="year")
+    )
+    .transform_joinaggregate(AverageRating="mean(IMDB Rating)")
+    .transform_calculate(RatingDelta=imdb_rating - alt.datum.AverageRating)
+    .encode(
+        x="Release Date:T",
+        y=alt.Y("RatingDelta:Q").title("Rating Delta"),
+        color=alt.Color("RatingDelta:Q").title("Rating Delta").scale(domainMid=0),
+    )
+)
+chart


### PR DESCRIPTION
Recreation of `vega-lite` example https://vega.github.io/vega-lite/examples/joinaggregate_residual_graph.html

I noticed the last example on [Vega Theme Test](https://vega.github.io/vega-themes/) didn't have an `altair` equivalent.
This PR will also bring us one step closer to https://github.com/vega/altair/issues/3519#issuecomment-2359179155

Really like how concise the methods syntax version ended up

![calculate_residuals](https://github.com/user-attachments/assets/f5ff407c-341b-47c2-8ebf-55424ae6bd2d)

```py
import altair as alt
from vega_datasets import data

imdb_rating = alt.datum["IMDB_Rating"]
source = data.movies.url

chart = (
    alt.Chart(source)
    .mark_point()
    .transform_filter(imdb_rating != None)
    .transform_filter(
        alt.FieldRangePredicate("Release_Date", [None, 2019], timeUnit="year")
    )
    .transform_joinaggregate(Average_Rating="mean(IMDB_Rating)")
    .transform_calculate(Rating_Delta=imdb_rating - alt.datum.Average_Rating)
    .encode(
        x=alt.X("Release_Date:T").title("Release Date"),
        y=alt.Y("Rating_Delta:Q").title("Rating Delta"),
        color=alt.Color("Rating_Delta:Q").title("Rating Delta").scale(domainMid=0),
    )
)
chart
```

# Note
Wasn't able to use the url from `vega_datasets.data.movies.url` for this, unsure why exactly
## Edit
Fixed in [docs: Use vega_datasets instead of url](https://github.com/vega/altair/pull/3625/commits/5052f4c146e985483e932c7d98d3c6f81b26c49d)