### PR TITLE
chore: Remove outdated `schemapi` comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -437,9 +437,6 @@ module = [
     "ipykernel.*",
     "ibis.*",
     "vegafusion.*",
-    # This refers to schemapi in the tools folder which is imported
-    # by the tools scripts such as generate_schema_wrapper.py
-    # "schemapi.*"
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
I commented this out in #3536 to identify remaining typing issues.

All of `"./tools/**/*.py"` is now typed, so re-enabling in the future is very unlikely