### PR TITLE
feat: Support `datetime.(date|datetime)` as a `SchemaBase` parameter

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -518,8 +518,16 @@ def _from_date_datetime(obj: dt.date | dt.datetime, /) -> dict[str, Any]:
             result.update(
                 hours=obj.hour, minutes=obj.minute, seconds=obj.second, milliseconds=ms
             )
-        if (name := obj.tzname()) and name == "UTC":
-            result["utc"] = True
+        if name := obj.tzname():
+            if name == "UTC":
+                result["utc"] = True
+            else:
+                msg = (
+                    f"Unsupported timezone {name!r}.\n"
+                    "Only `'UTC'` or naive (local) datetimes are permitted.\n"
+                    "See https://altair-viz.github.io/user_guide/generated/core/altair.DateTime.html"
+                )
+                raise TypeError(msg)
     return result
 
 

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -518,12 +518,12 @@ def _from_date_datetime(obj: dt.date | dt.datetime, /) -> dict[str, Any]:
             result.update(
                 hours=obj.hour, minutes=obj.minute, seconds=obj.second, milliseconds=ms
             )
-        if name := obj.tzname():
-            if name == "UTC":
+        if tzinfo := obj.tzinfo:
+            if tzinfo is dt.timezone.utc:
                 result["utc"] = True
             else:
                 msg = (
-                    f"Unsupported timezone {name!r}.\n"
+                    f"Unsupported timezone {tzinfo!r}.\n"
                     "Only `'UTC'` or naive (local) datetimes are permitted.\n"
                     "See https://altair-viz.github.io/user_guide/generated/core/altair.DateTime.html"
                 )

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1443,14 +1443,6 @@ def selection(type: Optional[SelectionType_T] = Undefined, **kwds: Any) -> Param
     return _selection(type=type, **kwds)
 
 
-_V2 = TypeVar("_V2", bool, float, str, Temporal, "DateTime")
-"""Vector2 value type.
-
-Constrained to non-`None` primitive values or date/datetime:
-
-    bool, float, str, datetime.date, datetime.datetime, alt.DateTime
-"""
-
 _SelectionPointValue: TypeAlias = "PrimitiveValue_T | Temporal | DateTime | Sequence[Mapping[SingleDefUnitChannel_T | LiteralString, PrimitiveValue_T | Temporal | DateTime]]"
 """
 Point selections can be initialized with a single primitive value:
@@ -1468,11 +1460,19 @@ You can also provide a sequence of mappings between ``encodings`` or ``fields`` 
     )
 """
 
