### PR TITLE
fix: Replace unsafe `locals()` manipulation in `Chart.encode`

### DIFF
--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -25256,10 +25256,48 @@ class _EncodingMixin:
         yOffset : str, :class:`YOffset`, Dict, :class:`YOffsetDatum`, :class:`YOffsetValue`
             Offset of y-position of the marks
         """
-        # Compat prep for `infer_encoding_types` signature
-        kwargs = locals()
-        kwargs.pop("self")
-        args = kwargs.pop("args")
+        kwargs = {
+            "angle": angle,
+            "color": color,
+            "column": column,
+            "description": description,
+            "detail": detail,
+            "facet": facet,
+            "fill": fill,
+            "fillOpacity": fillOpacity,
+            "href": href,
+            "key": key,
+            "latitude": latitude,
+            "latitude2": latitude2,
+            "longitude": longitude,
+            "longitude2": longitude2,
+            "opacity": opacity,
+            "order": order,
+            "radius": radius,
+            "radius2": radius2,
+            "row": row,
+            "shape": shape,
+            "size": size,
+            "stroke": stroke,
+            "strokeDash": strokeDash,
+            "strokeOpacity": strokeOpacity,
+            "strokeWidth": strokeWidth,
+            "text": text,
+            "theta": theta,
+            "theta2": theta2,
+            "tooltip": tooltip,
+            "url": url,
+            "x": x,
+            "x2": x2,
+            "xError": xError,
+            "xError2": xError2,
+            "xOffset": xOffset,
+            "y": y,
+            "y2": y2,
+            "yError": yError,
+            "yError2": yError2,
+            "yOffset": yOffset,
+        }
         if args:
             kwargs = {k: v for k, v in kwargs.items() if v is not Undefined}
 

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -277,10 +277,7 @@ class _EncodingMixin:
     def encode(self, *args: Any, {method_args}) -> Self:
         """Map properties of the data to visual properties of the chart (see :class:`FacetedEncoding`)
         {docstring}"""
-        # Compat prep for `infer_encoding_types` signature
-        kwargs = locals()
-        kwargs.pop("self")
-        args = kwargs.pop("args")
+        kwargs = {dict_literal}
         if args:
             kwargs = {{k: v for k, v in kwargs.items() if v is not Undefined}}
 
@@ -1180,6 +1177,7 @@ def generate_encoding_artifacts(
     method: str = fmt_method.format(
         method_args=", ".join(signature_args),
         docstring=indent_docstring(signature_doc_params, indent_level=8, lstrip=False),
+        dict_literal="{" + ", ".join(f"{kwd!r}:{kwd}" for kwd in channel_infos) + "}",
     )
     typed_dict = generate_typed_dict(
         facet_encoding,


### PR DESCRIPTION
Fixes #3634, #3554

# Description
See comments following https://github.com/vega/altair/issues/3634#issuecomment-2402420120

# Related
- https://peps.python.org/pep-0667/