### PR TITLE
fix: `mypy` 1.12.0 errors

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -56,6 +56,18 @@ Applies when `vl-convert`_ import would fail.
    https://github.com/vega/vl-convert
 """
 
+skip_requires_vegafusion: pytest.MarkDecorator = pytest.mark.skipif(
+    find_spec("vegafusion") is None, reason="`vegafusion` not installed."
+)
+"""
+``pytest.mark.skipif`` decorator.
+
+Applies when `vegafusion`_ import would fail.
+
+.. _vegafusion:
+    https://github.com/vega/vegafusion
+"""
+
 
 skip_requires_pyarrow: pytest.MarkDecorator = pytest.mark.skipif(
     find_spec("pyarrow") is None, reason="`pyarrow` not installed."

--- a/tests/utils/test_compiler.py
+++ b/tests/utils/test_compiler.py
@@ -3,11 +3,7 @@ import json
 import pytest
 
 from altair import Chart, vegalite_compilers
-
-try:
-    import vl_convert as vlc
-except ImportError:
-    vlc = None
+from tests import skip_requires_vl_convert
 
 
 @pytest.fixture
@@ -30,27 +26,21 @@ def assert_is_vega_spec(vega_spec):
     assert "axes" in vega_spec
 
 
+@skip_requires_vl_convert
 def test_vegalite_compiler(chart):
-    if vlc is None:
-        pytest.skip("vl_convert is not installed")
-
     vegalite_spec = chart.to_dict()
     vega_spec = vegalite_compilers.get()(vegalite_spec)
     assert_is_vega_spec(vega_spec)
 
 
+@skip_requires_vl_convert
 def test_to_dict_with_format_vega(chart):
-    if vlc is None:
-        pytest.skip("vl_convert is not installed")
-
     vega_spec = chart.to_dict(format="vega")
     assert_is_vega_spec(vega_spec)
 
 
+@skip_requires_vl_convert
 def test_to_json_with_format_vega(chart):
-    if vlc is None:
-        pytest.skip("vl_convert is not installed")
-
     json_spec = chart.to_json(format="vega")
     assert isinstance(json_spec, str)
     spec = json.loads(json_spec)

--- a/tests/utils/test_mimebundle.py
+++ b/tests/utils/test_mimebundle.py
@@ -3,16 +3,7 @@ import pytest
 import altair as alt
 from altair import VEGA_VERSION
 from altair.utils.mimebundle import spec_to_mimebundle
-
-try:
-    import vl_convert as vlc
-except ImportError:
-    vlc = None
-
-try:
-    import vegafusion as vf  # type: ignore
-except ImportError:
-    vf = None
+from tests import skip_requires_vegafusion, skip_requires_vl_convert
 
 
 @pytest.fixture
@@ -168,10 +159,8 @@ def vega_spec():
     }
 
 
+@skip_requires_vl_convert
 def test_vegalite_to_vega_mimebundle(vegalite_spec, vega_spec):
-    if vlc is None:
-        pytest.skip("vl_convert not importable; cannot run mimebundle tests")
-
     bundle = spec_to_mimebundle(
         spec=vegalite_spec,
         format="vega",
@@ -233,7 +222,7 @@ def check_pre_transformed_vega_spec(vega_spec):
     assert len(data_0.get("transform", [])) == 0
 
 
-@pytest.mark.skipif(vf is None, reason="vegafusion is not installed")
+@skip_requires_vegafusion
 def test_vegafusion_spec_to_vega_mime_bundle(vegalite_spec):
     with alt.data_transformers.enable("vegafusion"):
         bundle = spec_to_mimebundle(
@@ -246,7 +235,7 @@ def test_vegafusion_spec_to_vega_mime_bundle(vegalite_spec):
         check_pre_transformed_vega_spec(vega_spec)
 
 
-@pytest.mark.skipif(vf is None, reason="vegafusion is not installed")
+@skip_requires_vegafusion
 def test_vegafusion_chart_to_vega_mime_bundle(vegalite_spec):
     chart = alt.Chart.from_dict(vegalite_spec)
     with alt.data_transformers.enable("vegafusion"), alt.renderers.enable("json"):

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 from datetime import date, datetime
 from importlib.metadata import version as importlib_version
+from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
 import ibis
@@ -25,11 +26,6 @@ from packaging.version import Version
 import altair as alt
 from altair.utils.schemapi import Optional, SchemaValidationError, Undefined
 from tests import skip_requires_vl_convert, slow
-
-try:
-    import vl_convert as vlc
-except ImportError:
-    vlc = None
 
 if TYPE_CHECKING:
     from altair.vegalite.v5.api import _Conditional, _Conditions
@@ -833,7 +829,7 @@ def test_save(format, engine, basic_chart):
                 basic_chart.save(out, format=format, engine=engine)
             assert f"Unsupported format: '{format}'" in str(err.value)
             return
-        elif vlc is None:
+        elif find_spec("vl_convert") is None:
             with pytest.raises(ValueError) as err:  # noqa: PT011
                 basic_chart.save(out, format=format, engine=engine)
             assert "vl-convert-python" in str(err.value)

--- a/tests/vegalite/v5/test_renderers.py
+++ b/tests/vegalite/v5/test_renderers.py
@@ -7,11 +7,7 @@ import pytest
 from packaging.version import Version
 
 import altair.vegalite.v5 as alt
-
-try:
-    import vl_convert as vlc
-except ImportError:
-    vlc = None
+from tests import skip_requires_vl_convert
 
 try:
     import anywidget
@@ -92,10 +88,8 @@ def test_json_renderer_embed_options(chart, renderer="json"):
             assert metadata == {mimetype: {"option": "foo"}}
 
 
+@skip_requires_vl_convert
 def test_renderer_with_none_embed_options(chart, renderer="mimetype"):
-    if vlc is None:
-        pytest.skip("vl_convert not importable; cannot run this test")
-
     # Check that setting embed_options to None doesn't crash
     from altair.utils.mimebundle import spec_to_mimebundle
 


### PR DESCRIPTION
# Related
- https://github.com/vega/altair/pull/3630#issuecomment-2395091419

```py
tests\vegalite\v5\test_renderers.py:14: error: Incompatible types in assignment (expression has type "None", variable has type Module)  [assignment]
        vlc = None
              ^~~~
tests\vegalite\v5\test_api.py:32: error: Incompatible types in assignment (expression has type "None", variable has type Module)  [assignment]
        vlc = None
              ^~~~
tests\utils\test_mimebundle.py:10: error: Incompatible types in assignment (expression has type "None", variable has type Module)  [assignment]
        vlc = None
              ^~~~
tests\utils\test_compiler.py:10: error: Incompatible types in assignment (expression has type "None", variable has type Module)  [assignment]
        vlc = None
              ^~~~
Found 4 errors in 4 files (checked 332 source files)
```