### PR TITLE
ci: Bump `vl-convert-python` to `1.7.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Source = "https://github.com/vega/altair"
 [project.optional-dependencies]
 all = [
     "vega_datasets>=0.9.0",
-    "vl-convert-python>=1.6.0",
+    "vl-convert-python>=1.7.0",
     "pandas>=0.25.3",
     "numpy",
     "pyarrow>=11",
@@ -431,7 +431,6 @@ module = [
     "vega_datasets.*",
     "pyarrow.*",
     "yaml.*",
-    "vl_convert.*",
     "pandas.lib.*",
     "geopandas.*",
     "nbformat.*",

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -45,6 +45,7 @@ from tools.schemapi.utils import (
 
 if TYPE_CHECKING:
     from tools.schemapi.codegen import ArgInfo, AttrGetter
+    from vl_convert import VegaThemes
 
 SCHEMA_VERSION: Final = "v5.20.1"
 
@@ -482,8 +483,8 @@ def download_schemafile(
 
 
 def _vega_lite_props_only(
-    themes: dict[str, dict[str, Any]], props: SchemaProperties, /
-) -> Iterator[tuple[str, dict[str, Any]]]:
+    themes: dict[VegaThemes, dict[str, Any]], props: SchemaProperties, /
+) -> Iterator[tuple[VegaThemes, dict[str, Any]]]:
     """Removes properties that are allowed in `Vega` but not `Vega-Lite` from theme definitions."""
     keep = props.keys()
     for name, theme_spec in themes.items():


### PR DESCRIPTION
# Related
- [fix(typing): Add patch for vl-convert-python=1.7.0](https://github.com/vega/altair/pull/3630/commits/aa00dc12ab99fdb2e0f6082e1c3b1e8c9a799336)
- https://github.com/vega/vl-convert/pull/185
- https://github.com/vega/vl-convert/issues/191
- https://github.com/vega/altair/pull/3600#discussion_r1781010865

I ran into this on another branch, good news is the new stubs are working correctly:

```py
(doc) PS C:\Users\danie\Documents\GitHub\altair> mypy tools
tools\generate_schema_wrapper.py:496: error: Argument 1 to "_vega_lite_props_only" has incompatible type
"dict[Literal['carbong10', 'carbong100', 'carbong90', 'carbonwhite', 'dark', 'excel', 'fivethirtyeight', 'ggplot2', 'googlecharts', 'latimes', 'powerbi', 'quartz', 'urbaninstitute', 'vox'], dict[str, Any]]"; expected
"dict[str, dict[str, Any]]"  [arg-type]
        themes = dict(_vega_lite_props_only(vlc.get_themes(), vl_props))
```

