### PR TITLE
feat: adding observable10 color scheme

### DIFF
--- a/altair/vegalite/v5/schema/_typing.py
+++ b/altair/vegalite/v5/schema/_typing.py
@@ -481,6 +481,7 @@ ColorScheme_T: TypeAlias = Literal[
     "category20",
     "category20b",
     "category20c",
+    "observable10",
     "dark2",
     "paired",
     "pastel1",


### PR DESCRIPTION
I saw that Vega supports the [observable10](https://vega.github.io/vega/docs/schemes/#observable10) color scheme, which I think looks quite nice. It was added to Vega in: https://github.com/vega/vega/pull/3843

I am adding this scheme to Altair's list as well.

Since, `alt.Scale(scheme="observable10")` currently raises a SchemaValidationError on `altair==5.4.1`.