### PR TITLE
docs: adds info with step size/independent scale

### DIFF
--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -687,7 +687,7 @@ the subchart rather than to the overall chart:
        height=100
    )
 
-If you want to set the chart size relative to the number of observations in a faceted chart you can set the width using ``step`` size:
+To change the chart size relative to the number of distinct categories, you can use the ``step`` class to specify the width/height for each category:
 
 .. altair-plot::
 

--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -694,14 +694,11 @@ To change the chart size relative to the number of distinct categories, you can 
     source = pd.DataFrame(
         [
             {"category": "A", "group": "x", "value": 0.1},
-            # {"category":"A", "group":"y", "value":0.6},
-            # {"category":"A", "group":"z", "value":0.9},
             {"category": "B", "group": "x", "value": 0.7},
             {"category": "B", "group": "y", "value": 0.2},
             {"category": "B", "group": "z", "value": 1.1},
             {"category": "C", "group": "x", "value": 0.6},
             {"category": "C", "group": "y", "value": 0.1},
-            # {"category":"C", "group":"z", "value":0.2}
         ]
     )
 

--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -687,6 +687,36 @@ the subchart rather than to the overall chart:
        height=100
    )
 
+If you want to set the chart size relative to the number of observations in a faceted chart you can set the width using ``step`` size:
+
+.. altair-plot::
+
+    source = pd.DataFrame(
+        [
+            {"category": "A", "group": "x", "value": 0.1},
+            # {"category":"A", "group":"y", "value":0.6},
+            # {"category":"A", "group":"z", "value":0.9},
+            {"category": "B", "group": "x", "value": 0.7},
+            {"category": "B", "group": "y", "value": 0.2},
+            {"category": "B", "group": "z", "value": 1.1},
+            {"category": "C", "group": "x", "value": 0.6},
+            {"category": "C", "group": "y", "value": 0.1},
+            # {"category":"C", "group":"z", "value":0.2}
+        ]
+    )
+
+    alt.Chart(source).mark_bar().encode(
+        x="group",
+        y="value",
+        column="category",
+    ).resolve_scale(
+        x="independent"
+      ).properties(
+        width=alt.Step(50),
+        height=150,
+    )
+
+
 If you want your chart size to respond to the width of the HTML page or container in which
 it is rendered, you can set ``width`` or ``height`` to the string ``"container"``:
 

--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -624,32 +624,7 @@ But since ``mark_bar(size=10)`` only controls the width of the bars, it might be
       y='value:Q'
   )
 
-The width of the chart containing the bar plot can be controlled through setting the ``width``
-property of the chart, either to a pixel value for any chart, or to a step value
-in the case of discrete scales.
-
-Here is an example of setting the width to a single value for the whole chart:
-
-.. altair-plot::
-
-  alt.Chart(data).mark_bar(size=30).encode(
-      x='name:O',
-      y='value:Q'
-  ).properties(width=200)
-
-The width of the bars are set using ``mark_bar(size=30)`` and the width of the chart is set using ``properties(width=100)``
-
-Here is an example of setting the step width for a discrete scale:
-
-.. altair-plot::
-
-  alt.Chart(data).mark_bar(size=30).encode(
-      x='name:N',
-      y='value:Q'
-  ).properties(width=alt.Step(100))
-
-The width of the bars are set using ``mark_bar(size=30)`` and the width that is allocated for each bar bar in the chart is set using ``width=alt.Step(100)``
-
+Therefore, it is often preferred to set the width of the chart relative to the number of distinct categories using  ``Step``, which you can can see an example of a few charts down.
 
 .. _customization-chart-size:
 

--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -624,7 +624,7 @@ But since ``mark_bar(size=10)`` only controls the width of the bars, it might be
       y='value:Q'
   )
 
-Therefore, it is often preferred to set the width of the chart relative to the number of distinct categories using  ``Step``, which you can can see an example of a few charts down.
+Therefore, it is often preferred to set the width of the entire chart relative to the number of distinct categories using :class:`Step`, which you can can see an example of a few charts down.
 
 .. _customization-chart-size:
 
@@ -637,9 +637,9 @@ For example:
 
    import altair as alt
    from vega_datasets import data
-   
+
    cars = data.cars()
-   
+
    alt.Chart(cars).mark_bar().encode(
        x='Origin',
        y='count()'
@@ -664,7 +664,7 @@ the subchart rather than to the overall chart:
        x='independent'
    )
 
-To change the chart size relative to the number of distinct categories, you can use the ``step`` class to specify the width/height for each category rather than for the entire chart:
+To change the chart size relative to the number of distinct categories, you can use the :class:`Step` class to specify the width/height for each category rather than for the entire chart:
 
 .. altair-plot::
 

--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -685,33 +685,24 @@ the subchart rather than to the overall chart:
    ).properties(
        width=100,
        height=100
+   ).resolve_scale(
+       x='independent'
    )
 
-To change the chart size relative to the number of distinct categories, you can use the ``step`` class to specify the width/height for each category:
+To change the chart size relative to the number of distinct categories, you can use the ``step`` class to specify the width/height for each category rather than for the entire chart:
 
 .. altair-plot::
 
-    source = pd.DataFrame(
-        [
-            {"category": "A", "group": "x", "value": 0.1},
-            {"category": "B", "group": "x", "value": 0.7},
-            {"category": "B", "group": "y", "value": 0.2},
-            {"category": "B", "group": "z", "value": 1.1},
-            {"category": "C", "group": "x", "value": 0.6},
-            {"category": "C", "group": "y", "value": 0.1},
-        ]
-    )
-
-    alt.Chart(source).mark_bar().encode(
-        x="group",
-        y="value",
-        column="category",
-    ).resolve_scale(
-        x="independent"
-      ).properties(
-        width=alt.Step(50),
-        height=150,
-    )
+   alt.Chart(cars).mark_bar().encode(
+       x='Origin',
+       y='count()',
+       column='Cylinders:Q'
+   ).properties(
+       width=alt.Step(35),
+       height=100
+   ).resolve_scale(
+       x='independent'
+   )
 
 
 If you want your chart size to respond to the width of the HTML page or container in which


### PR DESCRIPTION
It was not clear from the existing docs how to set individual chart size when using an independent scale with faceted charts and an unequal number of observations.

This adds one more chart example to `user_guide/customization.rst` to show how to vary the size using `alt.Step` to achieve this.