### PR TITLE
Add upper version bound on VegaFusion

### DIFF
--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 def import_vegafusion() -> ModuleType:
     min_version = "1.5.0"
     try:
+        import vegafusion as vf  # type: ignore
+
         version = importlib_version("vegafusion")
         embed_version = importlib_version("vegafusion-python-embed")
         if version != embed_version or Version(version) < Version(min_version):
@@ -23,7 +25,6 @@ def import_vegafusion() -> ModuleType:
                 f" - vegafusion-python-embed=={embed_version}\n"
             )
             raise RuntimeError(msg)
-        import vegafusion as vf  # type: ignore
 
         return vf
     except ImportError as err:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ all = [
     "pandas>=0.25.3",
     "numpy",
     "pyarrow>=11",
-    "vegafusion[embed]>=1.6.6",
+    "vegafusion[embed]>=1.6.6,<2",
     "anywidget>=0.9.0",
     "altair_tiles>=0.3.0"
 ]


### PR DESCRIPTION
This PR is looking ahead toward the future release of [VegaFusion 2](https://github.com/vega/vegafusion/discussions/433). It adds an upper version bound in the `all` group, and makes a tweak to how the VegaFusion versions are validated.

I'm hoping there won't be breaking changes wrt to Altair's usage of VegFusion, but want to be safe.

VegaFusion 2 will only have a single Python package named VegaFusion (`vegafusion-python-embed` will be no more). If I can make things backward compatible, I'll patch things so that calling `importlib_version("vegafusion-python-embed")` will return the same version as `importlib_version("vegafusion")` so that our validation passes. To make this possible in the future, I moved the vegafusion import above these checks.