### PR TITLE
fix(typing): Add untyped `vegafusion` to `mypy` overrides

### DIFF
--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 def import_vegafusion() -> ModuleType:
     min_version = "1.5.0"
     try:
-        import vegafusion as vf  # type: ignore
+        import vegafusion as vf
 
         version = importlib_version("vegafusion")
         embed_version = importlib_version("vegafusion-python-embed")

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -26,7 +26,7 @@ from altair.vegalite.data import default_data_transformer
 if TYPE_CHECKING:
     from narwhals.typing import IntoDataFrame
 
-    from vegafusion.runtime import ChartState  # type: ignore
+    from vegafusion.runtime import ChartState
 
 # Temporary storage for dataframes that have been extracted
 # from charts by the vegafusion data transformer. Use a WeakValueDictionary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -436,6 +436,7 @@ module = [
     "nbformat.*",
     "ipykernel.*",
     "ibis.*",
+    "vegafusion.*",
     # This refers to schemapi in the tools folder which is imported
     # by the tools scripts such as generate_schema_wrapper.py
     # "schemapi.*"

--- a/tests/test_jupyter_chart.py
+++ b/tests/test_jupyter_chart.py
@@ -26,7 +26,7 @@ skip_requires_anywidget = pytest.mark.skipif(
 
 
 try:
-    import vegafusion  # type: ignore # noqa: F401
+    import vegafusion  # noqa: F401
 
     transformers = ["default", "vegafusion"]
 except ImportError:

--- a/tests/test_transformed_data.py
+++ b/tests/test_transformed_data.py
@@ -10,7 +10,7 @@ from tests import examples_methods_syntax, slow, ignore_DataFrameGroupBy
 import narwhals as nw
 
 try:
-    import vegafusion as vf  # type: ignore
+    import vegafusion as vf
 except ImportError:
     vf = None
 


### PR DESCRIPTION
# Related
- https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker
- https://github.com/vega/altair/pull/3638#pullrequestreview-2364909390

This can be removed in the future, if stubs are added like in https://github.com/vega/vl-convert/pull/185