-_SelectionIntervalValueMap = TypeAliasType(
-    "_SelectionIntervalValueMap",
-    Mapping[SingleDefUnitChannel_T, "tuple[_V2, _V2] | Sequence[_V2]"],
-    type_params=(_V2,),
-)
+_SelectionIntervalValueMap: TypeAlias = Mapping[
+    SingleDefUnitChannel_T,
+    Union[
+        tuple[bool, bool],
+        tuple[float, float],
+        tuple[str, str],
+        tuple["Temporal | DateTime", "Temporal | DateTime"],
+        Sequence[bool],
+        Sequence[float],
+        Sequence[str],
+        Sequence["Temporal | DateTime"],
+    ],
+]
 """
 Interval selections are initialized with a mapping between ``encodings`` to **values**:
 
@@ -1489,12 +1489,17 @@ The values specify the **start** and **end** of the interval selection.
 You can use a ``tuple`` for type-checking each sequence has **two** elements:
 
     alt.selection_interval(value={"x": (55, 160), "y": (13, 37)})
+
+
+.. note::
+
+    Unlike :func:`.selection_point()`, the use of ``None`` is not permitted.
 """
 
 
 def selection_interval(
     name: str | None = None,
-    value: Optional[_SelectionIntervalValueMap[_V2]] = Undefined,
+    value: Optional[_SelectionIntervalValueMap] = Undefined,
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,
     expr: Optional[str | Expr | Expression] = Undefined,

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -540,10 +540,8 @@ else:
 ```
 """
 
-_LiteralValue: TypeAlias = Union[str, bool, float, int]
-"""Primitive python value types."""
 
-_FieldEqualType: TypeAlias = Union[_LiteralValue, Map, Parameter, SchemaBase]
+_FieldEqualType: TypeAlias = Union[PrimitiveValue_T, Map, Parameter, SchemaBase]
 """Permitted types for equality checks on field values:
 
 - `datum.field == ...`
@@ -634,7 +632,7 @@ class _ConditionExtra(TypedDict, closed=True, total=False):  # type: ignore[call
     param: Parameter | str
     test: _TestPredicateType
     value: Any
-    __extra_items__: _StatementType | OneOrSeq[_LiteralValue]
+    __extra_items__: _StatementType | OneOrSeq[PrimitiveValue_T]
 
 
 _Condition: TypeAlias = _ConditionExtra

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -30,7 +30,7 @@ from .compiler import vegalite_compilers
 from .data import data_transformers
 from .display import VEGA_VERSION, VEGAEMBED_VERSION, VEGALITE_VERSION, renderers
 from .schema import SCHEMA_URL, channels, core, mixins
-from .schema._typing import Map
+from .schema._typing import Map, PrimitiveValue_T
 from .theme import themes
 
 if sys.version_info >= (3, 14):
@@ -1440,14 +1440,7 @@ def selection(type: Optional[SelectionType_T] = Undefined, **kwds: Any) -> Param
 def selection_interval(
     name: str | None = None,
     value: Optional[
-        str
-        | bool
-        | None
-        | float
-        | Temporal
-        | SchemaBase
-        | Sequence[SchemaBase | Map]
-        | Map
+        PrimitiveValue_T | Temporal | SchemaBase | Sequence[SchemaBase | Map] | Map
     ] = Undefined,
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,
@@ -1562,14 +1555,7 @@ def selection_interval(
 def selection_point(
     name: str | None = None,
     value: Optional[
-        str
-        | bool
-        | None
-        | float
-        | Temporal
-        | SchemaBase
-        | Sequence[SchemaBase | Map]
-        | Map
+        PrimitiveValue_T | Temporal | SchemaBase | Sequence[SchemaBase | Map] | Map
     ] = Undefined,
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -9,6 +9,7 @@ import operator
 import sys
 import typing as t
 import warnings
+from collections.abc import Mapping, Sequence
 from copy import deepcopy as _deepcopy
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, overload
 
@@ -30,7 +31,7 @@ from .compiler import vegalite_compilers
 from .data import data_transformers
 from .display import VEGA_VERSION, VEGAEMBED_VERSION, VEGALITE_VERSION, renderers
 from .schema import SCHEMA_URL, channels, core, mixins
-from .schema._typing import Map, PrimitiveValue_T
+from .schema._typing import Map, PrimitiveValue_T, SingleDefUnitChannel_T, Temporal
 from .theme import themes
 
 if sys.version_info >= (3, 14):
@@ -38,16 +39,24 @@ if sys.version_info >= (3, 14):
 else:
     from typing_extensions import TypedDict
 if sys.version_info >= (3, 12):
-    from typing import Protocol, runtime_checkable
+    from typing import Protocol, TypeAliasType, runtime_checkable
 else:
-    from typing_extensions import Protocol, runtime_checkable  # noqa: F401
+    from typing_extensions import (  # noqa: F401
+        Protocol,
+        TypeAliasType,
+        runtime_checkable,
+    )
+if sys.version_info >= (3, 11):
+    from typing import LiteralString
+else:
+    from typing_extensions import LiteralString
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
 else:
     from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence
+    from collections.abc import Iterable, Iterator
     from pathlib import Path
     from typing import IO
 
@@ -85,10 +94,8 @@ if TYPE_CHECKING:
         ResolveMode_T,
         SelectionResolution_T,
         SelectionType_T,
-        SingleDefUnitChannel_T,
         SingleTimeUnit_T,
         StackOffset_T,
-        Temporal,
     )
     from .schema.channels import Column, Facet, Row
     from .schema.core import (
@@ -100,6 +107,7 @@ if TYPE_CHECKING:
         BindRadioSelect,
         BindRange,
         BinParams,
+        DateTime,
         Expr,
         ExprRef,
         FacetedEncoding,
@@ -1435,11 +1443,58 @@ def selection(type: Optional[SelectionType_T] = Undefined, **kwds: Any) -> Param
     return _selection(type=type, **kwds)
 
 
+_V2 = TypeVar("_V2", bool, float, str, Temporal, "DateTime")
+"""Vector2 value type.
+
+Constrained to non-`None` primitive values or date/datetime:
+
+    bool, float, str, datetime.date, datetime.datetime, alt.DateTime
+"""
+
+_SelectionPointValue: TypeAlias = "PrimitiveValue_T | Temporal | DateTime | Sequence[Mapping[SingleDefUnitChannel_T | LiteralString, PrimitiveValue_T | Temporal | DateTime]]"
+"""
+Point selections can be initialized with a single primitive value:
+
+    import altair as alt
+
+    alt.selection_point(fields=["year"], value=1980)
+
+
+You can also provide a sequence of mappings between ``encodings`` or ``fields`` to **values**:
+
+    alt.selection_point(
+        fields=["cylinders", "year"],
+        value=[{"cylinders": 4, "year": 1981}, {"cylinders": 8, "year": 1972}],
+    )
+"""
+
+_SelectionIntervalValueMap = TypeAliasType(
+    "_SelectionIntervalValueMap",
+    Mapping[SingleDefUnitChannel_T, "tuple[_V2, _V2] | Sequence[_V2]"],
+    type_params=(_V2,),
+)
+"""
+Interval selections are initialized with a mapping between ``encodings`` to **values**:
+
+    import altair as alt
+
+    alt.selection_interval(
+        encodings=["longitude"],
+        empty=False,
+        value={"longitude": [-50, -110]},
+    )
+
+The values specify the **start** and **end** of the interval selection.
+
+You can use a ``tuple`` for type-checking each sequence has **two** elements:
+
+    alt.selection_interval(value={"x": (55, 160), "y": (13, 37)})
+"""
+
+
 def selection_interval(
     name: str | None = None,
-    value: Optional[
-        PrimitiveValue_T | Temporal | SchemaBase | Sequence[SchemaBase | Map] | Map
-    ] = Undefined,
+    value: Optional[_SelectionIntervalValueMap[_V2]] = Undefined,
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,
     expr: Optional[str | Expr | Expression] = Undefined,
@@ -1552,9 +1607,7 @@ def selection_interval(
 
 def selection_point(
     name: str | None = None,
-    value: Optional[
-        PrimitiveValue_T | Temporal | SchemaBase | Sequence[SchemaBase | Map] | Map
-    ] = Undefined,
+    value: Optional[_SelectionPointValue] = Undefined,
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,
     expr: Optional[Expr] = Undefined,

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
         SingleDefUnitChannel_T,
         SingleTimeUnit_T,
         StackOffset_T,
+        Temporal,
     )
     from .schema.channels import Column, Facet, Row
     from .schema.core import (
@@ -1438,7 +1439,16 @@ def selection(type: Optional[SelectionType_T] = Undefined, **kwds: Any) -> Param
 
 def selection_interval(
     name: str | None = None,
-    value: Optional[Any] = Undefined,
+    value: Optional[
+        str
+        | bool
+        | None
+        | float
+        | Temporal
+        | SchemaBase
+        | Sequence[SchemaBase | Map]
+        | Map
+    ] = Undefined,
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,
     expr: Optional[str | Expr | Expression] = Undefined,
@@ -1551,7 +1561,16 @@ def selection_interval(
 
 def selection_point(
     name: str | None = None,
-    value: Optional[Any] = Undefined,
+    value: Optional[
+        str
+        | bool
+        | None
+        | float
+        | Temporal
+        | SchemaBase
+        | Sequence[SchemaBase | Map]
+        | Map
+    ] = Undefined,
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,
     expr: Optional[Expr] = Undefined,

--- a/altair/vegalite/v5/schema/_typing.py
+++ b/altair/vegalite/v5/schema/_typing.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import re
 import sys
 from collections.abc import Mapping, Sequence
+from datetime import date, datetime
 from typing import Annotated, Any, Generic, Literal, TypeVar, Union, get_args
 
 if sys.version_info >= (3, 14):  # https://peps.python.org/pep-0728/
@@ -86,6 +87,7 @@ __all__ = [
     "StepFor_T",
     "StrokeCap_T",
     "StrokeJoin_T",
+    "Temporal",
     "TextBaseline_T",
     "TextDirection_T",
     "TimeInterval_T",
@@ -196,6 +198,8 @@ class PaddingKwds(TypedDict, total=False):
     right: float
     top: float
 
+
+Temporal: TypeAlias = Union[date, datetime]
 
 VegaThemes: TypeAlias = Literal[
     "carbong10",

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -651,7 +651,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -673,12 +673,18 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -845,7 +851,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -1075,7 +1081,7 @@ class AngleValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -1093,7 +1099,7 @@ class AngleValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -1120,7 +1126,7 @@ class AngleValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -1137,7 +1143,7 @@ class AngleValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -1577,7 +1583,7 @@ class Color(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -1599,12 +1605,18 @@ class Color(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -1771,7 +1783,7 @@ class Color(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -2004,7 +2016,7 @@ class ColorValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -2022,7 +2034,7 @@ class ColorValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -2049,7 +2061,7 @@ class ColorValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -2066,7 +2078,7 @@ class ColorValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -2549,7 +2561,7 @@ class Column(FieldChannelMixin, core.RowColumnEncodingFieldDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | SortOrder_T
         ] = Undefined,
@@ -3002,7 +3014,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -3020,7 +3032,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -3047,7 +3059,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -3064,7 +3076,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -3931,7 +3943,7 @@ class Facet(FieldChannelMixin, core.FacetEncodingFieldDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | SortOrder_T
         ] = Undefined,
@@ -4361,7 +4373,7 @@ class Fill(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -4383,12 +4395,18 @@ class Fill(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -4555,7 +4573,7 @@ class Fill(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -4788,7 +4806,7 @@ class FillValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -4806,7 +4824,7 @@ class FillValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -4833,7 +4851,7 @@ class FillValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -4850,7 +4868,7 @@ class FillValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -5289,7 +5307,7 @@ class FillOpacity(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -5311,12 +5329,18 @@ class FillOpacity(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -5483,7 +5507,7 @@ class FillOpacity(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -5715,7 +5739,7 @@ class FillOpacityValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -5733,7 +5757,7 @@ class FillOpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -5760,7 +5784,7 @@ class FillOpacityValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -5777,7 +5801,7 @@ class FillOpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -6242,7 +6266,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -6260,7 +6284,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -6287,7 +6311,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -6304,7 +6328,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -8665,7 +8689,7 @@ class Opacity(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -8687,12 +8711,18 @@ class Opacity(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -8859,7 +8889,7 @@ class Opacity(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -9089,7 +9119,7 @@ class OpacityValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -9107,7 +9137,7 @@ class OpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -9134,7 +9164,7 @@ class OpacityValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -9151,7 +9181,7 @@ class OpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -9869,12 +9899,18 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -10048,7 +10084,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -10238,12 +10274,18 @@ class RadiusDatum(DatumChannelMixin, core.PositionDatumDefBase):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -11159,7 +11201,7 @@ class Row(FieldChannelMixin, core.RowColumnEncodingFieldDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | SortOrder_T
         ] = Undefined,
@@ -11587,7 +11629,7 @@ class Shape(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -11609,12 +11651,18 @@ class Shape(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -11781,7 +11829,7 @@ class Shape(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -12014,7 +12062,7 @@ class ShapeValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -12032,7 +12080,7 @@ class ShapeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -12059,7 +12107,7 @@ class ShapeValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -12076,7 +12124,7 @@ class ShapeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -12513,7 +12561,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -12535,12 +12583,18 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -12707,7 +12761,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -12937,7 +12991,7 @@ class SizeValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -12955,7 +13009,7 @@ class SizeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -12982,7 +13036,7 @@ class SizeValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -12999,7 +13053,7 @@ class SizeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -13439,7 +13493,7 @@ class Stroke(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -13461,12 +13515,18 @@ class Stroke(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -13633,7 +13693,7 @@ class Stroke(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -13866,7 +13926,7 @@ class StrokeValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -13884,7 +13944,7 @@ class StrokeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -13911,7 +13971,7 @@ class StrokeValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -13928,7 +13988,7 @@ class StrokeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -14367,7 +14427,7 @@ class StrokeDash(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -14389,12 +14449,18 @@ class StrokeDash(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -14561,7 +14627,7 @@ class StrokeDash(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -14793,7 +14859,7 @@ class StrokeDashValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -14811,7 +14877,7 @@ class StrokeDashValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -14838,7 +14904,7 @@ class StrokeDashValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -14855,7 +14921,7 @@ class StrokeDashValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -15294,7 +15360,7 @@ class StrokeOpacity(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -15316,12 +15382,18 @@ class StrokeOpacity(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -15488,7 +15560,7 @@ class StrokeOpacity(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -15720,7 +15792,7 @@ class StrokeOpacityValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -15738,7 +15810,7 @@ class StrokeOpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -15765,7 +15837,7 @@ class StrokeOpacityValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -15782,7 +15854,7 @@ class StrokeOpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -16221,7 +16293,7 @@ class StrokeWidth(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -16243,12 +16315,18 @@ class StrokeWidth(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -16415,7 +16493,7 @@ class StrokeWidth(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -16647,7 +16725,7 @@ class StrokeWidthValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -16665,7 +16743,7 @@ class StrokeWidthValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -16692,7 +16770,7 @@ class StrokeWidthValue(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -16709,7 +16787,7 @@ class StrokeWidthValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -17740,12 +17818,18 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -17919,7 +18003,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -18109,12 +18193,18 @@ class ThetaDatum(DatumChannelMixin, core.PositionDatumDefBase):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -19012,7 +19102,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -19030,7 +19120,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -19057,7 +19147,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -19074,7 +19164,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -19539,7 +19629,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -19557,7 +19647,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -19584,7 +19674,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -19601,7 +19691,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[None | SchemaBase | Map] = Undefined,
@@ -20022,7 +20112,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -20095,12 +20185,18 @@ class X(FieldChannelMixin, core.PositionFieldDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -20276,7 +20372,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -20581,7 +20677,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -20619,12 +20715,18 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -21865,12 +21967,18 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -22035,7 +22143,7 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -22193,12 +22301,18 @@ class XOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -22662,7 +22776,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -22735,12 +22849,18 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -22916,7 +23036,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -23221,7 +23341,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -23259,12 +23379,18 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -24505,12 +24631,18 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -24675,7 +24807,7 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -24833,12 +24965,18 @@ class YOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -1725,7 +1725,7 @@ class Axis(VegaLiteSchema):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -2302,7 +2302,7 @@ class AxisConfig(VegaLiteSchema):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -5647,7 +5647,7 @@ class DomainUnionWith(VegaLiteSchema):
     def __init__(
         self,
         unionWith: Optional[
-            Sequence[str | bool | float | SchemaBase | Map]
+            Sequence[str | bool | float | Temporal | SchemaBase | Map]
         ] = Undefined,
         **kwds,
     ):
@@ -6600,7 +6600,7 @@ class FacetEncodingFieldDef(VegaLiteSchema):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | SortOrder_T
         ] = Undefined,
@@ -6826,7 +6826,7 @@ class FacetFieldDef(VegaLiteSchema):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | SortOrder_T
         ] = Undefined,
@@ -9728,7 +9728,7 @@ class Legend(VegaLiteSchema):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
         ] = Undefined,
         zindex: Optional[float] = Undefined,
@@ -12470,7 +12470,7 @@ class FieldOrDatumDefWithConditionDatumDefGradientstringnull(
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
@@ -12728,7 +12728,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -13120,7 +13120,7 @@ class FieldOrDatumDefWithConditionDatumDefnumberArray(
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
@@ -13378,7 +13378,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -13529,7 +13529,7 @@ class FieldOrDatumDefWithConditionDatumDefnumber(MarkPropDefnumber, NumericMarkP
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
@@ -13787,7 +13787,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -15164,7 +15164,7 @@ class DatumDef(LatLongDef, Position2Def):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
@@ -15324,7 +15324,7 @@ class PositionDatumDefBase(PolarDef):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
         stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
@@ -15519,7 +15519,7 @@ class PositionDatumDef(PositionDef):
         axis: Optional[None | SchemaBase | Map] = Undefined,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         impute: Optional[None | SchemaBase | Map] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
@@ -15810,7 +15810,7 @@ class PositionFieldDef(PositionDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -16090,7 +16090,7 @@ class PositionFieldDefBase(PolarDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -16229,7 +16229,9 @@ class FieldEqualPredicate(Predicate):
 
     def __init__(
         self,
-        equal: Optional[str | bool | float | Parameter | SchemaBase | Map] = Undefined,
+        equal: Optional[
+            str | bool | float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         field: Optional[str | SchemaBase] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
@@ -16258,7 +16260,9 @@ class FieldGTEPredicate(Predicate):
     def __init__(
         self,
         field: Optional[str | SchemaBase] = Undefined,
-        gte: Optional[str | float | Parameter | SchemaBase | Map] = Undefined,
+        gte: Optional[
+            str | float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
@@ -16286,7 +16290,7 @@ class FieldGTPredicate(Predicate):
     def __init__(
         self,
         field: Optional[str | SchemaBase] = Undefined,
-        gt: Optional[str | float | Parameter | SchemaBase | Map] = Undefined,
+        gt: Optional[str | float | Temporal | Parameter | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
@@ -16314,7 +16318,9 @@ class FieldLTEPredicate(Predicate):
     def __init__(
         self,
         field: Optional[str | SchemaBase] = Undefined,
-        lte: Optional[str | float | Parameter | SchemaBase | Map] = Undefined,
+        lte: Optional[
+            str | float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
@@ -16342,7 +16348,7 @@ class FieldLTPredicate(Predicate):
     def __init__(
         self,
         field: Optional[str | SchemaBase] = Undefined,
-        lt: Optional[str | float | Parameter | SchemaBase | Map] = Undefined,
+        lt: Optional[str | float | Temporal | Parameter | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
@@ -16375,7 +16381,7 @@ class FieldOneOfPredicate(Predicate):
             Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
@@ -16408,7 +16414,7 @@ class FieldRangePredicate(Predicate):
         range: Optional[
             Parameter
             | SchemaBase
-            | Sequence[None | float | Parameter | SchemaBase | Map]
+            | Sequence[None | float | Temporal | Parameter | SchemaBase | Map]
             | Map
         ] = Undefined,
         timeUnit: Optional[
@@ -17987,7 +17993,7 @@ class RowColumnEncodingFieldDef(VegaLiteSchema):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | SortOrder_T
         ] = Undefined,
@@ -18290,12 +18296,18 @@ class Scale(VegaLiteSchema):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[
+                str | bool | None | float | Temporal | Parameter | SchemaBase | Map
+            ]
             | Map
         ] = Undefined,
-        domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMax: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainMid: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        domainMin: Optional[float | Parameter | SchemaBase | Map] = Undefined,
+        domainMin: Optional[
+            float | Temporal | Parameter | SchemaBase | Map
+        ] = Undefined,
         domainRaw: Optional[Parameter | SchemaBase | Map] = Undefined,
         exponent: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[
@@ -18742,7 +18754,7 @@ class ScaleDatumDef(OffsetDef):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         scale: Optional[None | SchemaBase | Map] = Undefined,
         title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
@@ -18979,7 +18991,7 @@ class ScaleFieldDef(OffsetDef):
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -20072,7 +20084,14 @@ class SelectionParameter(VegaLiteSchema):
         select: Optional[SchemaBase | Map | SelectionType_T] = Undefined,
         bind: Optional[SchemaBase | Literal["legend", "scales"] | Map] = Undefined,
         value: Optional[
-            str | bool | None | float | SchemaBase | Sequence[SchemaBase | Map] | Map
+            str
+            | bool
+            | None
+            | float
+            | Temporal
+            | SchemaBase
+            | Sequence[SchemaBase | Map]
+            | Map
         ] = Undefined,
         **kwds,
     ):
@@ -20297,7 +20316,7 @@ class FieldOrDatumDefWithConditionDatumDefstringnull(
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
@@ -20555,7 +20574,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
-            | Sequence[SchemaBase | Map]
+            | Sequence[Temporal | SchemaBase | Map]
             | Map
             | AllSortString_T
         ] = Undefined,
@@ -22766,7 +22785,7 @@ class FieldOrDatumDefWithConditionStringDatumDefText(TextDef):
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | None | float | Temporal | Parameter | SchemaBase | Map
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
@@ -24223,7 +24242,14 @@ class TopLevelSelectionParameter(TopLevelParameter):
         select: Optional[SchemaBase | Map | SelectionType_T] = Undefined,
         bind: Optional[SchemaBase | Literal["legend", "scales"] | Map] = Undefined,
         value: Optional[
-            str | bool | None | float | SchemaBase | Sequence[SchemaBase | Map] | Map
+            str
+            | bool
+            | None
+            | float
+            | Temporal
+            | SchemaBase
+            | Sequence[SchemaBase | Map]
+            | Map
         ] = Undefined,
         views: Optional[Sequence[str]] = Undefined,
         **kwds,

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1094,7 +1094,7 @@ def DateTime(
     ids=["date", "datetime (no time)", "datetime (microseconds)", "datetime (UTC)"],
 )
 def test_to_dict_datetime(
-    stocks, window: tuple[Any, Any], expected: tuple[alt.DateTime, alt.DateTime]
+    stocks, window: tuple[dt.date, dt.date], expected: tuple[alt.DateTime, alt.DateTime]
 ) -> None:
     """
     Includes `datetime.datetime` with an empty time component.

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1148,7 +1148,7 @@ def test_to_dict_datetime_typing() -> None:
     assert alt.FieldOneOfPredicate(
         oneOf=datetime_seq,  # type: ignore[arg-type]
         field="column 1",
-    )  # type: ignore[arg-type]
+    )
 
     assert alt.Legend(values=datetime_seq)  # type: ignore[arg-type]
 

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import datetime as dt
 import inspect
 import io
 import json
@@ -1024,3 +1025,91 @@ def test_to_dict_range(tp) -> None:
     x_dict = alt.X("x:O", sort=tp(0, 5)).to_dict()
     actual = x_dict["sort"]  # type: ignore
     assert actual == expected
+
+
+@pytest.fixture
+def stocks() -> alt.Chart:
+    source = "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/sp500.csv"
+    return alt.Chart(source).mark_area().encode(x="date:T", y="price:Q")
+
+
+def DateTime(
+    year: int,
+    month: int,
+    day: int,
+    hour: int = 0,
+    minute: int = 0,
+    second: int = 0,
+    milliseconds: int = 0,
+    *,
+    utc: bool | None = None,
+) -> alt.DateTime:
+    """Factory for positionally aligning `datetime.datetime`/ `alt.DateTime`."""
+    kwds: dict[str, Any] = {}
+    if utc is True:
+        kwds.update(utc=utc)
+    if (hour, minute, second, milliseconds) != (0, 0, 0, 0):
+        kwds.update(
+            hours=hour, minutes=minute, seconds=second, milliseconds=milliseconds
+        )
+    return alt.DateTime(year=year, month=month, date=day, **kwds)
+
+
+@pytest.mark.parametrize(
+    ("window", "expected"),
+    [
+        (
+            (dt.date(2005, 1, 1), dt.date(2009, 1, 1)),
+            (DateTime(2005, 1, 1), DateTime(2009, 1, 1)),
+        ),
+        (
+            (dt.datetime(2005, 1, 1), dt.datetime(2009, 1, 1)),
+            (
+                # NOTE: Keep this to test truncating independently!
+                alt.DateTime(year=2005, month=1, date=1),
+                alt.DateTime(year=2009, month=1, date=1),
+            ),
+        ),
+        (
+            (
+                dt.datetime(2001, 1, 1, 9, 30, 0, 2999),
+                dt.datetime(2002, 1, 1, 17, 0, 0, 5000),
+            ),
+            (
+                DateTime(2001, 1, 1, 9, 30, 0, 2),
+                DateTime(2002, 1, 1, 17, 0, 0, 5),
+            ),
+        ),
+        (
+            (
+                dt.datetime(2003, 5, 1, 1, 30, tzinfo=dt.timezone.utc),
+                dt.datetime(2003, 6, 3, 4, 3, tzinfo=dt.timezone.utc),
+            ),
+            (
+                DateTime(2003, 5, 1, 1, 30, 0, 0, utc=True),
+                DateTime(2003, 6, 3, 4, 3, 0, 0, utc=True),
+            ),
+        ),
+    ],
+    ids=["date", "datetime (no time)", "datetime (microseconds)", "datetime (UTC)"],
+)
+def test_to_dict_datetime(
+    stocks, window: tuple[Any, Any], expected: tuple[alt.DateTime, alt.DateTime]
+) -> None:
+    """
+    Includes `datetime.datetime` with an empty time component.
+
+    This confirms that conversion matches how `alt.DateTime` omits `Undefined`.
+    """
+    expected_dicts = [e.to_dict() for e in expected]
+    brush = alt.selection_interval(encodings=["x"], value={"x": window})
+    base = stocks
+
+    upper = base.encode(alt.X("date:T").scale(domain=brush))
+    lower = base.add_params(brush)
+    chart = upper & lower
+    mapping = chart.to_dict()
+    params_value = mapping["params"][0]["value"]["x"]
+
+    assert isinstance(params_value, list)
+    assert params_value == expected_dicts

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1132,3 +1132,32 @@ def test_to_dict_datetime_unsupported_timezone(tzinfo: dt.timezone) -> None:
 
     with pytest.raises(TypeError, match=r"Unsupported timezone.+\n.+UTC.+local"):
         alt.FieldEqualPredicate(datetime.replace(tzinfo=tzinfo), "column 1")  # type: ignore[arg-type]
+
+
+def test_to_dict_datetime_typing() -> None:
+    """
+    Enumerating various places that need updated annotations.
+
+    All work at runtime, just need to give the type checkers the new info.
+
+    Sub-issue of https://github.com/vega/altair/issues/3650
+    """
+    datetime = dt.datetime(2003, 5, 1, 1, 30)
+    datetime_seq = [datetime, datetime.replace(2005), datetime.replace(2008)]
+    assert alt.FieldEqualPredicate(datetime, field="column 1")  # type: ignore[arg-type]
+    assert alt.FieldOneOfPredicate(
+        oneOf=datetime_seq,  # type: ignore[arg-type]
+        field="column 1",
+    )  # type: ignore[arg-type]
+
+    assert alt.Legend(values=datetime_seq)  # type: ignore[arg-type]
+
+    assert alt.Scale(domain=datetime_seq)  # type: ignore[arg-type]
+    assert alt.Scale(domainMin=datetime_seq[0], domainMax=datetime_seq[2])  # type: ignore[arg-type]
+
+    # NOTE: `datum` is not annotated?
+    assert alt.XDatum(datum=datetime).to_dict()
+
+    # NOTE: `*args` is not annotated?
+    # - All of these uses *args incorrectly
+    assert alt.Vector2DateTime(datetime_seq[:2])

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1127,11 +1127,11 @@ def test_to_dict_datetime(
 def test_to_dict_datetime_unsupported_timezone(tzinfo: dt.timezone) -> None:
     datetime = dt.datetime(2003, 5, 1, 1, 30)
 
-    result = alt.FieldEqualPredicate(datetime, "column 1")  # type: ignore[arg-type]
+    result = alt.FieldEqualPredicate(datetime, "column 1")
     assert result.to_dict()
 
     with pytest.raises(TypeError, match=r"Unsupported timezone.+\n.+UTC.+local"):
-        alt.FieldEqualPredicate(datetime.replace(tzinfo=tzinfo), "column 1")  # type: ignore[arg-type]
+        alt.FieldEqualPredicate(datetime.replace(tzinfo=tzinfo), "column 1")
 
 
 def test_to_dict_datetime_typing() -> None:
@@ -1144,16 +1144,13 @@ def test_to_dict_datetime_typing() -> None:
     """
     datetime = dt.datetime(2003, 5, 1, 1, 30)
     datetime_seq = [datetime, datetime.replace(2005), datetime.replace(2008)]
-    assert alt.FieldEqualPredicate(datetime, field="column 1")  # type: ignore[arg-type]
-    assert alt.FieldOneOfPredicate(
-        oneOf=datetime_seq,  # type: ignore[arg-type]
-        field="column 1",
-    )
+    assert alt.FieldEqualPredicate(datetime, field="column 1")
+    assert alt.FieldOneOfPredicate(oneOf=datetime_seq, field="column 1")
 
-    assert alt.Legend(values=datetime_seq)  # type: ignore[arg-type]
+    assert alt.Legend(values=datetime_seq)
 
-    assert alt.Scale(domain=datetime_seq)  # type: ignore[arg-type]
-    assert alt.Scale(domainMin=datetime_seq[0], domainMax=datetime_seq[2])  # type: ignore[arg-type]
+    assert alt.Scale(domain=datetime_seq)
+    assert alt.Scale(domainMin=datetime_seq[0], domainMax=datetime_seq[2])
 
     # NOTE: `datum` is not annotated?
     assert alt.XDatum(datum=datetime).to_dict()

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1113,3 +1113,22 @@ def test_to_dict_datetime(
 
     assert isinstance(params_value, list)
     assert params_value == expected_dicts
+
+
+@pytest.mark.parametrize(
+    "tzinfo",
+    [
+        dt.timezone(dt.timedelta(hours=2), "UTC+2"),
+        dt.timezone(dt.timedelta(hours=1), "BST"),
+        dt.timezone(dt.timedelta(hours=-7), "pdt"),
+        dt.timezone(dt.timedelta(hours=-3), "BRT"),
+    ],
+)
+def test_to_dict_datetime_unsupported_timezone(tzinfo: dt.timezone) -> None:
+    datetime = dt.datetime(2003, 5, 1, 1, 30)
+
+    result = alt.FieldEqualPredicate(datetime, "column 1")  # type: ignore[arg-type]
+    assert result.to_dict()
+
+    with pytest.raises(TypeError, match=r"Unsupported timezone.+\n.+UTC.+local"):
+        alt.FieldEqualPredicate(datetime.replace(tzinfo=tzinfo), "column 1")  # type: ignore[arg-type]

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1122,6 +1122,8 @@ def test_to_dict_datetime(
         dt.timezone(dt.timedelta(hours=1), "BST"),
         dt.timezone(dt.timedelta(hours=-7), "pdt"),
         dt.timezone(dt.timedelta(hours=-3), "BRT"),
+        dt.timezone(dt.timedelta(hours=9), "UTC"),
+        dt.timezone(dt.timedelta(minutes=60), "utc"),
     ],
 )
 def test_to_dict_datetime_unsupported_timezone(tzinfo: dt.timezone) -> None:

--- a/tests/vegalite/v5/test_params.py
+++ b/tests/vegalite/v5/test_params.py
@@ -175,9 +175,9 @@ def test_selection_interval_value_typing() -> None:
 
     a = alt.selection_interval(encodings=["x"], value={"x": window_date}).to_dict()
     b = alt.selection_interval(encodings=["y"], value={"y": window_other}).to_dict()
-    a_b = alt.selection_interval(  # type: ignore[type-var]
+    a_b = alt.selection_interval(
         encodings=["x", "y"],
-        value={"x": window_date, "y": window_other},  # pyright: ignore[reportArgumentType]
+        value={"x": window_date, "y": window_other},
     ).to_dict()
 
     assert a

--- a/tests/vegalite/v5/test_params.py
+++ b/tests/vegalite/v5/test_params.py
@@ -168,21 +168,37 @@ def test_selection_condition():
 
 
 def test_selection_interval_value_typing() -> None:
+    """Ensure each encoding restricts types independently."""
     import datetime as dt
 
-    window_date = dt.date(2005, 1, 1), dt.date(2009, 1, 1)
-    window_other = (0, 999)
+    w_date = dt.date(2005, 1, 1), dt.date(2009, 1, 1)
+    w_float = (0, 999)
+    w_date_datetime = dt.date(2005, 1, 1), alt.DateTime(year=2009)
+    w_str = ["0", "500"]
 
-    a = alt.selection_interval(encodings=["x"], value={"x": window_date}).to_dict()
-    b = alt.selection_interval(encodings=["y"], value={"y": window_other}).to_dict()
+    a = alt.selection_interval(encodings=["x"], value={"x": w_date}).to_dict()
+    b = alt.selection_interval(encodings=["y"], value={"y": w_float}).to_dict()
+    c = alt.selection_interval(encodings=["x"], value={"x": w_date_datetime}).to_dict()
+    d = alt.selection_interval(encodings=["text"], value={"text": w_str}).to_dict()
+
     a_b = alt.selection_interval(
-        encodings=["x", "y"],
-        value={"x": window_date, "y": window_other},
+        encodings=["x", "y"], value={"x": w_date, "y": w_float}
+    ).to_dict()
+    a_c = alt.selection_interval(
+        encodings=["x", "y"], value={"x": w_date, "y": w_date_datetime}
+    ).to_dict()
+    b_c_d = alt.selection_interval(
+        encodings=["x", "y", "text"],
+        value={"x": w_date_datetime, "y": w_float, "text": w_str},
     ).to_dict()
 
     assert a
     assert b
+    assert c
+    assert d
     assert a_b
+    assert a_c
+    assert b_c_d
 
 
 def test_creation_views_params_layered_repeat_chart():

--- a/tests/vegalite/v5/test_params.py
+++ b/tests/vegalite/v5/test_params.py
@@ -167,6 +167,24 @@ def test_selection_condition():
     assert dct["encoding"]["size"]["value"] == 10
 
 
+def test_selection_interval_value_typing() -> None:
+    import datetime as dt
+
+    window_date = dt.date(2005, 1, 1), dt.date(2009, 1, 1)
+    window_other = (0, 999)
+
+    a = alt.selection_interval(encodings=["x"], value={"x": window_date}).to_dict()
+    b = alt.selection_interval(encodings=["y"], value={"y": window_other}).to_dict()
+    a_b = alt.selection_interval(  # type: ignore[type-var]
+        encodings=["x", "y"],
+        value={"x": window_date, "y": window_other},  # pyright: ignore[reportArgumentType]
+    ).to_dict()
+
+    assert a
+    assert b
+    assert a_b
+
+
 def test_creation_views_params_layered_repeat_chart():
     import altair as alt
     from vega_datasets import data

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -255,6 +255,7 @@ ENCODE_KWDS: Literal["EncodeKwds"] = "EncodeKwds"
 THEME_CONFIG: Literal["ThemeConfig"] = "ThemeConfig"
 PADDING_KWDS: Literal["PaddingKwds"] = "PaddingKwds"
 ROW_COL_KWDS: Literal["RowColKwds"] = "RowColKwds"
+TEMPORAL: Literal["Temporal"] = "Temporal"
 ENCODE_KWDS_SUMMARY: Final = (
     "Encoding channels map properties of the data to visual properties of the chart."
 )
@@ -392,6 +393,8 @@ class PaddingKwds(TypedDict, total=False):
     left: float
     right: float
     top: float
+
+Temporal: TypeAlias = Union[date, datetime]
 '''
 
 _ChannelType = Literal["field", "datum", "value"]
@@ -667,6 +670,7 @@ def generate_vegalite_schema_wrapper(fp: Path, /) -> str:
         "from narwhals.dependencies import is_pandas_dataframe as _is_pandas_dataframe",
         "from altair.utils.schemapi import SchemaBase, Undefined, UndefinedType, _subclasses # noqa: F401\n",
         import_type_checking(
+            "from datetime import date, datetime",
             "from altair import Parameter",
             "from altair.typing import Optional",
             "from ._typing import * # noqa: F403",
@@ -792,6 +796,7 @@ def generate_vegalite_channel_wrappers(fp: Path, /) -> str:
         CHANNEL_MYPY_IGNORE_STATEMENTS,
         *imports,
         import_type_checking(
+            "from datetime import date, datetime",
             "from altair import Parameter, SchemaBase",
             "from altair.typing import Optional",
             f"from altair.vegalite.v5.api import {INTO_CONDITION}",
@@ -1102,6 +1107,7 @@ def vegalite_main(skip_download: bool = False) -> None:
         "is_color_hex",
         ROW_COL_KWDS,
         PADDING_KWDS,
+        TEMPORAL,
         header=HEADER,
         extra=TYPING_EXTRA,
     )

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -516,12 +516,12 @@ def _from_date_datetime(obj: dt.date | dt.datetime, /) -> dict[str, Any]:
             result.update(
                 hours=obj.hour, minutes=obj.minute, seconds=obj.second, milliseconds=ms
             )
-        if name := obj.tzname():
-            if name == "UTC":
+        if tzinfo := obj.tzinfo:
+            if tzinfo is dt.timezone.utc:
                 result["utc"] = True
             else:
                 msg = (
-                    f"Unsupported timezone {name!r}.\n"
+                    f"Unsupported timezone {tzinfo!r}.\n"
                     "Only `'UTC'` or naive (local) datetimes are permitted.\n"
                     "See https://altair-viz.github.io/user_guide/generated/core/altair.DateTime.html"
                 )

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import datetime as dt
 import inspect
 import json
 import sys
@@ -500,6 +501,26 @@ def _from_array_like(obj: Iterable[Any], /) -> list[Any]:
         return list(obj)
 
 
+def _from_date_datetime(obj: dt.date | dt.datetime, /) -> dict[str, Any]:
+    """
+    Parse native `datetime.(date|datetime)` into a `DateTime`_ schema.
+
+    .. _DateTime:
+        https://vega.github.io/vega-lite/docs/datetime.html
+    """
+    result: dict[str, Any] = {"year": obj.year, "month": obj.month, "date": obj.day}
+    if isinstance(obj, dt.datetime):
+        if obj.time() != dt.time.min:
+            us = obj.microsecond
+            ms = us if us == 0 else us // 1_000
+            result.update(
+                hours=obj.hour, minutes=obj.minute, seconds=obj.second, milliseconds=ms
+            )
+        if (name := obj.tzname()) and name == "UTC":
+            result["utc"] = True
+    return result
+
+
 def _todict(obj: Any, context: dict[str, Any] | None, np_opt: Any, pd_opt: Any) -> Any:  # noqa: C901
     """Convert an object to a dict representation."""
     if np_opt is not None:
@@ -530,6 +551,8 @@ def _todict(obj: Any, context: dict[str, Any] | None, np_opt: Any, pd_opt: Any) 
         return pd_opt.Timestamp(obj).isoformat()
     elif _is_iterable(obj, exclude=(str, bytes)):
         return _todict(_from_array_like(obj), context, np_opt, pd_opt)
+    elif isinstance(obj, dt.date):
+        return _from_date_datetime(obj)
     else:
         return obj
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -516,8 +516,16 @@ def _from_date_datetime(obj: dt.date | dt.datetime, /) -> dict[str, Any]:
             result.update(
                 hours=obj.hour, minutes=obj.minute, seconds=obj.second, milliseconds=ms
             )
-        if (name := obj.tzname()) and name == "UTC":
-            result["utc"] = True
+        if name := obj.tzname():
+            if name == "UTC":
+                result["utc"] = True
+            else:
+                msg = (
+                    f"Unsupported timezone {name!r}.\n"
+                    "Only `'UTC'` or naive (local) datetimes are permitted.\n"
+                    "See https://altair-viz.github.io/user_guide/generated/core/altair.DateTime.html"
+                )
+                raise TypeError(msg)
     return result
 
 

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -100,6 +100,7 @@ class _TypeAliasTracer:
         self._imports: Sequence[str] = (
             "from __future__ import annotations\n",
             "import sys",
+            "from datetime import date, datetime",
             "from typing import Annotated, Any, Generic, Literal, Mapping, TypeVar, Sequence, Union, get_args",
             "import re",
             import_typing_extensions(
@@ -524,6 +525,8 @@ class SchemaInfo:
             # NOTE: To keep type hints simple, we annotate with `SchemaBase` for all subclasses.
             if title in tp_param:
                 tps.add("Parameter")
+            if self.is_datetime():
+                tps.add("Temporal")
         elif self.is_value():
             value = self.properties["value"]
             t = value.to_type_repr(target="annotation", use_concrete=use_concrete)
@@ -782,6 +785,9 @@ class SchemaInfo:
             and "field" not in self.required
             and not (iskeyword(next(iter(self.required), "")))
         )
+
+    def is_datetime(self) -> bool:
+        return self.refname == "DateTime"
 
 
 def flatten(container: Iterable) -> Iterable:


### PR DESCRIPTION
Closes #3651

# Example
This is now a working solution for #3643.

No user conversions, or dependency on `pandas`/`polars` required:

<details><summary>Code block</summary>
<p>

```py
from datetime import date

import altair as alt
from vega_datasets import data

source = data.sp500.url

# Create a brush (interval) selection with initial range
brush = alt.selection_interval(
    encodings=["x"], value={"x": (date(2005, 1, 1), date(2009, 1, 1))}
)

base = (
    alt.Chart(source, width=600, height=200).mark_area().encode(x="date:T", y="price:Q")
)
upper = base.encode(alt.X("date:T").scale(domain=brush))
lower = base.properties(height=60).add_params(brush)
chart = upper & lower
chart
```

</p>
</details> 



<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/9394c8a5-dd4a-4fb2-9a68-af82977cb0e5)

</p>
</details> 

<details><summary>Schema output</summary>
<p>

```py
{'config': {'view': {'continuousWidth': 300, 'continuousHeight': 300}},
 'vconcat': [{'mark': {'type': 'area'},
   'encoding': {'x': {'field': 'date',
     'scale': {'domain': {'param': 'param_9'}},
     'type': 'temporal'},
    'y': {'field': 'price', 'type': 'quantitative'}},
   'height': 200,
   'width': 600},
  {'mark': {'type': 'area'},
   'encoding': {'x': {'field': 'date', 'type': 'temporal'},
    'y': {'field': 'price', 'type': 'quantitative'}},
   'height': 60,
   'name': 'view_3',
   'width': 600}],
 'data': {'url': 'https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/sp500.csv'},
 'params': [{'name': 'param_9',
   'select': {'type': 'interval', 'encodings': ['x']},
   'value': {'x': [{'year': 2005, 'month': 1, 'date': 1},
     {'year': 2009, 'month': 1, 'date': 1}]},
   'views': ['view_3']}],
 '$schema': 'https://vega.github.io/schema/vega-lite/v5.20.1.json'}
```

</p>
</details> 

# Typing Examples
Utilizing #3656, and making some progress towards resolving #3643 - these functions now have much more useful annotations.

This wasn't straightforward to piece together, but the types (*and their docs*) are informed by these sources:
- https://vega.github.io/vega-lite/docs/selection.html#current-limitations
- https://vega.github.io/vega-lite/docs/param-value.html
- https://vega.github.io/vega-lite/docs/selection.html#project
- https://github.com/vega/altair/blob/5a6f70dc193f7ed9c89e6cc22e95c9d885167939/altair/vegalite/v5/schema/vega-lite-schema.json#L23087-L23118

## `alt.selection_interval`

https://github.com/user-attachments/assets/86a52125-9295-4ead-9998-c8379458dfd3

## `alt.selection_point`

https://github.com/user-attachments/assets/77a3cfe4-b965-479a-a5da-a86c73ce082c

# Tasks
- [x] Handle conversion from `datetime.(date|datetime)` -> `core.DateTime`
- [x] Update generated annotations
- [x] Update `api.py` annotations
	- [x] `selection_(interval|point)`
		- [x] `value` -> `core.SelectorParameter(value=...)`
		- [x] Mapping (https://github.com/vega/altair/pull/3653/commits/30aa4baa537308ffa7e27effb2bcd386ee9a701e)
			- Seems underspecified in the schema, but the docs imply
				- `Mapping[SingleDefUnitChannel_T | LiteralString, Any]`
			- [1](https://vega.github.io/vega-lite/docs/selection.html#project), [2](https://altair-viz.github.io/user_guide/generated/core/altair.SelectionInitIntervalMapping.html), [3](https://altair-viz.github.io/user_guide/generated/core/altair.SelectionInitMapping.html)
	- [x] [refactor(typing): Factor out `_LiteralValue` alias](https://github.com/vega/altair/pull/3653/commits/23f7a70adc1efa3085b178b4d8bb6fbac50100fc)