### PR TITLE
fix(typing): Revise generated annotation order

### DIFF
--- a/altair/vegalite/v5/schema/_config.py
+++ b/altair/vegalite/v5/schema/_config.py
@@ -515,7 +515,7 @@ class AreaConfigKwds(TypedDict, total=False):
     dy: float
     ellipsis: str
     endAngle: float
-    fill: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    fill: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     fillOpacity: float
     filled: bool
     font: str
@@ -526,7 +526,7 @@ class AreaConfigKwds(TypedDict, total=False):
     href: str
     innerRadius: float
     interpolate: Interpolate_T
-    invalid: None | MarkInvalidDataMode_T
+    invalid: MarkInvalidDataMode_T | None
     limit: float
     line: bool | OverlayMarkDefKwds
     lineBreak: str
@@ -543,7 +543,7 @@ class AreaConfigKwds(TypedDict, total=False):
     size: float
     smooth: bool
     startAngle: float
-    stroke: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    stroke: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     strokeCap: StrokeCap_T
     strokeDash: Sequence[float]
     strokeDashOffset: float
@@ -558,7 +558,7 @@ class AreaConfigKwds(TypedDict, total=False):
     theta2: float
     timeUnitBandPosition: float
     timeUnitBandSize: float
-    tooltip: str | bool | None | float | TooltipContentKwds
+    tooltip: str | bool | float | TooltipContentKwds | None
     url: str
     width: float
     x: float | Literal["width"]
@@ -982,7 +982,7 @@ class AxisConfigKwds(TypedDict, total=False):
     disable: bool
     domain: bool
     domainCap: StrokeCap_T
-    domainColor: None | ColorHex | ColorName_T
+    domainColor: ColorHex | ColorName_T | None
     domainDash: Sequence[float]
     domainDashOffset: float
     domainOpacity: float
@@ -991,7 +991,7 @@ class AxisConfigKwds(TypedDict, total=False):
     formatType: str
     grid: bool
     gridCap: StrokeCap_T
-    gridColor: None | ColorHex | ColorName_T
+    gridColor: ColorHex | ColorName_T | None
     gridDash: Sequence[float]
     gridDashOffset: float
     gridOpacity: float
@@ -1000,7 +1000,7 @@ class AxisConfigKwds(TypedDict, total=False):
     labelAngle: float
     labelBaseline: TextBaseline_T
     labelBound: bool | float
-    labelColor: None | ColorHex | ColorName_T
+    labelColor: ColorHex | ColorName_T | None
     labelExpr: str
     labelFlush: bool | float
     labelFlushOffset: float
@@ -1024,7 +1024,7 @@ class AxisConfigKwds(TypedDict, total=False):
     style: str | Sequence[str]
     tickBand: Literal["center", "extent"]
     tickCap: StrokeCap_T
-    tickColor: None | ColorHex | ColorName_T
+    tickColor: ColorHex | ColorName_T | None
     tickCount: float | TimeIntervalStepKwds | TimeInterval_T
     tickDash: Sequence[float]
     tickDashOffset: float
@@ -1036,12 +1036,12 @@ class AxisConfigKwds(TypedDict, total=False):
     tickSize: float
     tickWidth: float
     ticks: bool
-    title: str | None | Sequence[str]
+    title: str | Sequence[str] | None
     titleAlign: Align_T
     titleAnchor: TitleAnchor_T
     titleAngle: float
     titleBaseline: TextBaseline_T
-    titleColor: None | ColorHex | ColorName_T
+    titleColor: ColorHex | ColorName_T | None
     titleFont: str
     titleFontSize: float
     titleFontStyle: str
@@ -1493,7 +1493,7 @@ class BarConfigKwds(TypedDict, total=False):
     dy: float
     ellipsis: str
     endAngle: float
-    fill: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    fill: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     fillOpacity: float
     filled: bool
     font: str
@@ -1504,7 +1504,7 @@ class BarConfigKwds(TypedDict, total=False):
     href: str
     innerRadius: float
     interpolate: Interpolate_T
-    invalid: None | MarkInvalidDataMode_T
+    invalid: MarkInvalidDataMode_T | None
     limit: float
     lineBreak: str
     lineHeight: float
@@ -1520,7 +1520,7 @@ class BarConfigKwds(TypedDict, total=False):
     size: float
     smooth: bool
     startAngle: float
-    stroke: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    stroke: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     strokeCap: StrokeCap_T
     strokeDash: Sequence[float]
     strokeDashOffset: float
@@ -1535,7 +1535,7 @@ class BarConfigKwds(TypedDict, total=False):
     theta2: float
     timeUnitBandPosition: float
     timeUnitBandSize: float
-    tooltip: str | bool | None | float | TooltipContentKwds
+    tooltip: str | bool | float | TooltipContentKwds | None
     url: str
     width: float
     x: float | Literal["width"]
@@ -3285,7 +3285,7 @@ class LegendConfigKwds(TypedDict, total=False):
     description: str
     direction: Orientation_T
     disable: bool
-    fillColor: None | ColorHex | ColorName_T
+    fillColor: ColorHex | ColorName_T | None
     gradientDirection: Orientation_T
     gradientHorizontalMaxLength: float
     gradientHorizontalMinLength: float
@@ -3293,7 +3293,7 @@ class LegendConfigKwds(TypedDict, total=False):
     gradientLabelOffset: float
     gradientLength: float
     gradientOpacity: float
-    gradientStrokeColor: None | ColorHex | ColorName_T
+    gradientStrokeColor: ColorHex | ColorName_T | None
     gradientStrokeWidth: float
     gradientThickness: float
     gradientVerticalMaxLength: float
@@ -3301,7 +3301,7 @@ class LegendConfigKwds(TypedDict, total=False):
     gridAlign: LayoutAlign_T
     labelAlign: Align_T
     labelBaseline: TextBaseline_T
-    labelColor: None | ColorHex | ColorName_T
+    labelColor: ColorHex | ColorName_T | None
     labelFont: str
     labelFontSize: float
     labelFontStyle: str
@@ -3319,20 +3319,20 @@ class LegendConfigKwds(TypedDict, total=False):
     orient: LegendOrient_T
     padding: float
     rowPadding: float
-    strokeColor: None | ColorHex | ColorName_T
+    strokeColor: ColorHex | ColorName_T | None
     strokeDash: Sequence[float]
     strokeWidth: float
-    symbolBaseFillColor: None | ColorHex | ColorName_T
-    symbolBaseStrokeColor: None | ColorHex | ColorName_T
+    symbolBaseFillColor: ColorHex | ColorName_T | None
+    symbolBaseStrokeColor: ColorHex | ColorName_T | None
     symbolDash: Sequence[float]
     symbolDashOffset: float
     symbolDirection: Orientation_T
-    symbolFillColor: None | ColorHex | ColorName_T
+    symbolFillColor: ColorHex | ColorName_T | None
     symbolLimit: float
     symbolOffset: float
     symbolOpacity: float
     symbolSize: float
-    symbolStrokeColor: None | ColorHex | ColorName_T
+    symbolStrokeColor: ColorHex | ColorName_T | None
     symbolStrokeWidth: float
     symbolType: str
     tickCount: float | TimeIntervalStepKwds | TimeInterval_T
@@ -3340,7 +3340,7 @@ class LegendConfigKwds(TypedDict, total=False):
     titleAlign: Align_T
     titleAnchor: TitleAnchor_T
     titleBaseline: TextBaseline_T
-    titleColor: None | ColorHex | ColorName_T
+    titleColor: ColorHex | ColorName_T | None
     titleFont: str
     titleFontSize: float
     titleFontStyle: str
@@ -3822,7 +3822,7 @@ class LineConfigKwds(TypedDict, total=False):
     dy: float
     ellipsis: str
     endAngle: float
-    fill: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    fill: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     fillOpacity: float
     filled: bool
     font: str
@@ -3833,7 +3833,7 @@ class LineConfigKwds(TypedDict, total=False):
     href: str
     innerRadius: float
     interpolate: Interpolate_T
-    invalid: None | MarkInvalidDataMode_T
+    invalid: MarkInvalidDataMode_T | None
     limit: float
     lineBreak: str
     lineHeight: float
@@ -3849,7 +3849,7 @@ class LineConfigKwds(TypedDict, total=False):
     size: float
     smooth: bool
     startAngle: float
-    stroke: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    stroke: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     strokeCap: StrokeCap_T
     strokeDash: Sequence[float]
     strokeDashOffset: float
@@ -3864,7 +3864,7 @@ class LineConfigKwds(TypedDict, total=False):
     theta2: float
     timeUnitBandPosition: float
     timeUnitBandSize: float
-    tooltip: str | bool | None | float | TooltipContentKwds
+    tooltip: str | bool | float | TooltipContentKwds | None
     url: str
     width: float
     x: float | Literal["width"]
@@ -4346,7 +4346,7 @@ class MarkConfigKwds(TypedDict, total=False):
     dy: float
     ellipsis: str
     endAngle: float
-    fill: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    fill: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     fillOpacity: float
     filled: bool
     font: str
@@ -4357,7 +4357,7 @@ class MarkConfigKwds(TypedDict, total=False):
     href: str
     innerRadius: float
     interpolate: Interpolate_T
-    invalid: None | MarkInvalidDataMode_T
+    invalid: MarkInvalidDataMode_T | None
     limit: float
     lineBreak: str
     lineHeight: float
@@ -4372,7 +4372,7 @@ class MarkConfigKwds(TypedDict, total=False):
     size: float
     smooth: bool
     startAngle: float
-    stroke: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    stroke: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     strokeCap: StrokeCap_T
     strokeDash: Sequence[float]
     strokeDashOffset: float
@@ -4387,7 +4387,7 @@ class MarkConfigKwds(TypedDict, total=False):
     theta2: float
     timeUnitBandPosition: float
     timeUnitBandSize: float
-    tooltip: str | bool | None | float | TooltipContentKwds
+    tooltip: str | bool | float | TooltipContentKwds | None
     url: str
     width: float
     x: float | Literal["width"]
@@ -4955,7 +4955,7 @@ class OverlayMarkDefKwds(TypedDict, total=False):
     dy: float
     ellipsis: str
     endAngle: float
-    fill: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    fill: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     fillOpacity: float
     filled: bool
     font: str
@@ -4966,7 +4966,7 @@ class OverlayMarkDefKwds(TypedDict, total=False):
     href: str
     innerRadius: float
     interpolate: Interpolate_T
-    invalid: None | MarkInvalidDataMode_T
+    invalid: MarkInvalidDataMode_T | None
     limit: float
     lineBreak: str
     lineHeight: float
@@ -4983,7 +4983,7 @@ class OverlayMarkDefKwds(TypedDict, total=False):
     size: float
     smooth: bool
     startAngle: float
-    stroke: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    stroke: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     strokeCap: StrokeCap_T
     strokeDash: Sequence[float]
     strokeDashOffset: float
@@ -5001,7 +5001,7 @@ class OverlayMarkDefKwds(TypedDict, total=False):
     thetaOffset: float
     timeUnitBandPosition: float
     timeUnitBandSize: float
-    tooltip: str | bool | None | float | TooltipContentKwds
+    tooltip: str | bool | float | TooltipContentKwds | None
     url: str
     width: float
     x: float | Literal["width"]
@@ -5635,27 +5635,27 @@ class RangeConfigKwds(TypedDict, total=False):
 
     category: (
         Sequence[ColorHex | ColorName_T]
-        | Sequence[str | bool | None | float | Sequence[float]]
+        | Sequence[str | bool | float | Sequence[float] | None]
         | RangeEnum_T
     )
     diverging: (
         Sequence[ColorHex | ColorName_T]
-        | Sequence[str | bool | None | float | Sequence[float]]
+        | Sequence[str | bool | float | Sequence[float] | None]
         | RangeEnum_T
     )
     heatmap: (
         Sequence[ColorHex | ColorName_T]
-        | Sequence[str | bool | None | float | Sequence[float]]
+        | Sequence[str | bool | float | Sequence[float] | None]
         | RangeEnum_T
     )
     ordinal: (
         Sequence[ColorHex | ColorName_T]
-        | Sequence[str | bool | None | float | Sequence[float]]
+        | Sequence[str | bool | float | Sequence[float] | None]
         | RangeEnum_T
     )
     ramp: (
         Sequence[ColorHex | ColorName_T]
-        | Sequence[str | bool | None | float | Sequence[float]]
+        | Sequence[str | bool | float | Sequence[float] | None]
         | RangeEnum_T
     )
     symbol: Sequence[str]
@@ -6076,7 +6076,7 @@ class RectConfigKwds(TypedDict, total=False):
     dy: float
     ellipsis: str
     endAngle: float
-    fill: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    fill: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     fillOpacity: float
     filled: bool
     font: str
@@ -6087,7 +6087,7 @@ class RectConfigKwds(TypedDict, total=False):
     href: str
     innerRadius: float
     interpolate: Interpolate_T
-    invalid: None | MarkInvalidDataMode_T
+    invalid: MarkInvalidDataMode_T | None
     limit: float
     lineBreak: str
     lineHeight: float
@@ -6103,7 +6103,7 @@ class RectConfigKwds(TypedDict, total=False):
     size: float
     smooth: bool
     startAngle: float
-    stroke: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    stroke: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     strokeCap: StrokeCap_T
     strokeDash: Sequence[float]
     strokeDashOffset: float
@@ -6118,7 +6118,7 @@ class RectConfigKwds(TypedDict, total=False):
     theta2: float
     timeUnitBandPosition: float
     timeUnitBandSize: float
-    tooltip: str | bool | None | float | TooltipContentKwds
+    tooltip: str | bool | float | TooltipContentKwds | None
     url: str
     width: float
     x: float | Literal["width"]
@@ -6378,7 +6378,7 @@ class ScaleInvalidDataConfigKwds(TypedDict, total=False):
     )
     fill: (
         Literal["zero-or-min"]
-        | Value[None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T]
+        | Value[ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None]
     )
     fillOpacity: Value[float] | Literal["zero-or-min"]
     opacity: Value[float] | Literal["zero-or-min"]
@@ -6387,7 +6387,7 @@ class ScaleInvalidDataConfigKwds(TypedDict, total=False):
     size: Value[float] | Literal["zero-or-min"]
     stroke: (
         Literal["zero-or-min"]
-        | Value[None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T]
+        | Value[ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None]
     )
     strokeDash: Literal["zero-or-min"] | Value[Sequence[float]]
     strokeOpacity: Value[float] | Literal["zero-or-min"]
@@ -6988,7 +6988,7 @@ class TickConfigKwds(TypedDict, total=False):
     dy: float
     ellipsis: str
     endAngle: float
-    fill: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    fill: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     fillOpacity: float
     filled: bool
     font: str
@@ -6999,7 +6999,7 @@ class TickConfigKwds(TypedDict, total=False):
     href: str
     innerRadius: float
     interpolate: Interpolate_T
-    invalid: None | MarkInvalidDataMode_T
+    invalid: MarkInvalidDataMode_T | None
     limit: float
     lineBreak: str
     lineHeight: float
@@ -7014,7 +7014,7 @@ class TickConfigKwds(TypedDict, total=False):
     size: float
     smooth: bool
     startAngle: float
-    stroke: None | ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T
+    stroke: ColorHex | LinearGradientKwds | RadialGradientKwds | ColorName_T | None
     strokeCap: StrokeCap_T
     strokeDash: Sequence[float]
     strokeDashOffset: float
@@ -7030,7 +7030,7 @@ class TickConfigKwds(TypedDict, total=False):
     thickness: float
     timeUnitBandPosition: float
     timeUnitBandSize: float
-    tooltip: str | bool | None | float | TooltipContentKwds
+    tooltip: str | bool | float | TooltipContentKwds | None
     url: str
     width: float
     x: float | Literal["width"]
@@ -7175,7 +7175,7 @@ class TitleConfigKwds(TypedDict, total=False):
     angle: float
     aria: bool
     baseline: TextBaseline_T
-    color: None | ColorHex | ColorName_T
+    color: ColorHex | ColorName_T | None
     dx: float
     dy: float
     font: str
@@ -7187,7 +7187,7 @@ class TitleConfigKwds(TypedDict, total=False):
     lineHeight: float
     offset: float
     orient: TitleOrient_T
-    subtitleColor: None | ColorHex | ColorName_T
+    subtitleColor: ColorHex | ColorName_T | None
     subtitleFont: str
     subtitleFontSize: float
     subtitleFontStyle: str
@@ -7304,7 +7304,7 @@ class TitleParamsKwds(TypedDict, total=False):
     angle: float
     aria: bool
     baseline: TextBaseline_T
-    color: None | ColorHex | ColorName_T
+    color: ColorHex | ColorName_T | None
     dx: float
     dy: float
     font: str
@@ -7318,7 +7318,7 @@ class TitleParamsKwds(TypedDict, total=False):
     orient: TitleOrient_T
     style: str | Sequence[str]
     subtitle: str | Sequence[str]
-    subtitleColor: None | ColorHex | ColorName_T
+    subtitleColor: ColorHex | ColorName_T | None
     subtitleFont: str
     subtitleFontSize: float
     subtitleFontStyle: str
@@ -7399,7 +7399,7 @@ class TopLevelSelectionParameterKwds(TypedDict, total=False):
         | LegendStreamBindingKwds
         | Literal["legend", "scales"]
     )
-    value: str | bool | None | float | DateTimeKwds | Sequence[Map]
+    value: str | bool | float | DateTimeKwds | Sequence[Map] | None
     views: Sequence[str]
 
 
@@ -7512,10 +7512,10 @@ class ViewBackgroundKwds(TypedDict, total=False):
 
     cornerRadius: float
     cursor: Cursor_T
-    fill: None | ColorHex | ColorName_T
+    fill: ColorHex | ColorName_T | None
     fillOpacity: float
     opacity: float
-    stroke: None | ColorHex | ColorName_T
+    stroke: ColorHex | ColorName_T | None
     strokeCap: StrokeCap_T
     strokeDash: Sequence[float]
     strokeDashOffset: float
@@ -7612,11 +7612,11 @@ class ViewConfigKwds(TypedDict, total=False):
     cursor: Cursor_T
     discreteHeight: float
     discreteWidth: float
-    fill: None | ColorHex | ColorName_T
+    fill: ColorHex | ColorName_T | None
     fillOpacity: float
     opacity: float
     step: float
-    stroke: None | ColorHex | ColorName_T
+    stroke: ColorHex | ColorName_T | None
     strokeCap: StrokeCap_T
     strokeDash: Sequence[float]
     strokeDashOffset: float

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -277,7 +277,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -320,7 +320,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -329,7 +329,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -342,7 +342,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -389,7 +389,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -561,14 +561,14 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -578,7 +578,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -602,21 +602,21 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -624,14 +624,14 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -673,7 +673,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -735,7 +735,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Angle: ...
 
@@ -743,7 +743,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Angle: ...
 
@@ -834,25 +834,25 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -891,9 +891,9 @@ class AngleDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefnum
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -1026,7 +1026,7 @@ class AngleDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefnum
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -1065,25 +1065,25 @@ class AngleValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> AngleValue: ...
@@ -1093,12 +1093,12 @@ class AngleValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> AngleValue: ...
@@ -1108,26 +1108,26 @@ class AngleValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> AngleValue: ...
@@ -1137,13 +1137,13 @@ class AngleValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> AngleValue: ...
@@ -1203,7 +1203,7 @@ class Color(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -1246,7 +1246,7 @@ class Color(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -1255,7 +1255,7 @@ class Color(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -1268,7 +1268,7 @@ class Color(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -1315,7 +1315,7 @@ class Color(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -1448,7 +1448,7 @@ class Color(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> Color: ...
 
@@ -1457,7 +1457,7 @@ class Color(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> Color: ...
 
@@ -1487,14 +1487,14 @@ class Color(
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1504,7 +1504,7 @@ class Color(
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -1528,21 +1528,21 @@ class Color(
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -1550,14 +1550,14 @@ class Color(
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1599,7 +1599,7 @@ class Color(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1661,7 +1661,7 @@ class Color(
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Color: ...
 
@@ -1669,7 +1669,7 @@ class Color(
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Color: ...
 
@@ -1760,25 +1760,25 @@ class Color(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -1819,9 +1819,9 @@ class ColorDatum(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -1919,7 +1919,7 @@ class ColorDatum(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> ColorDatum: ...
 
@@ -1928,7 +1928,7 @@ class ColorDatum(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> ColorDatum: ...
 
@@ -1954,7 +1954,7 @@ class ColorDatum(
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -1980,7 +1980,7 @@ class ColorValue(
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefGradientstringnullExprRef`, :class:`ConditionalParameterValueDefGradientstringnullExprRef`, :class:`ConditionalPredicateValueDefGradientstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefGradientstringnullExprRef`, :class:`ConditionalParameterValueDefGradientstringnullExprRef`, :class:`ConditionalPredicateValueDefGradientstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`
+    value : str, dict, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -1994,25 +1994,25 @@ class ColorValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> ColorValue: ...
@@ -2022,12 +2022,12 @@ class ColorValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> ColorValue: ...
@@ -2037,26 +2037,26 @@ class ColorValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> ColorValue: ...
@@ -2066,13 +2066,13 @@ class ColorValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> ColorValue: ...
@@ -2081,7 +2081,7 @@ class ColorValue(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> ColorValue: ...
 
@@ -2090,7 +2090,7 @@ class ColorValue(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> ColorValue: ...
 
@@ -2142,7 +2142,7 @@ class Column(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -2183,9 +2183,9 @@ class Column(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    header : dict, None, :class:`Header`
+    header : dict, :class:`Header`, None
         An object defining properties of a facet's header.
-    sort : dict, None, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending']
+    sort : dict, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -2226,7 +2226,7 @@ class Column(FieldChannelMixin, core.RowColumnEncodingFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -2398,7 +2398,7 @@ class Column(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         labelPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         labels: Optional[bool] = Undefined,
         orient: Optional[SchemaBase | Orient_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[SchemaBase | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float] = Undefined,
@@ -2444,7 +2444,7 @@ class Column(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Column: ...
 
@@ -2539,25 +2539,25 @@ class Column(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         align: Optional[SchemaBase | LayoutAlign_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         center: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        header: Optional[None | SchemaBase | Map] = Undefined,
+        header: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | SortOrder_T
+            | None
         ] = Undefined,
         spacing: Optional[float] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -2600,7 +2600,7 @@ class Description(FieldChannelMixin, core.StringFieldDefWithCondition):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -2684,7 +2684,7 @@ class Description(FieldChannelMixin, core.StringFieldDefWithCondition):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -2941,7 +2941,7 @@ class Description(FieldChannelMixin, core.StringFieldDefWithCondition):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -2949,7 +2949,7 @@ class Description(FieldChannelMixin, core.StringFieldDefWithCondition):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -2978,7 +2978,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -2992,25 +2992,25 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> DescriptionValue: ...
@@ -3020,12 +3020,12 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> DescriptionValue: ...
@@ -3035,26 +3035,26 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> DescriptionValue: ...
@@ -3064,13 +3064,13 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> DescriptionValue: ...
@@ -3079,7 +3079,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> DescriptionValue: ...
 
@@ -3088,7 +3088,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> DescriptionValue: ...
 
@@ -3129,7 +3129,7 @@ class Detail(FieldChannelMixin, core.FieldDefWithoutScale):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -3174,7 +3174,7 @@ class Detail(FieldChannelMixin, core.FieldDefWithoutScale):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -3400,12 +3400,12 @@ class Detail(FieldChannelMixin, core.FieldDefWithoutScale):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -3459,7 +3459,7 @@ class Facet(FieldChannelMixin, core.FacetEncodingFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -3531,9 +3531,9 @@ class Facet(FieldChannelMixin, core.FacetEncodingFieldDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    header : dict, None, :class:`Header`
+    header : dict, :class:`Header`, None
         An object defining properties of a facet's header.
-    sort : dict, None, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending']
+    sort : dict, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -3576,7 +3576,7 @@ class Facet(FieldChannelMixin, core.FacetEncodingFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -3770,7 +3770,7 @@ class Facet(FieldChannelMixin, core.FacetEncodingFieldDef):
         labelPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         labels: Optional[bool] = Undefined,
         orient: Optional[SchemaBase | Orient_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[SchemaBase | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float] = Undefined,
@@ -3816,7 +3816,7 @@ class Facet(FieldChannelMixin, core.FacetEncodingFieldDef):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Facet: ...
 
@@ -3919,27 +3919,27 @@ class Facet(FieldChannelMixin, core.FacetEncodingFieldDef):
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         align: Optional[SchemaBase | Map | LayoutAlign_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool | SchemaBase | Map] = Undefined,
         columns: Optional[float] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        header: Optional[None | SchemaBase | Map] = Undefined,
+        header: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | SortOrder_T
+            | None
         ] = Undefined,
         spacing: Optional[float | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -3987,7 +3987,7 @@ class Fill(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -4030,7 +4030,7 @@ class Fill(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -4039,7 +4039,7 @@ class Fill(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -4052,7 +4052,7 @@ class Fill(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -4099,7 +4099,7 @@ class Fill(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -4232,7 +4232,7 @@ class Fill(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> Fill: ...
 
@@ -4241,7 +4241,7 @@ class Fill(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> Fill: ...
 
@@ -4271,14 +4271,14 @@ class Fill(
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -4288,7 +4288,7 @@ class Fill(
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -4312,21 +4312,21 @@ class Fill(
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -4334,14 +4334,14 @@ class Fill(
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -4383,7 +4383,7 @@ class Fill(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -4445,7 +4445,7 @@ class Fill(
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Fill: ...
 
@@ -4453,7 +4453,7 @@ class Fill(
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Fill: ...
 
@@ -4544,25 +4544,25 @@ class Fill(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -4603,9 +4603,9 @@ class FillDatum(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -4703,7 +4703,7 @@ class FillDatum(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> FillDatum: ...
 
@@ -4712,7 +4712,7 @@ class FillDatum(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> FillDatum: ...
 
@@ -4738,7 +4738,7 @@ class FillDatum(
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -4764,7 +4764,7 @@ class FillValue(
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefGradientstringnullExprRef`, :class:`ConditionalParameterValueDefGradientstringnullExprRef`, :class:`ConditionalPredicateValueDefGradientstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefGradientstringnullExprRef`, :class:`ConditionalParameterValueDefGradientstringnullExprRef`, :class:`ConditionalPredicateValueDefGradientstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`
+    value : str, dict, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -4778,25 +4778,25 @@ class FillValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> FillValue: ...
@@ -4806,12 +4806,12 @@ class FillValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> FillValue: ...
@@ -4821,26 +4821,26 @@ class FillValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> FillValue: ...
@@ -4850,13 +4850,13 @@ class FillValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> FillValue: ...
@@ -4865,7 +4865,7 @@ class FillValue(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> FillValue: ...
 
@@ -4874,7 +4874,7 @@ class FillValue(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> FillValue: ...
 
@@ -4915,7 +4915,7 @@ class FillOpacity(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -4958,7 +4958,7 @@ class FillOpacity(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -4967,7 +4967,7 @@ class FillOpacity(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -4980,7 +4980,7 @@ class FillOpacity(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -5027,7 +5027,7 @@ class FillOpacity(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -5199,14 +5199,14 @@ class FillOpacity(
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -5216,7 +5216,7 @@ class FillOpacity(
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -5240,21 +5240,21 @@ class FillOpacity(
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -5262,14 +5262,14 @@ class FillOpacity(
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -5311,7 +5311,7 @@ class FillOpacity(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -5373,7 +5373,7 @@ class FillOpacity(
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> FillOpacity: ...
 
@@ -5381,7 +5381,7 @@ class FillOpacity(
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> FillOpacity: ...
 
@@ -5472,25 +5472,25 @@ class FillOpacity(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -5531,9 +5531,9 @@ class FillOpacityDatum(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -5666,7 +5666,7 @@ class FillOpacityDatum(
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -5705,25 +5705,25 @@ class FillOpacityValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> FillOpacityValue: ...
@@ -5733,12 +5733,12 @@ class FillOpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> FillOpacityValue: ...
@@ -5748,26 +5748,26 @@ class FillOpacityValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> FillOpacityValue: ...
@@ -5777,13 +5777,13 @@ class FillOpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> FillOpacityValue: ...
@@ -5840,7 +5840,7 @@ class Href(FieldChannelMixin, core.StringFieldDefWithCondition):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -5924,7 +5924,7 @@ class Href(FieldChannelMixin, core.StringFieldDefWithCondition):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -6181,7 +6181,7 @@ class Href(FieldChannelMixin, core.StringFieldDefWithCondition):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -6189,7 +6189,7 @@ class Href(FieldChannelMixin, core.StringFieldDefWithCondition):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -6218,7 +6218,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -6232,25 +6232,25 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> HrefValue: ...
@@ -6260,12 +6260,12 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> HrefValue: ...
@@ -6275,26 +6275,26 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> HrefValue: ...
@@ -6304,13 +6304,13 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> HrefValue: ...
@@ -6319,7 +6319,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> HrefValue: ...
 
@@ -6328,7 +6328,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> HrefValue: ...
 
@@ -6369,7 +6369,7 @@ class Key(FieldChannelMixin, core.FieldDefWithoutScale):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -6414,7 +6414,7 @@ class Key(FieldChannelMixin, core.FieldDefWithoutScale):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -6640,12 +6640,12 @@ class Key(FieldChannelMixin, core.FieldDefWithoutScale):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -6728,7 +6728,7 @@ class Latitude(FieldChannelMixin, core.LatLongFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -6937,7 +6937,7 @@ class Latitude(FieldChannelMixin, core.LatLongFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[Literal["quantitative"]] = Undefined,
         **kwds,
     ):
@@ -6965,9 +6965,9 @@ class LatitudeDatum(DatumChannelMixin, core.DatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -7077,7 +7077,7 @@ class LatitudeDatum(DatumChannelMixin, core.DatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -7155,7 +7155,7 @@ class Latitude2(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -7295,7 +7295,7 @@ class Latitude2(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -7321,9 +7321,9 @@ class Latitude2Datum(DatumChannelMixin, core.DatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -7433,7 +7433,7 @@ class Latitude2Datum(DatumChannelMixin, core.DatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -7531,7 +7531,7 @@ class Longitude(FieldChannelMixin, core.LatLongFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -7740,7 +7740,7 @@ class Longitude(FieldChannelMixin, core.LatLongFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[Literal["quantitative"]] = Undefined,
         **kwds,
     ):
@@ -7768,9 +7768,9 @@ class LongitudeDatum(DatumChannelMixin, core.DatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -7880,7 +7880,7 @@ class LongitudeDatum(DatumChannelMixin, core.DatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -7958,7 +7958,7 @@ class Longitude2(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -8098,7 +8098,7 @@ class Longitude2(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -8124,9 +8124,9 @@ class Longitude2Datum(DatumChannelMixin, core.DatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -8236,7 +8236,7 @@ class Longitude2Datum(DatumChannelMixin, core.DatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -8291,7 +8291,7 @@ class Opacity(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -8334,7 +8334,7 @@ class Opacity(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -8343,7 +8343,7 @@ class Opacity(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -8356,7 +8356,7 @@ class Opacity(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -8403,7 +8403,7 @@ class Opacity(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -8575,14 +8575,14 @@ class Opacity(
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -8592,7 +8592,7 @@ class Opacity(
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -8616,21 +8616,21 @@ class Opacity(
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -8638,14 +8638,14 @@ class Opacity(
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -8687,7 +8687,7 @@ class Opacity(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -8749,7 +8749,7 @@ class Opacity(
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Opacity: ...
 
@@ -8757,7 +8757,7 @@ class Opacity(
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Opacity: ...
 
@@ -8848,25 +8848,25 @@ class Opacity(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -8905,9 +8905,9 @@ class OpacityDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefn
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -9040,7 +9040,7 @@ class OpacityDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefn
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -9079,25 +9079,25 @@ class OpacityValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> OpacityValue: ...
@@ -9107,12 +9107,12 @@ class OpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> OpacityValue: ...
@@ -9122,26 +9122,26 @@ class OpacityValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> OpacityValue: ...
@@ -9151,13 +9151,13 @@ class OpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> OpacityValue: ...
@@ -9214,7 +9214,7 @@ class Order(FieldChannelMixin, core.OrderFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -9261,7 +9261,7 @@ class Order(FieldChannelMixin, core.OrderFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -9490,13 +9490,13 @@ class Order(FieldChannelMixin, core.OrderFieldDef):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         sort: Optional[SchemaBase | SortOrder_T] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -9589,7 +9589,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -9625,7 +9625,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -9638,7 +9638,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -9676,7 +9676,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
 
         **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -9715,7 +9715,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -9869,7 +9869,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -9931,7 +9931,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Radius: ...
 
@@ -9939,7 +9939,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Radius: ...
 
@@ -10039,24 +10039,24 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -10087,9 +10087,9 @@ class RadiusDatum(DatumChannelMixin, core.PositionDatumDefBase):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -10102,7 +10102,7 @@ class RadiusDatum(DatumChannelMixin, core.PositionDatumDefBase):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -10132,7 +10132,7 @@ class RadiusDatum(DatumChannelMixin, core.PositionDatumDefBase):
 
         **See also:** `stack <https://vega.github.io/vega-lite/docs/stack.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -10238,7 +10238,7 @@ class RadiusDatum(DatumChannelMixin, core.PositionDatumDefBase):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -10299,9 +10299,9 @@ class RadiusDatum(DatumChannelMixin, core.PositionDatumDefBase):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -10408,7 +10408,7 @@ class Radius2(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -10548,7 +10548,7 @@ class Radius2(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -10574,9 +10574,9 @@ class Radius2Datum(DatumChannelMixin, core.DatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -10686,7 +10686,7 @@ class Radius2Datum(DatumChannelMixin, core.DatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -10752,7 +10752,7 @@ class Row(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -10793,9 +10793,9 @@ class Row(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    header : dict, None, :class:`Header`
+    header : dict, :class:`Header`, None
         An object defining properties of a facet's header.
-    sort : dict, None, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending']
+    sort : dict, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -10836,7 +10836,7 @@ class Row(FieldChannelMixin, core.RowColumnEncodingFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -11008,7 +11008,7 @@ class Row(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         labelPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         labels: Optional[bool] = Undefined,
         orient: Optional[SchemaBase | Orient_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[SchemaBase | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float] = Undefined,
@@ -11054,7 +11054,7 @@ class Row(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Row: ...
 
@@ -11149,25 +11149,25 @@ class Row(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         align: Optional[SchemaBase | LayoutAlign_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         center: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        header: Optional[None | SchemaBase | Map] = Undefined,
+        header: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | SortOrder_T
+            | None
         ] = Undefined,
         spacing: Optional[float] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -11213,7 +11213,7 @@ class Shape(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -11256,7 +11256,7 @@ class Shape(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -11265,7 +11265,7 @@ class Shape(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -11278,7 +11278,7 @@ class Shape(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -11325,7 +11325,7 @@ class Shape(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -11458,7 +11458,7 @@ class Shape(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> Shape: ...
 
@@ -11467,7 +11467,7 @@ class Shape(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> Shape: ...
 
@@ -11497,14 +11497,14 @@ class Shape(
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -11514,7 +11514,7 @@ class Shape(
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -11538,21 +11538,21 @@ class Shape(
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -11560,14 +11560,14 @@ class Shape(
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -11609,7 +11609,7 @@ class Shape(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -11671,7 +11671,7 @@ class Shape(
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Shape: ...
 
@@ -11679,7 +11679,7 @@ class Shape(
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Shape: ...
 
@@ -11770,25 +11770,25 @@ class Shape(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | TypeForShape_T] = Undefined,
         **kwds,
     ):
@@ -11829,9 +11829,9 @@ class ShapeDatum(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -11929,7 +11929,7 @@ class ShapeDatum(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> ShapeDatum: ...
 
@@ -11938,7 +11938,7 @@ class ShapeDatum(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> ShapeDatum: ...
 
@@ -11964,7 +11964,7 @@ class ShapeDatum(
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -11990,7 +11990,7 @@ class ShapeValue(
     ----------
     condition : dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`, :class:`ConditionalMarkPropFieldOrDatumDefTypeForShape`, :class:`ConditionalParameterMarkPropFieldOrDatumDefTypeForShape`, :class:`ConditionalPredicateMarkPropFieldOrDatumDefTypeForShape`, Sequence[dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -12004,25 +12004,25 @@ class ShapeValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | TypeForShape_T] = Undefined,
         **kwds,
     ) -> ShapeValue: ...
@@ -12032,12 +12032,12 @@ class ShapeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> ShapeValue: ...
@@ -12047,26 +12047,26 @@ class ShapeValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | TypeForShape_T] = Undefined,
         **kwds,
     ) -> ShapeValue: ...
@@ -12076,13 +12076,13 @@ class ShapeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> ShapeValue: ...
@@ -12091,7 +12091,7 @@ class ShapeValue(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> ShapeValue: ...
 
@@ -12100,7 +12100,7 @@ class ShapeValue(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> ShapeValue: ...
 
@@ -12139,7 +12139,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -12182,7 +12182,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -12191,7 +12191,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -12204,7 +12204,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -12251,7 +12251,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -12423,14 +12423,14 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -12440,7 +12440,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -12464,21 +12464,21 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -12486,14 +12486,14 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -12535,7 +12535,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -12597,7 +12597,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Size: ...
 
@@ -12605,7 +12605,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Size: ...
 
@@ -12696,25 +12696,25 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -12753,9 +12753,9 @@ class SizeDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefnumb
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -12888,7 +12888,7 @@ class SizeDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefnumb
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -12927,25 +12927,25 @@ class SizeValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> SizeValue: ...
@@ -12955,12 +12955,12 @@ class SizeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> SizeValue: ...
@@ -12970,26 +12970,26 @@ class SizeValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> SizeValue: ...
@@ -12999,13 +12999,13 @@ class SizeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> SizeValue: ...
@@ -13065,7 +13065,7 @@ class Stroke(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -13108,7 +13108,7 @@ class Stroke(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -13117,7 +13117,7 @@ class Stroke(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -13130,7 +13130,7 @@ class Stroke(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -13177,7 +13177,7 @@ class Stroke(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -13310,7 +13310,7 @@ class Stroke(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> Stroke: ...
 
@@ -13319,7 +13319,7 @@ class Stroke(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> Stroke: ...
 
@@ -13349,14 +13349,14 @@ class Stroke(
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -13366,7 +13366,7 @@ class Stroke(
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -13390,21 +13390,21 @@ class Stroke(
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -13412,14 +13412,14 @@ class Stroke(
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -13461,7 +13461,7 @@ class Stroke(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -13523,7 +13523,7 @@ class Stroke(
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Stroke: ...
 
@@ -13531,7 +13531,7 @@ class Stroke(
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Stroke: ...
 
@@ -13622,25 +13622,25 @@ class Stroke(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -13681,9 +13681,9 @@ class StrokeDatum(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -13781,7 +13781,7 @@ class StrokeDatum(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> StrokeDatum: ...
 
@@ -13790,7 +13790,7 @@ class StrokeDatum(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> StrokeDatum: ...
 
@@ -13816,7 +13816,7 @@ class StrokeDatum(
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -13842,7 +13842,7 @@ class StrokeValue(
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefGradientstringnullExprRef`, :class:`ConditionalParameterValueDefGradientstringnullExprRef`, :class:`ConditionalPredicateValueDefGradientstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefGradientstringnullExprRef`, :class:`ConditionalParameterValueDefGradientstringnullExprRef`, :class:`ConditionalPredicateValueDefGradientstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`
+    value : str, dict, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -13856,25 +13856,25 @@ class StrokeValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> StrokeValue: ...
@@ -13884,12 +13884,12 @@ class StrokeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> StrokeValue: ...
@@ -13899,26 +13899,26 @@ class StrokeValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> StrokeValue: ...
@@ -13928,13 +13928,13 @@ class StrokeValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> StrokeValue: ...
@@ -13943,7 +13943,7 @@ class StrokeValue(
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> StrokeValue: ...
 
@@ -13952,7 +13952,7 @@ class StrokeValue(
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> StrokeValue: ...
 
@@ -13993,7 +13993,7 @@ class StrokeDash(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -14036,7 +14036,7 @@ class StrokeDash(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -14045,7 +14045,7 @@ class StrokeDash(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -14058,7 +14058,7 @@ class StrokeDash(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -14105,7 +14105,7 @@ class StrokeDash(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -14277,14 +14277,14 @@ class StrokeDash(
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -14294,7 +14294,7 @@ class StrokeDash(
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -14318,21 +14318,21 @@ class StrokeDash(
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -14340,14 +14340,14 @@ class StrokeDash(
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -14389,7 +14389,7 @@ class StrokeDash(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -14451,7 +14451,7 @@ class StrokeDash(
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> StrokeDash: ...
 
@@ -14459,7 +14459,7 @@ class StrokeDash(
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> StrokeDash: ...
 
@@ -14550,25 +14550,25 @@ class StrokeDash(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -14609,9 +14609,9 @@ class StrokeDashDatum(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -14744,7 +14744,7 @@ class StrokeDashDatum(
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -14783,25 +14783,25 @@ class StrokeDashValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> StrokeDashValue: ...
@@ -14811,12 +14811,12 @@ class StrokeDashValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> StrokeDashValue: ...
@@ -14826,26 +14826,26 @@ class StrokeDashValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> StrokeDashValue: ...
@@ -14855,13 +14855,13 @@ class StrokeDashValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> StrokeDashValue: ...
@@ -14920,7 +14920,7 @@ class StrokeOpacity(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -14963,7 +14963,7 @@ class StrokeOpacity(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -14972,7 +14972,7 @@ class StrokeOpacity(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -14985,7 +14985,7 @@ class StrokeOpacity(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -15032,7 +15032,7 @@ class StrokeOpacity(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -15204,14 +15204,14 @@ class StrokeOpacity(
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -15221,7 +15221,7 @@ class StrokeOpacity(
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -15245,21 +15245,21 @@ class StrokeOpacity(
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -15267,14 +15267,14 @@ class StrokeOpacity(
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -15316,7 +15316,7 @@ class StrokeOpacity(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -15378,7 +15378,7 @@ class StrokeOpacity(
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> StrokeOpacity: ...
 
@@ -15386,7 +15386,7 @@ class StrokeOpacity(
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> StrokeOpacity: ...
 
@@ -15477,25 +15477,25 @@ class StrokeOpacity(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -15536,9 +15536,9 @@ class StrokeOpacityDatum(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -15671,7 +15671,7 @@ class StrokeOpacityDatum(
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -15710,25 +15710,25 @@ class StrokeOpacityValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> StrokeOpacityValue: ...
@@ -15738,12 +15738,12 @@ class StrokeOpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> StrokeOpacityValue: ...
@@ -15753,26 +15753,26 @@ class StrokeOpacityValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> StrokeOpacityValue: ...
@@ -15782,13 +15782,13 @@ class StrokeOpacityValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> StrokeOpacityValue: ...
@@ -15847,7 +15847,7 @@ class StrokeWidth(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -15890,7 +15890,7 @@ class StrokeWidth(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -15899,7 +15899,7 @@ class StrokeWidth(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -15912,7 +15912,7 @@ class StrokeWidth(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -15959,7 +15959,7 @@ class StrokeWidth(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -16131,14 +16131,14 @@ class StrokeWidth(
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -16148,7 +16148,7 @@ class StrokeWidth(
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -16172,21 +16172,21 @@ class StrokeWidth(
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -16194,14 +16194,14 @@ class StrokeWidth(
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -16243,7 +16243,7 @@ class StrokeWidth(
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -16305,7 +16305,7 @@ class StrokeWidth(
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> StrokeWidth: ...
 
@@ -16313,7 +16313,7 @@ class StrokeWidth(
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> StrokeWidth: ...
 
@@ -16404,25 +16404,25 @@ class StrokeWidth(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -16463,9 +16463,9 @@ class StrokeWidthDatum(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -16598,7 +16598,7 @@ class StrokeWidthDatum(
         datum,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -16637,25 +16637,25 @@ class StrokeWidthValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> StrokeWidthValue: ...
@@ -16665,12 +16665,12 @@ class StrokeWidthValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> StrokeWidthValue: ...
@@ -16680,26 +16680,26 @@ class StrokeWidthValue(
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> StrokeWidthValue: ...
@@ -16709,13 +16709,13 @@ class StrokeWidthValue(
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> StrokeWidthValue: ...
@@ -16772,7 +16772,7 @@ class Text(FieldChannelMixin, core.FieldOrDatumDefWithConditionStringFieldDefTex
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -16856,7 +16856,7 @@ class Text(FieldChannelMixin, core.FieldOrDatumDefWithConditionStringFieldDefTex
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -17113,7 +17113,7 @@ class Text(FieldChannelMixin, core.FieldOrDatumDefWithConditionStringFieldDefTex
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -17121,7 +17121,7 @@ class Text(FieldChannelMixin, core.FieldOrDatumDefWithConditionStringFieldDefTex
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -17159,7 +17159,7 @@ class TextDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionStringDatumD
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
     format : str, dict, :class:`Dict`
         When used with the default ``"number"`` and ``"time"`` format type, the text
@@ -17193,7 +17193,7 @@ class TextDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionStringDatumD
         * ``"time"`` for temporal fields and ordinal and nominal fields with ``timeUnit``.
         * ``"number"`` for quantitative fields as well as ordinal and nominal fields without
           ``timeUnit``.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -17337,7 +17337,7 @@ class TextDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionStringDatumD
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -17376,7 +17376,7 @@ class TextValue(ValueChannelMixin, core.ValueDefWithConditionStringFieldDefText)
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
@@ -17384,7 +17384,7 @@ class TextValue(ValueChannelMixin, core.ValueDefWithConditionStringFieldDefText)
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> TextValue: ...
@@ -17394,7 +17394,7 @@ class TextValue(ValueChannelMixin, core.ValueDefWithConditionStringFieldDefText)
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -17403,7 +17403,7 @@ class TextValue(ValueChannelMixin, core.ValueDefWithConditionStringFieldDefText)
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> TextValue: ...
@@ -17460,7 +17460,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -17496,7 +17496,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -17509,7 +17509,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -17547,7 +17547,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
 
         **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -17586,7 +17586,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -17740,7 +17740,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -17802,7 +17802,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Theta: ...
 
@@ -17810,7 +17810,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Theta: ...
 
@@ -17910,24 +17910,24 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -17958,9 +17958,9 @@ class ThetaDatum(DatumChannelMixin, core.PositionDatumDefBase):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -17973,7 +17973,7 @@ class ThetaDatum(DatumChannelMixin, core.PositionDatumDefBase):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -18003,7 +18003,7 @@ class ThetaDatum(DatumChannelMixin, core.PositionDatumDefBase):
 
         **See also:** `stack <https://vega.github.io/vega-lite/docs/stack.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -18109,7 +18109,7 @@ class ThetaDatum(DatumChannelMixin, core.PositionDatumDefBase):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -18170,9 +18170,9 @@ class ThetaDatum(DatumChannelMixin, core.PositionDatumDefBase):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -18279,7 +18279,7 @@ class Theta2(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -18419,7 +18419,7 @@ class Theta2(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -18445,9 +18445,9 @@ class Theta2Datum(DatumChannelMixin, core.DatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -18557,7 +18557,7 @@ class Theta2Datum(DatumChannelMixin, core.DatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -18610,7 +18610,7 @@ class Tooltip(FieldChannelMixin, core.StringFieldDefWithCondition):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -18694,7 +18694,7 @@ class Tooltip(FieldChannelMixin, core.StringFieldDefWithCondition):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -18951,7 +18951,7 @@ class Tooltip(FieldChannelMixin, core.StringFieldDefWithCondition):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -18959,7 +18959,7 @@ class Tooltip(FieldChannelMixin, core.StringFieldDefWithCondition):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -18988,7 +18988,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -19002,25 +19002,25 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> TooltipValue: ...
@@ -19030,12 +19030,12 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> TooltipValue: ...
@@ -19045,26 +19045,26 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> TooltipValue: ...
@@ -19074,13 +19074,13 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> TooltipValue: ...
@@ -19089,7 +19089,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> TooltipValue: ...
 
@@ -19098,7 +19098,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> TooltipValue: ...
 
@@ -19137,7 +19137,7 @@ class Url(FieldChannelMixin, core.StringFieldDefWithCondition):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -19221,7 +19221,7 @@ class Url(FieldChannelMixin, core.StringFieldDefWithCondition):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -19478,7 +19478,7 @@ class Url(FieldChannelMixin, core.StringFieldDefWithCondition):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -19486,7 +19486,7 @@ class Url(FieldChannelMixin, core.StringFieldDefWithCondition):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -19515,7 +19515,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -19529,25 +19529,25 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> UrlValue: ...
@@ -19557,12 +19557,12 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> UrlValue: ...
@@ -19572,26 +19572,26 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ) -> UrlValue: ...
@@ -19601,13 +19601,13 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         empty: Optional[bool] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ) -> UrlValue: ...
@@ -19616,7 +19616,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> UrlValue: ...
 
@@ -19625,7 +19625,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
         self,
         empty: Optional[bool] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ) -> UrlValue: ...
 
@@ -19660,7 +19660,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
         documentation.
-    axis : dict, None, :class:`Axis`
+    axis : dict, :class:`Axis`, None
         An object defining properties of axis's gridlines, ticks and labels. If ``null``,
         the axis for the encoding channel will be removed.
 
@@ -19673,7 +19673,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -19709,7 +19709,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    impute : dict, None, :class:`ImputeParams`
+    impute : dict, :class:`ImputeParams`, None
         An object defining the properties of the Impute Operation to be applied. The field
         value of the other positional channel is taken as ``key`` of the ``Impute``
         Operation. The field of the ``color`` channel if specified is used as ``groupby`` of
@@ -19717,7 +19717,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `impute <https://vega.github.io/vega-lite/docs/impute.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -19730,7 +19730,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -19768,7 +19768,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -19807,7 +19807,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -19920,7 +19920,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         domain: Optional[bool] = Undefined,
         domainCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         domainColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         domainDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
@@ -19933,7 +19933,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         grid: Optional[bool] = Undefined,
         gridCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         gridColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gridDash: Optional[Parameter | SchemaBase | Sequence[float] | Map] = Undefined,
         gridDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -19946,7 +19946,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         ] = Undefined,
         labelBound: Optional[bool | float | Parameter | SchemaBase | Map] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFlush: Optional[bool | float] = Undefined,
@@ -19978,7 +19978,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         ] = Undefined,
         tickCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         tickColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         tickCount: Optional[
             float | Parameter | SchemaBase | Map | TimeInterval_T
@@ -19993,7 +19993,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         tickSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         tickWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ticks: Optional[bool] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -20001,7 +20001,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -20073,7 +20073,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
     @overload
     def impute(
         self,
-        frame: Optional[Sequence[None | float]] = Undefined,
+        frame: Optional[Sequence[float | None]] = Undefined,
         keyvals: Optional[SchemaBase | Sequence[Any] | Map] = Undefined,
         method: Optional[SchemaBase | ImputeMethod_T] = Undefined,
         value: Optional[Any] = Undefined,
@@ -20095,7 +20095,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -20157,7 +20157,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> X: ...
 
@@ -20165,7 +20165,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> X: ...
 
@@ -20264,27 +20264,27 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         self,
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
-        axis: Optional[None | SchemaBase | Map] = Undefined,
+        axis: Optional[SchemaBase | Map | None] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        impute: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        impute: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -20313,7 +20313,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
 
     Parameters
     ----------
-    axis : dict, None, :class:`Axis`
+    axis : dict, :class:`Axis`, None
         An object defining properties of axis's gridlines, ticks and labels. If ``null``,
         the axis for the encoding channel will be removed.
 
@@ -20326,9 +20326,9 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    impute : dict, None, :class:`ImputeParams`
+    impute : dict, :class:`ImputeParams`, None
         An object defining the properties of the Impute Operation to be applied. The field
         value of the other positional channel is taken as ``key`` of the ``Impute``
         Operation. The field of the ``color`` channel if specified is used as ``groupby`` of
@@ -20336,7 +20336,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
 
         **See also:** `impute <https://vega.github.io/vega-lite/docs/impute.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -20349,7 +20349,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -20379,7 +20379,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
 
         **See also:** `stack <https://vega.github.io/vega-lite/docs/stack.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -20479,7 +20479,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
         domain: Optional[bool] = Undefined,
         domainCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         domainColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         domainDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
@@ -20492,7 +20492,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
         grid: Optional[bool] = Undefined,
         gridCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         gridColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gridDash: Optional[Parameter | SchemaBase | Sequence[float] | Map] = Undefined,
         gridDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -20505,7 +20505,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
         ] = Undefined,
         labelBound: Optional[bool | float | Parameter | SchemaBase | Map] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFlush: Optional[bool | float] = Undefined,
@@ -20537,7 +20537,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
         ] = Undefined,
         tickCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         tickColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         tickCount: Optional[
             float | Parameter | SchemaBase | Map | TimeInterval_T
@@ -20552,7 +20552,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
         tickSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         tickWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ticks: Optional[bool] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -20560,7 +20560,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -20597,7 +20597,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
     @overload
     def impute(
         self,
-        frame: Optional[Sequence[None | float]] = Undefined,
+        frame: Optional[Sequence[float | None]] = Undefined,
         keyvals: Optional[SchemaBase | Sequence[Any] | Map] = Undefined,
         method: Optional[SchemaBase | ImputeMethod_T] = Undefined,
         value: Optional[Any] = Undefined,
@@ -20619,7 +20619,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -20679,12 +20679,12 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
     def __init__(
         self,
         datum,
-        axis: Optional[None | SchemaBase | Map] = Undefined,
+        axis: Optional[SchemaBase | Map | None] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        impute: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        impute: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -20793,7 +20793,7 @@ class X2(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -20933,7 +20933,7 @@ class X2(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -20959,9 +20959,9 @@ class X2Datum(DatumChannelMixin, core.DatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -21071,7 +21071,7 @@ class X2Datum(DatumChannelMixin, core.DatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -21172,7 +21172,7 @@ class XError(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -21312,7 +21312,7 @@ class XError(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -21419,7 +21419,7 @@ class XError2(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -21559,7 +21559,7 @@ class XError2(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -21618,7 +21618,7 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -21654,7 +21654,7 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -21667,7 +21667,7 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -21714,7 +21714,7 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -21865,7 +21865,7 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -21927,7 +21927,7 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> XOffset: ...
 
@@ -21935,7 +21935,7 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> XOffset: ...
 
@@ -22026,23 +22026,23 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -22072,9 +22072,9 @@ class XOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -22087,7 +22087,7 @@ class XOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -22193,7 +22193,7 @@ class XOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -22245,8 +22245,8 @@ class XOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -22300,7 +22300,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
         documentation.
-    axis : dict, None, :class:`Axis`
+    axis : dict, :class:`Axis`, None
         An object defining properties of axis's gridlines, ticks and labels. If ``null``,
         the axis for the encoding channel will be removed.
 
@@ -22313,7 +22313,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -22349,7 +22349,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    impute : dict, None, :class:`ImputeParams`
+    impute : dict, :class:`ImputeParams`, None
         An object defining the properties of the Impute Operation to be applied. The field
         value of the other positional channel is taken as ``key`` of the ``Impute``
         Operation. The field of the ``color`` channel if specified is used as ``groupby`` of
@@ -22357,7 +22357,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `impute <https://vega.github.io/vega-lite/docs/impute.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -22370,7 +22370,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -22408,7 +22408,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -22447,7 +22447,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -22560,7 +22560,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         domain: Optional[bool] = Undefined,
         domainCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         domainColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         domainDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
@@ -22573,7 +22573,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         grid: Optional[bool] = Undefined,
         gridCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         gridColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gridDash: Optional[Parameter | SchemaBase | Sequence[float] | Map] = Undefined,
         gridDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -22586,7 +22586,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         ] = Undefined,
         labelBound: Optional[bool | float | Parameter | SchemaBase | Map] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFlush: Optional[bool | float] = Undefined,
@@ -22618,7 +22618,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         ] = Undefined,
         tickCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         tickColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         tickCount: Optional[
             float | Parameter | SchemaBase | Map | TimeInterval_T
@@ -22633,7 +22633,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         tickSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         tickWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ticks: Optional[bool] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -22641,7 +22641,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -22713,7 +22713,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
     @overload
     def impute(
         self,
-        frame: Optional[Sequence[None | float]] = Undefined,
+        frame: Optional[Sequence[float | None]] = Undefined,
         keyvals: Optional[SchemaBase | Sequence[Any] | Map] = Undefined,
         method: Optional[SchemaBase | ImputeMethod_T] = Undefined,
         value: Optional[Any] = Undefined,
@@ -22735,7 +22735,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -22797,7 +22797,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Y: ...
 
@@ -22805,7 +22805,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> Y: ...
 
@@ -22904,27 +22904,27 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         self,
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
-        axis: Optional[None | SchemaBase | Map] = Undefined,
+        axis: Optional[SchemaBase | Map | None] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        impute: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        impute: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -22953,7 +22953,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
 
     Parameters
     ----------
-    axis : dict, None, :class:`Axis`
+    axis : dict, :class:`Axis`, None
         An object defining properties of axis's gridlines, ticks and labels. If ``null``,
         the axis for the encoding channel will be removed.
 
@@ -22966,9 +22966,9 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    impute : dict, None, :class:`ImputeParams`
+    impute : dict, :class:`ImputeParams`, None
         An object defining the properties of the Impute Operation to be applied. The field
         value of the other positional channel is taken as ``key`` of the ``Impute``
         Operation. The field of the ``color`` channel if specified is used as ``groupby`` of
@@ -22976,7 +22976,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
 
         **See also:** `impute <https://vega.github.io/vega-lite/docs/impute.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -22989,7 +22989,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -23019,7 +23019,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
 
         **See also:** `stack <https://vega.github.io/vega-lite/docs/stack.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -23119,7 +23119,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
         domain: Optional[bool] = Undefined,
         domainCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         domainColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         domainDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
@@ -23132,7 +23132,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
         grid: Optional[bool] = Undefined,
         gridCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         gridColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gridDash: Optional[Parameter | SchemaBase | Sequence[float] | Map] = Undefined,
         gridDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -23145,7 +23145,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
         ] = Undefined,
         labelBound: Optional[bool | float | Parameter | SchemaBase | Map] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFlush: Optional[bool | float] = Undefined,
@@ -23177,7 +23177,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
         ] = Undefined,
         tickCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         tickColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         tickCount: Optional[
             float | Parameter | SchemaBase | Map | TimeInterval_T
@@ -23192,7 +23192,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
         tickSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         tickWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ticks: Optional[bool] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -23200,7 +23200,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -23237,7 +23237,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
     @overload
     def impute(
         self,
-        frame: Optional[Sequence[None | float]] = Undefined,
+        frame: Optional[Sequence[float | None]] = Undefined,
         keyvals: Optional[SchemaBase | Sequence[Any] | Map] = Undefined,
         method: Optional[SchemaBase | ImputeMethod_T] = Undefined,
         value: Optional[Any] = Undefined,
@@ -23259,7 +23259,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -23319,12 +23319,12 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
     def __init__(
         self,
         datum,
-        axis: Optional[None | SchemaBase | Map] = Undefined,
+        axis: Optional[SchemaBase | Map | None] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        impute: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        impute: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -23433,7 +23433,7 @@ class Y2(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -23573,7 +23573,7 @@ class Y2(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -23599,9 +23599,9 @@ class Y2Datum(DatumChannelMixin, core.DatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -23711,7 +23711,7 @@ class Y2Datum(DatumChannelMixin, core.DatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -23812,7 +23812,7 @@ class YError(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -23952,7 +23952,7 @@ class YError(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -24059,7 +24059,7 @@ class YError2(FieldChannelMixin, core.SecondaryFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -24199,7 +24199,7 @@ class YError2(FieldChannelMixin, core.SecondaryFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -24258,7 +24258,7 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -24294,7 +24294,7 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -24307,7 +24307,7 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -24354,7 +24354,7 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -24505,7 +24505,7 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -24567,7 +24567,7 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> YOffset: ...
 
@@ -24575,7 +24575,7 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
     def sort(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ) -> YOffset: ...
 
@@ -24666,23 +24666,23 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -24712,9 +24712,9 @@ class YOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -24727,7 +24727,7 @@ class YOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -24833,7 +24833,7 @@ class YOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -24885,8 +24885,8 @@ class YOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
         self,
         datum,
         bandPosition: Optional[float] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -689,7 +689,7 @@ class AreaConfig(AnyMarkConfig):
     endAngle : dict, float, :class:`ExprRef`
         The end angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
@@ -750,7 +750,7 @@ class AreaConfig(AnyMarkConfig):
         * ``"bundle"``: equivalent to basis, except the tension parameter is used to
           straighten the spline.
         * ``"monotone"``: cubic interpolation that preserves monotonicity in y.
-    invalid : None, :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show']
+    invalid : :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show'], None
         Invalid data mode, which defines how the marks and corresponding scales should
         represent invalid values (``null`` and ``NaN`` in continuous scales *without*
         defined output for invalid values).
@@ -889,7 +889,7 @@ class AreaConfig(AnyMarkConfig):
     startAngle : dict, float, :class:`ExprRef`
         The start angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
@@ -941,7 +941,7 @@ class AreaConfig(AnyMarkConfig):
         Default relative band size for a time unit. If set to ``1``, the bandwidth of the
         marks will be equal to the time unit band step. If set to ``0.5``, bandwidth of the
         marks will be half of the time unit band step.
-    tooltip : str, bool, dict, None, float, :class:`ExprRef`, :class:`TooltipContent`
+    tooltip : str, bool, dict, float, :class:`ExprRef`, :class:`TooltipContent`, None
         The tooltip text string to show upon mouse hover or an object defining which fields
         should the tooltip be derived from.
 
@@ -1015,7 +1015,7 @@ class AreaConfig(AnyMarkConfig):
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         endAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -1027,7 +1027,7 @@ class AreaConfig(AnyMarkConfig):
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -1045,7 +1045,7 @@ class AreaConfig(AnyMarkConfig):
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         startAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -1064,7 +1064,7 @@ class AreaConfig(AnyMarkConfig):
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1276,7 +1276,7 @@ class Axis(VegaLiteSchema):
         ``"square"``.
 
         **Default value:** ``"butt"``
-    domainColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    domainColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Color of axis domain line.
 
         **Default value:** ``"gray"``.
@@ -1333,7 +1333,7 @@ class Axis(VegaLiteSchema):
         ``"square"``.
 
         **Default value:** ``"butt"``
-    gridColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    gridColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Color of gridlines.
 
         **Default value:** ``"lightGray"``.
@@ -1370,7 +1370,7 @@ class Axis(VegaLiteSchema):
         bounding box may exceed the axis range.
 
         **Default value:** ``false``.
-    labelColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    labelColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the tick label, can be in hex color code or regular color name.
     labelExpr : str
         `Vega expression <https://vega.github.io/vega/docs/expressions/>`__ for customizing
@@ -1485,7 +1485,7 @@ class Axis(VegaLiteSchema):
         ``"square"``.
 
         **Default value:** ``"butt"``
-    tickColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    tickColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the axis's tick.
 
         **Default value:** ``"gray"``
@@ -1538,7 +1538,7 @@ class Axis(VegaLiteSchema):
         Boolean value that determines whether the axis should include ticks.
 
         **Default value:** ``true``
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -1570,7 +1570,7 @@ class Axis(VegaLiteSchema):
         ``"line-top"`` and ``"line-bottom"`` values operate similarly to ``"top"`` and
         ``"bottom"``, but are calculated relative to the *lineHeight* rather than *fontSize*
         alone.
-    titleColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    titleColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Color of the title, can be in hex color code or regular color name.
     titleFont : str, dict, :class:`ExprRef`
         Font of the title. (e.g., ``"Helvetica Neue"``).
@@ -1623,7 +1623,7 @@ class Axis(VegaLiteSchema):
         domain: Optional[bool] = Undefined,
         domainCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         domainColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         domainDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
@@ -1636,7 +1636,7 @@ class Axis(VegaLiteSchema):
         grid: Optional[bool] = Undefined,
         gridCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         gridColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gridDash: Optional[Parameter | SchemaBase | Sequence[float] | Map] = Undefined,
         gridDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1649,7 +1649,7 @@ class Axis(VegaLiteSchema):
         ] = Undefined,
         labelBound: Optional[bool | float | Parameter | SchemaBase | Map] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFlush: Optional[bool | float] = Undefined,
@@ -1681,7 +1681,7 @@ class Axis(VegaLiteSchema):
         ] = Undefined,
         tickCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         tickColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         tickCount: Optional[
             float | Parameter | SchemaBase | Map | TimeInterval_T
@@ -1696,7 +1696,7 @@ class Axis(VegaLiteSchema):
         tickSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         tickWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ticks: Optional[bool] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1704,7 +1704,7 @@ class Axis(VegaLiteSchema):
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1852,7 +1852,7 @@ class AxisConfig(VegaLiteSchema):
         ``"square"``.
 
         **Default value:** ``"butt"``
-    domainColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    domainColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Color of axis domain line.
 
         **Default value:** ``"gray"``.
@@ -1909,7 +1909,7 @@ class AxisConfig(VegaLiteSchema):
         ``"square"``.
 
         **Default value:** ``"butt"``
-    gridColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    gridColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Color of gridlines.
 
         **Default value:** ``"lightGray"``.
@@ -1946,7 +1946,7 @@ class AxisConfig(VegaLiteSchema):
         bounding box may exceed the axis range.
 
         **Default value:** ``false``.
-    labelColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    labelColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the tick label, can be in hex color code or regular color name.
     labelExpr : str
         `Vega expression <https://vega.github.io/vega/docs/expressions/>`__ for customizing
@@ -2061,7 +2061,7 @@ class AxisConfig(VegaLiteSchema):
         ``"square"``.
 
         **Default value:** ``"butt"``
-    tickColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    tickColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, :class:`ConditionalAxisColor`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the axis's tick.
 
         **Default value:** ``"gray"``
@@ -2114,7 +2114,7 @@ class AxisConfig(VegaLiteSchema):
         Boolean value that determines whether the axis should include ticks.
 
         **Default value:** ``true``
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -2146,7 +2146,7 @@ class AxisConfig(VegaLiteSchema):
         ``"line-top"`` and ``"line-bottom"`` values operate similarly to ``"top"`` and
         ``"bottom"``, but are calculated relative to the *lineHeight* rather than *fontSize*
         alone.
-    titleColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    titleColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Color of the title, can be in hex color code or regular color name.
     titleFont : str, dict, :class:`ExprRef`
         Font of the title. (e.g., ``"Helvetica Neue"``).
@@ -2200,7 +2200,7 @@ class AxisConfig(VegaLiteSchema):
         domain: Optional[bool] = Undefined,
         domainCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         domainColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         domainDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
@@ -2213,7 +2213,7 @@ class AxisConfig(VegaLiteSchema):
         grid: Optional[bool] = Undefined,
         gridCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         gridColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gridDash: Optional[Parameter | SchemaBase | Sequence[float] | Map] = Undefined,
         gridDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -2226,7 +2226,7 @@ class AxisConfig(VegaLiteSchema):
         ] = Undefined,
         labelBound: Optional[bool | float | Parameter | SchemaBase | Map] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFlush: Optional[bool | float] = Undefined,
@@ -2258,7 +2258,7 @@ class AxisConfig(VegaLiteSchema):
         ] = Undefined,
         tickCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         tickColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         tickCount: Optional[
             float | Parameter | SchemaBase | Map | TimeInterval_T
@@ -2273,7 +2273,7 @@ class AxisConfig(VegaLiteSchema):
         tickSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         tickWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ticks: Optional[bool] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -2281,7 +2281,7 @@ class AxisConfig(VegaLiteSchema):
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -2560,7 +2560,7 @@ class BarConfig(AnyMarkConfig):
     endAngle : dict, float, :class:`ExprRef`
         The end angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
@@ -2621,7 +2621,7 @@ class BarConfig(AnyMarkConfig):
         * ``"bundle"``: equivalent to basis, except the tension parameter is used to
           straighten the spline.
         * ``"monotone"``: cubic interpolation that preserves monotonicity in y.
-    invalid : None, :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show']
+    invalid : :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show'], None
         Invalid data mode, which defines how the marks and corresponding scales should
         represent invalid values (``null`` and ``NaN`` in continuous scales *without*
         defined output for invalid values).
@@ -2738,7 +2738,7 @@ class BarConfig(AnyMarkConfig):
     startAngle : dict, float, :class:`ExprRef`
         The start angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
@@ -2790,7 +2790,7 @@ class BarConfig(AnyMarkConfig):
         Default relative band size for a time unit. If set to ``1``, the bandwidth of the
         marks will be equal to the time unit band step. If set to ``0.5``, bandwidth of the
         marks will be half of the time unit band step.
-    tooltip : str, bool, dict, None, float, :class:`ExprRef`, :class:`TooltipContent`
+    tooltip : str, bool, dict, float, :class:`ExprRef`, :class:`TooltipContent`, None
         The tooltip text string to show upon mouse hover or an object defining which fields
         should the tooltip be derived from.
 
@@ -2868,7 +2868,7 @@ class BarConfig(AnyMarkConfig):
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         endAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -2880,7 +2880,7 @@ class BarConfig(AnyMarkConfig):
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         lineHeight: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -2897,7 +2897,7 @@ class BarConfig(AnyMarkConfig):
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         startAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -2916,7 +2916,7 @@ class BarConfig(AnyMarkConfig):
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -3041,7 +3041,7 @@ class BaseTitleNoValueRefs(VegaLiteSchema):
         ``"line-bottom"``. The ``"line-top"`` and ``"line-bottom"`` values operate similarly
         to ``"top"`` and ``"bottom"``, but are calculated relative to the *lineHeight*
         rather than *fontSize* alone.
-    color : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    color : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Text color for title text.
     dx : dict, float, :class:`ExprRef`
         Delta offset for title and subtitle text x-coordinate.
@@ -3071,7 +3071,7 @@ class BaseTitleNoValueRefs(VegaLiteSchema):
         position along the edge of the chart.
     orient : dict, :class:`ExprRef`, :class:`TitleOrient`, Literal['none', 'left', 'right', 'top', 'bottom']
         Default title orientation (``"top"``, ``"bottom"``, ``"left"``, or ``"right"``)
-    subtitleColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    subtitleColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Text color for subtitle text.
     subtitleFont : str, dict, :class:`ExprRef`
         Font name for subtitle text.
@@ -3104,7 +3104,7 @@ class BaseTitleNoValueRefs(VegaLiteSchema):
         aria: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         baseline: Optional[SchemaBase | TextBaseline_T] = Undefined,
         color: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         dx: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -3118,7 +3118,7 @@ class BaseTitleNoValueRefs(VegaLiteSchema):
         offset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         orient: Optional[Parameter | SchemaBase | Map | TitleOrient_T] = Undefined,
         subtitleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         subtitleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         subtitleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -3723,7 +3723,7 @@ class BoxPlotDef(CompositeMarkDef):
           range (*Q3-Q1*).
 
         **Default value:** ``1.5``.
-    invalid : None, :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show']
+    invalid : :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show'], None
         Invalid data mode, which defines how the marks and corresponding scales should
         represent invalid values (``null`` and ``NaN`` in continuous scales *without*
         defined output for invalid values).
@@ -3783,7 +3783,7 @@ class BoxPlotDef(CompositeMarkDef):
         clip: Optional[bool] = Undefined,
         color: Optional[str | Parameter | SchemaBase | Map | ColorName_T] = Undefined,
         extent: Optional[float | Literal["min-max"]] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         median: Optional[bool | SchemaBase | Map] = Undefined,
         opacity: Optional[float] = Undefined,
         orient: Optional[SchemaBase | Orientation_T] = Undefined,
@@ -4163,7 +4163,7 @@ class ConditionalParameterStringFieldDef(ConditionalStringFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -4243,7 +4243,7 @@ class ConditionalParameterStringFieldDef(ConditionalStringFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -4338,7 +4338,7 @@ class ConditionalParameterStringFieldDef(ConditionalStringFieldDef):
         param: Optional[str | SchemaBase] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -4346,7 +4346,7 @@ class ConditionalParameterStringFieldDef(ConditionalStringFieldDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -4386,7 +4386,7 @@ class ConditionalPredicateStringFieldDef(ConditionalStringFieldDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -4463,7 +4463,7 @@ class ConditionalPredicateStringFieldDef(ConditionalStringFieldDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -4558,14 +4558,14 @@ class ConditionalPredicateStringFieldDef(ConditionalStringFieldDef):
         test: Optional[str | SchemaBase | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -4605,7 +4605,7 @@ class ConditionalParameterValueDefGradientstringnullExprRef(
     ----------
     param : str, :class:`ParameterName`
         Filter using a parameter name.
-    value : str, dict, None, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`
+    value : str, dict, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -4621,7 +4621,7 @@ class ConditionalParameterValueDefGradientstringnullExprRef(
     def __init__(
         self,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         **kwds,
     ):
@@ -4638,7 +4638,7 @@ class ConditionalPredicateValueDefGradientstringnullExprRef(
     ----------
     test : str, dict, :class:`Predicate`, :class:`FieldGTPredicate`, :class:`FieldLTPredicate`, :class:`FieldGTEPredicate`, :class:`FieldLTEPredicate`, :class:`LogicalOrPredicate`, :class:`ParameterPredicate`, :class:`FieldEqualPredicate`, :class:`FieldOneOfPredicate`, :class:`FieldRangePredicate`, :class:`FieldValidPredicate`, :class:`LogicalAndPredicate`, :class:`LogicalNotPredicate`, :class:`PredicateComposition`
         Predicate for triggering the condition
-    value : str, dict, None, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`
+    value : str, dict, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -4651,7 +4651,7 @@ class ConditionalPredicateValueDefGradientstringnullExprRef(
     def __init__(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ):
         super().__init__(test=test, value=value, **kwds)
@@ -4999,7 +4999,7 @@ class ConditionalParameterValueDefstringnullExprRef(
     ----------
     param : str, :class:`ParameterName`
         Filter using a parameter name.
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -5015,7 +5015,7 @@ class ConditionalParameterValueDefstringnullExprRef(
     def __init__(
         self,
         param: Optional[str | SchemaBase] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         empty: Optional[bool] = Undefined,
         **kwds,
     ):
@@ -5032,7 +5032,7 @@ class ConditionalPredicateValueDefstringnullExprRef(
     ----------
     test : str, dict, :class:`Predicate`, :class:`FieldGTPredicate`, :class:`FieldLTPredicate`, :class:`FieldGTEPredicate`, :class:`FieldLTEPredicate`, :class:`LogicalOrPredicate`, :class:`ParameterPredicate`, :class:`FieldEqualPredicate`, :class:`FieldOneOfPredicate`, :class:`FieldRangePredicate`, :class:`FieldValidPredicate`, :class:`LogicalAndPredicate`, :class:`LogicalNotPredicate`, :class:`PredicateComposition`
         Predicate for triggering the condition
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -5045,7 +5045,7 @@ class ConditionalPredicateValueDefstringnullExprRef(
     def __init__(
         self,
         test: Optional[str | SchemaBase | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ):
         super().__init__(test=test, value=value, **kwds)
@@ -5525,7 +5525,7 @@ class CsvDataFormat(DataFormat):
 
     Parameters
     ----------
-    parse : dict, None, :class:`Parse`
+    parse : dict, :class:`Parse`, None
         If set to ``null``, disable type inference based on the spec and only use type
         inference based on the data. Alternatively, a parsing directive object can be
         provided for explicit data types. Each property of the object corresponds to a field
@@ -5552,7 +5552,7 @@ class CsvDataFormat(DataFormat):
 
     def __init__(
         self,
-        parse: Optional[None | SchemaBase | Map] = Undefined,
+        parse: Optional[SchemaBase | Map | None] = Undefined,
         type: Optional[Literal["csv", "tsv"]] = Undefined,
         **kwds,
     ):
@@ -5664,7 +5664,7 @@ class DsvDataFormat(DataFormat):
         The delimiter between records. The delimiter must be a single character (i.e., a
         single 16-bit code unit); so, ASCII delimiters are fine, but emoji delimiters are
         not.
-    parse : dict, None, :class:`Parse`
+    parse : dict, :class:`Parse`, None
         If set to ``null``, disable type inference based on the spec and only use type
         inference based on the data. Alternatively, a parsing directive object can be
         provided for explicit data types. Each property of the object corresponds to a field
@@ -5692,7 +5692,7 @@ class DsvDataFormat(DataFormat):
     def __init__(
         self,
         delimiter: Optional[str] = Undefined,
-        parse: Optional[None | SchemaBase | Map] = Undefined,
+        parse: Optional[SchemaBase | Map | None] = Undefined,
         type: Optional[Literal["dsv"]] = Undefined,
         **kwds,
     ):
@@ -5853,7 +5853,7 @@ class Encoding(VegaLiteSchema):
     theta2 : dict, :class:`DatumDef`, :class:`Position2Def`, :class:`PositionValueDef`, :class:`SecondaryFieldDef`
         The end angle of arc marks in radians. A value of 0 indicates up or “north”,
         increasing values proceed clockwise.
-    tooltip : dict, None, :class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`, Sequence[dict, :class:`StringFieldDef`]
+    tooltip : dict, :class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`, Sequence[dict, :class:`StringFieldDef`], None
         The tooltip text to show upon mouse hover. Specifying ``tooltip`` encoding overrides
         `the tooltip property in the mark definition
         <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
@@ -5930,7 +5930,7 @@ class Encoding(VegaLiteSchema):
         theta: Optional[SchemaBase | Map] = Undefined,
         theta2: Optional[SchemaBase | Map] = Undefined,
         tooltip: Optional[
-            None | SchemaBase | Sequence[SchemaBase | Map] | Map
+            SchemaBase | Sequence[SchemaBase | Map] | Map | None
         ] = Undefined,
         url: Optional[SchemaBase | Map] = Undefined,
         x: Optional[SchemaBase | Map] = Undefined,
@@ -6375,7 +6375,7 @@ class FacetEncodingFieldDef(VegaLiteSchema):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -6447,9 +6447,9 @@ class FacetEncodingFieldDef(VegaLiteSchema):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    header : dict, None, :class:`Header`
+    header : dict, :class:`Header`, None
         An object defining properties of a facet's header.
-    sort : dict, None, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending']
+    sort : dict, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -6492,7 +6492,7 @@ class FacetEncodingFieldDef(VegaLiteSchema):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -6588,27 +6588,27 @@ class FacetEncodingFieldDef(VegaLiteSchema):
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         align: Optional[SchemaBase | Map | LayoutAlign_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool | SchemaBase | Map] = Undefined,
         columns: Optional[float] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        header: Optional[None | SchemaBase | Map] = Undefined,
+        header: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | SortOrder_T
+            | None
         ] = Undefined,
         spacing: Optional[float | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -6650,7 +6650,7 @@ class FacetFieldDef(VegaLiteSchema):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -6686,9 +6686,9 @@ class FacetFieldDef(VegaLiteSchema):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    header : dict, None, :class:`Header`
+    header : dict, :class:`Header`, None
         An object defining properties of a facet's header.
-    sort : dict, None, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending']
+    sort : dict, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -6723,7 +6723,7 @@ class FacetFieldDef(VegaLiteSchema):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -6817,23 +6817,23 @@ class FacetFieldDef(VegaLiteSchema):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        header: Optional[None | SchemaBase | Map] = Undefined,
+        header: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | SortOrder_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -7027,7 +7027,7 @@ class FacetedEncoding(VegaLiteSchema):
     theta2 : dict, :class:`DatumDef`, :class:`Position2Def`, :class:`PositionValueDef`, :class:`SecondaryFieldDef`
         The end angle of arc marks in radians. A value of 0 indicates up or “north”,
         increasing values proceed clockwise.
-    tooltip : dict, None, :class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`, Sequence[dict, :class:`StringFieldDef`]
+    tooltip : dict, :class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`, Sequence[dict, :class:`StringFieldDef`], None
         The tooltip text to show upon mouse hover. Specifying ``tooltip`` encoding overrides
         `the tooltip property in the mark definition
         <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
@@ -7107,7 +7107,7 @@ class FacetedEncoding(VegaLiteSchema):
         theta: Optional[SchemaBase | Map] = Undefined,
         theta2: Optional[SchemaBase | Map] = Undefined,
         tooltip: Optional[
-            None | SchemaBase | Sequence[SchemaBase | Map] | Map
+            SchemaBase | Sequence[SchemaBase | Map] | Map | None
         ] = Undefined,
         url: Optional[SchemaBase | Map] = Undefined,
         x: Optional[SchemaBase | Map] = Undefined,
@@ -7178,7 +7178,7 @@ class Feature(VegaLiteSchema):
     ----------
     geometry : dict, :class:`Point`, :class:`Polygon`, :class:`Geometry`, :class:`LineString`, :class:`MultiPoint`, :class:`MultiPolygon`, :class:`MultiLineString`, :class:`GeometryCollection`
         The feature's geometry
-    properties : dict, None, :class:`GeoJsonProperties`
+    properties : dict, :class:`GeoJsonProperties`, None
         Properties associated with this feature.
     type : Literal['Feature']
         Specifies the type of GeoJSON object.
@@ -7195,7 +7195,7 @@ class Feature(VegaLiteSchema):
     def __init__(
         self,
         geometry: Optional[SchemaBase | Map] = Undefined,
-        properties: Optional[None | SchemaBase | Map] = Undefined,
+        properties: Optional[SchemaBase | Map | None] = Undefined,
         type: Optional[Literal["Feature"]] = Undefined,
         bbox: Optional[SchemaBase | Sequence[float]] = Undefined,
         id: Optional[str | float] = Undefined,
@@ -7251,7 +7251,7 @@ class FeatureGeometryGeoJsonProperties(VegaLiteSchema):
     ----------
     geometry : dict, :class:`Point`, :class:`Polygon`, :class:`Geometry`, :class:`LineString`, :class:`MultiPoint`, :class:`MultiPolygon`, :class:`MultiLineString`, :class:`GeometryCollection`
         The feature's geometry
-    properties : dict, None, :class:`GeoJsonProperties`
+    properties : dict, :class:`GeoJsonProperties`, None
         Properties associated with this feature.
     type : Literal['Feature']
         Specifies the type of GeoJSON object.
@@ -7268,7 +7268,7 @@ class FeatureGeometryGeoJsonProperties(VegaLiteSchema):
     def __init__(
         self,
         geometry: Optional[SchemaBase | Map] = Undefined,
-        properties: Optional[None | SchemaBase | Map] = Undefined,
+        properties: Optional[SchemaBase | Map | None] = Undefined,
         type: Optional[Literal["Feature"]] = Undefined,
         bbox: Optional[SchemaBase | Sequence[float]] = Undefined,
         id: Optional[str | float] = Undefined,
@@ -7315,7 +7315,7 @@ class FieldDefWithoutScale(VegaLiteSchema):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -7360,7 +7360,7 @@ class FieldDefWithoutScale(VegaLiteSchema):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -7455,12 +7455,12 @@ class FieldDefWithoutScale(VegaLiteSchema):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -7504,7 +7504,7 @@ class FieldOrDatumDefWithConditionStringFieldDefstring(VegaLiteSchema):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -7588,7 +7588,7 @@ class FieldOrDatumDefWithConditionStringFieldDefstring(VegaLiteSchema):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -7684,7 +7684,7 @@ class FieldOrDatumDefWithConditionStringFieldDefstring(VegaLiteSchema):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -7692,7 +7692,7 @@ class FieldOrDatumDefWithConditionStringFieldDefstring(VegaLiteSchema):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -7860,7 +7860,7 @@ class GenericUnitSpecEncodingAnyMark(VegaLiteSchema):
         ``"tick"``, ``"line"``, ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and
         ``"text"``) or a `mark definition object
         <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -7887,7 +7887,7 @@ class GenericUnitSpecEncodingAnyMark(VegaLiteSchema):
     def __init__(
         self,
         mark: Optional[SchemaBase | Map | Mark_T | CompositeMark_T] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         encoding: Optional[SchemaBase | Map] = Undefined,
         name: Optional[str] = Undefined,
@@ -7922,7 +7922,7 @@ class GeoJsonFeature(Fit):
     ----------
     geometry : dict, :class:`Point`, :class:`Polygon`, :class:`Geometry`, :class:`LineString`, :class:`MultiPoint`, :class:`MultiPolygon`, :class:`MultiLineString`, :class:`GeometryCollection`
         The feature's geometry
-    properties : dict, None, :class:`GeoJsonProperties`
+    properties : dict, :class:`GeoJsonProperties`, None
         Properties associated with this feature.
     type : Literal['Feature']
         Specifies the type of GeoJSON object.
@@ -7939,7 +7939,7 @@ class GeoJsonFeature(Fit):
     def __init__(
         self,
         geometry: Optional[SchemaBase | Map] = Undefined,
-        properties: Optional[None | SchemaBase | Map] = Undefined,
+        properties: Optional[SchemaBase | Map | None] = Undefined,
         type: Optional[Literal["Feature"]] = Undefined,
         bbox: Optional[SchemaBase | Sequence[float]] = Undefined,
         id: Optional[str | float] = Undefined,
@@ -8243,7 +8243,7 @@ class Header(VegaLiteSchema):
         **Default value:** ``true``.
     orient : :class:`Orient`, Literal['left', 'right', 'top', 'bottom']
         Shortcut for setting both labelOrient and titleOrient.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -8338,7 +8338,7 @@ class Header(VegaLiteSchema):
         labelPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         labels: Optional[bool] = Undefined,
         orient: Optional[SchemaBase | Orient_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[SchemaBase | TitleAnchor_T] = Undefined,
         titleAngle: Optional[float] = Undefined,
@@ -8649,7 +8649,7 @@ class ImputeParams(VegaLiteSchema):
 
     Parameters
     ----------
-    frame : Sequence[None, float]
+    frame : Sequence[float, None]
         A frame specification as a two-element array used to control the window over which
         the specified method is applied. The array entries should either be a number
         indicating the offset from the current data object, or null to indicate unbounded
@@ -8683,7 +8683,7 @@ class ImputeParams(VegaLiteSchema):
 
     def __init__(
         self,
-        frame: Optional[Sequence[None | float]] = Undefined,
+        frame: Optional[Sequence[float | None]] = Undefined,
         keyvals: Optional[SchemaBase | Sequence[Any] | Map] = Undefined,
         method: Optional[SchemaBase | ImputeMethod_T] = Undefined,
         value: Optional[Any] = Undefined,
@@ -9056,7 +9056,7 @@ class JsonDataFormat(DataFormat):
 
     Parameters
     ----------
-    parse : dict, None, :class:`Parse`
+    parse : dict, :class:`Parse`, None
         If set to ``null``, disable type inference based on the spec and only use type
         inference based on the data. Alternatively, a parsing directive object can be
         provided for explicit data types. Each property of the object corresponds to a field
@@ -9088,7 +9088,7 @@ class JsonDataFormat(DataFormat):
 
     def __init__(
         self,
-        parse: Optional[None | SchemaBase | Map] = Undefined,
+        parse: Optional[SchemaBase | Map | None] = Undefined,
         property: Optional[str] = Undefined,
         type: Optional[Literal["json"]] = Undefined,
         **kwds,
@@ -9179,7 +9179,7 @@ class LatLongFieldDef(LatLongDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -9279,7 +9279,7 @@ class LatLongFieldDef(LatLongDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[Literal["quantitative"]] = Undefined,
         **kwds,
     ):
@@ -9373,7 +9373,7 @@ class Legend(VegaLiteSchema):
         * For left-/right-``orient``ed legends, ``"vertical"``
         * For top/bottom-left/right-``orient``ed legends, ``"horizontal"`` for gradient
           legends and ``"vertical"`` for symbol legends.
-    fillColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fillColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Background fill color for the full legend.
     format : str, dict, :class:`Dict`
         When used with the default ``"number"`` and ``"time"`` format type, the text
@@ -9414,7 +9414,7 @@ class Legend(VegaLiteSchema):
         **Default value:** ``200``.
     gradientOpacity : dict, float, :class:`ExprRef`
         Opacity of the color gradient.
-    gradientStrokeColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    gradientStrokeColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the gradient stroke, can be in hex color code or regular color name.
 
         **Default value:** ``"lightGray"``.
@@ -9440,7 +9440,7 @@ class Legend(VegaLiteSchema):
         ``"bottom"``, or ``"alphabetic"``.
 
         **Default value:** ``"middle"``.
-    labelColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    labelColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the legend label, can be in hex color code or regular color name.
     labelExpr : str
         `Vega expression <https://vega.github.io/vega/docs/expressions/>`__ for customizing
@@ -9505,13 +9505,13 @@ class Legend(VegaLiteSchema):
         The vertical padding in pixels between symbol legend entries.
 
         **Default value:** ``2``.
-    strokeColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    strokeColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Border stroke color for the full legend.
     symbolDash : dict, Sequence[float], :class:`ExprRef`
         An array of alternating [stroke, space] lengths for dashed symbol strokes.
     symbolDashOffset : dict, float, :class:`ExprRef`
         The pixel offset at which to start drawing with the symbol stroke dash array.
-    symbolFillColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    symbolFillColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the legend symbol,
     symbolLimit : dict, float, :class:`ExprRef`
         The maximum number of allowed entries for a symbol legend. Additional entries will
@@ -9526,7 +9526,7 @@ class Legend(VegaLiteSchema):
         The size of the legend symbol, in pixels.
 
         **Default value:** ``100``.
-    symbolStrokeColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    symbolStrokeColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Stroke color for legend symbols.
     symbolStrokeWidth : dict, float, :class:`ExprRef`
         The width of the symbol's stroke.
@@ -9552,7 +9552,7 @@ class Legend(VegaLiteSchema):
         necessary, to enforce the minimum step value.
 
         **Default value**: ``undefined``
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -9586,7 +9586,7 @@ class Legend(VegaLiteSchema):
         alone.
 
         **Default value:** ``"top"``.
-    titleColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    titleColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the legend title, can be in hex color code or regular color name.
     titleFont : str, dict, :class:`ExprRef`
         The font of the legend title.
@@ -9638,14 +9638,14 @@ class Legend(VegaLiteSchema):
         description: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -9655,7 +9655,7 @@ class Legend(VegaLiteSchema):
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelExpr: Optional[str] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -9679,21 +9679,21 @@ class Legend(VegaLiteSchema):
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         symbolDashOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -9701,14 +9701,14 @@ class Legend(VegaLiteSchema):
             float | Parameter | SchemaBase | Map | TimeInterval_T
         ] = Undefined,
         tickMinStep: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         titleAlign: Optional[Parameter | SchemaBase | Map | Align_T] = Undefined,
         titleAnchor: Optional[Parameter | SchemaBase | Map | TitleAnchor_T] = Undefined,
         titleBaseline: Optional[
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -9856,7 +9856,7 @@ class LegendConfig(VegaLiteSchema):
           legends and ``"vertical"`` for symbol legends.
     disable : bool
         Disable legend by default
-    fillColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fillColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Background fill color for the full legend.
     gradientDirection : dict, :class:`ExprRef`, :class:`Orientation`, Literal['horizontal', 'vertical']
         The default direction (``"horizontal"`` or ``"vertical"``) for gradient legends.
@@ -9885,7 +9885,7 @@ class LegendConfig(VegaLiteSchema):
         **Default value:** ``200``.
     gradientOpacity : dict, float, :class:`ExprRef`
         Opacity of the color gradient.
-    gradientStrokeColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    gradientStrokeColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the gradient stroke, can be in hex color code or regular color name.
 
         **Default value:** ``"lightGray"``.
@@ -9921,7 +9921,7 @@ class LegendConfig(VegaLiteSchema):
         ``"bottom"``, or ``"alphabetic"``.
 
         **Default value:** ``"middle"``.
-    labelColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    labelColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the legend label, can be in hex color code or regular color name.
     labelFont : str, dict, :class:`ExprRef`
         The font of the legend label.
@@ -9982,18 +9982,18 @@ class LegendConfig(VegaLiteSchema):
         The vertical padding in pixels between symbol legend entries.
 
         **Default value:** ``2``.
-    strokeColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    strokeColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Border stroke color for the full legend.
     strokeDash : dict, Sequence[float], :class:`ExprRef`
         Border stroke dash pattern for the full legend.
     strokeWidth : dict, float, :class:`ExprRef`
         Border stroke width for the full legend.
-    symbolBaseFillColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    symbolBaseFillColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color for legend symbols. Only applied if there is no ``"fill"`` scale
         color encoding for the legend.
 
         **Default value:** ``"transparent"``.
-    symbolBaseStrokeColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    symbolBaseStrokeColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color for legend symbols. Only applied if there is no ``"fill"``
         scale color encoding for the legend.
 
@@ -10006,7 +10006,7 @@ class LegendConfig(VegaLiteSchema):
         The default direction (``"horizontal"`` or ``"vertical"``) for symbol legends.
 
         **Default value:** ``"vertical"``.
-    symbolFillColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    symbolFillColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the legend symbol,
     symbolLimit : dict, float, :class:`ExprRef`
         The maximum number of allowed entries for a symbol legend. Additional entries will
@@ -10021,7 +10021,7 @@ class LegendConfig(VegaLiteSchema):
         The size of the legend symbol, in pixels.
 
         **Default value:** ``100``.
-    symbolStrokeColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    symbolStrokeColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Stroke color for legend symbols.
     symbolStrokeWidth : dict, float, :class:`ExprRef`
         The width of the symbol's stroke.
@@ -10056,7 +10056,7 @@ class LegendConfig(VegaLiteSchema):
         alone.
 
         **Default value:** ``"top"``.
-    titleColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    titleColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The color of the legend title, can be in hex color code or regular color name.
     titleFont : str, dict, :class:`ExprRef`
         The font of the legend title.
@@ -10105,7 +10105,7 @@ class LegendConfig(VegaLiteSchema):
         direction: Optional[SchemaBase | Orientation_T] = Undefined,
         disable: Optional[bool] = Undefined,
         fillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientDirection: Optional[
             Parameter | SchemaBase | Map | Orientation_T
@@ -10117,7 +10117,7 @@ class LegendConfig(VegaLiteSchema):
         gradientLength: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         gradientStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         gradientThickness: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -10129,7 +10129,7 @@ class LegendConfig(VegaLiteSchema):
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         labelColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         labelFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         labelFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -10153,17 +10153,17 @@ class LegendConfig(VegaLiteSchema):
         padding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         rowPadding: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         strokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
         ] = Undefined,
         strokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolBaseFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolBaseStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolDash: Optional[
             Parameter | SchemaBase | Sequence[float] | Map
@@ -10173,14 +10173,14 @@ class LegendConfig(VegaLiteSchema):
             Parameter | SchemaBase | Map | Orientation_T
         ] = Undefined,
         symbolFillColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolLimit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolStrokeColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         symbolStrokeWidth: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         symbolType: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -10194,7 +10194,7 @@ class LegendConfig(VegaLiteSchema):
             Parameter | SchemaBase | Map | TextBaseline_T
         ] = Undefined,
         titleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         titleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         titleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -10486,7 +10486,7 @@ class LineConfig(AnyMarkConfig):
     endAngle : dict, float, :class:`ExprRef`
         The end angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
@@ -10547,7 +10547,7 @@ class LineConfig(AnyMarkConfig):
         * ``"bundle"``: equivalent to basis, except the tension parameter is used to
           straighten the spline.
         * ``"monotone"``: cubic interpolation that preserves monotonicity in y.
-    invalid : None, :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show']
+    invalid : :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show'], None
         Invalid data mode, which defines how the marks and corresponding scales should
         represent invalid values (``null`` and ``NaN`` in continuous scales *without*
         defined output for invalid values).
@@ -10676,7 +10676,7 @@ class LineConfig(AnyMarkConfig):
     startAngle : dict, float, :class:`ExprRef`
         The start angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
@@ -10728,7 +10728,7 @@ class LineConfig(AnyMarkConfig):
         Default relative band size for a time unit. If set to ``1``, the bandwidth of the
         marks will be equal to the time unit band step. If set to ``0.5``, bandwidth of the
         marks will be half of the time unit band step.
-    tooltip : str, bool, dict, None, float, :class:`ExprRef`, :class:`TooltipContent`
+    tooltip : str, bool, dict, float, :class:`ExprRef`, :class:`TooltipContent`, None
         The tooltip text string to show upon mouse hover or an object defining which fields
         should the tooltip be derived from.
 
@@ -10802,7 +10802,7 @@ class LineConfig(AnyMarkConfig):
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         endAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -10814,7 +10814,7 @@ class LineConfig(AnyMarkConfig):
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         lineHeight: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -10831,7 +10831,7 @@ class LineConfig(AnyMarkConfig):
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         startAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -10850,7 +10850,7 @@ class LineConfig(AnyMarkConfig):
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -11217,7 +11217,7 @@ class MarkConfig(AnyMarkConfig):
     endAngle : dict, float, :class:`ExprRef`
         The end angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
@@ -11278,7 +11278,7 @@ class MarkConfig(AnyMarkConfig):
         * ``"bundle"``: equivalent to basis, except the tension parameter is used to
           straighten the spline.
         * ``"monotone"``: cubic interpolation that preserves monotonicity in y.
-    invalid : None, :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show']
+    invalid : :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show'], None
         Invalid data mode, which defines how the marks and corresponding scales should
         represent invalid values (``null`` and ``NaN`` in continuous scales *without*
         defined output for invalid values).
@@ -11393,7 +11393,7 @@ class MarkConfig(AnyMarkConfig):
     startAngle : dict, float, :class:`ExprRef`
         The start angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
@@ -11445,7 +11445,7 @@ class MarkConfig(AnyMarkConfig):
         Default relative band size for a time unit. If set to ``1``, the bandwidth of the
         marks will be equal to the time unit band step. If set to ``0.5``, bandwidth of the
         marks will be half of the time unit band step.
-    tooltip : str, bool, dict, None, float, :class:`ExprRef`, :class:`TooltipContent`
+    tooltip : str, bool, dict, float, :class:`ExprRef`, :class:`TooltipContent`, None
         The tooltip text string to show upon mouse hover or an object defining which fields
         should the tooltip be derived from.
 
@@ -11519,7 +11519,7 @@ class MarkConfig(AnyMarkConfig):
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         endAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -11531,7 +11531,7 @@ class MarkConfig(AnyMarkConfig):
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         lineHeight: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -11547,7 +11547,7 @@ class MarkConfig(AnyMarkConfig):
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         startAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -11566,7 +11566,7 @@ class MarkConfig(AnyMarkConfig):
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -11790,7 +11790,7 @@ class MarkDef(AnyMark):
         The ellipsis string for text truncated in response to the limit parameter.
 
         **Default value:** ``"…"``
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
@@ -11856,7 +11856,7 @@ class MarkDef(AnyMark):
         * ``"bundle"``: equivalent to basis, except the tension parameter is used to
           straighten the spline.
         * ``"monotone"``: cubic interpolation that preserves monotonicity in y.
-    invalid : None, :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show']
+    invalid : :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show'], None
         Invalid data mode, which defines how the marks and corresponding scales should
         represent invalid values (``null`` and ``NaN`` in continuous scales *without*
         defined output for invalid values).
@@ -11998,7 +11998,7 @@ class MarkDef(AnyMark):
         resized. If false, individual pixels should be scaled directly rather than
         interpolated with smoothing. For SVG rendering, this option may not work in some
         browsers due to lack of standardization.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
@@ -12072,7 +12072,7 @@ class MarkDef(AnyMark):
         Default relative band size for a time unit. If set to ``1``, the bandwidth of the
         marks will be equal to the time unit band step. If set to ``0.5``, bandwidth of the
         marks will be half of the time unit band step.
-    tooltip : str, bool, dict, None, float, :class:`ExprRef`, :class:`TooltipContent`
+    tooltip : str, bool, dict, float, :class:`ExprRef`, :class:`TooltipContent`, None
         The tooltip text string to show upon mouse hover or an object defining which fields
         should the tooltip be derived from.
 
@@ -12165,7 +12165,7 @@ class MarkDef(AnyMark):
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -12177,7 +12177,7 @@ class MarkDef(AnyMark):
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -12197,7 +12197,7 @@ class MarkDef(AnyMark):
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -12220,7 +12220,7 @@ class MarkDef(AnyMark):
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -12371,9 +12371,9 @@ class FieldOrDatumDefWithConditionDatumDefGradientstringnull(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -12470,9 +12470,9 @@ class FieldOrDatumDefWithConditionDatumDefGradientstringnull(
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -12508,7 +12508,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -12551,7 +12551,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -12560,7 +12560,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -12573,7 +12573,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -12620,7 +12620,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -12717,25 +12717,25 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -13023,9 +13023,9 @@ class FieldOrDatumDefWithConditionDatumDefnumberArray(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -13120,9 +13120,9 @@ class FieldOrDatumDefWithConditionDatumDefnumberArray(
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -13158,7 +13158,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -13201,7 +13201,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -13210,7 +13210,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -13223,7 +13223,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -13270,7 +13270,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -13367,25 +13367,25 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -13432,9 +13432,9 @@ class FieldOrDatumDefWithConditionDatumDefnumber(MarkPropDefnumber, NumericMarkP
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -13529,9 +13529,9 @@ class FieldOrDatumDefWithConditionDatumDefnumber(MarkPropDefnumber, NumericMarkP
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -13567,7 +13567,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -13610,7 +13610,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -13619,7 +13619,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -13632,7 +13632,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -13679,7 +13679,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -13776,25 +13776,25 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -13844,7 +13844,7 @@ class OrderFieldDef(VegaLiteSchema):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -13891,7 +13891,7 @@ class OrderFieldDef(VegaLiteSchema):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -13986,13 +13986,13 @@ class OrderFieldDef(VegaLiteSchema):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         sort: Optional[SchemaBase | SortOrder_T] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -14183,7 +14183,7 @@ class OverlayMarkDef(VegaLiteSchema):
     endAngle : dict, float, :class:`ExprRef`
         The end angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
@@ -14244,7 +14244,7 @@ class OverlayMarkDef(VegaLiteSchema):
         * ``"bundle"``: equivalent to basis, except the tension parameter is used to
           straighten the spline.
         * ``"monotone"``: cubic interpolation that preserves monotonicity in y.
-    invalid : None, :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show']
+    invalid : :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show'], None
         Invalid data mode, which defines how the marks and corresponding scales should
         represent invalid values (``null`` and ``NaN`` in continuous scales *without*
         defined output for invalid values).
@@ -14363,7 +14363,7 @@ class OverlayMarkDef(VegaLiteSchema):
     startAngle : dict, float, :class:`ExprRef`
         The start angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
@@ -14433,7 +14433,7 @@ class OverlayMarkDef(VegaLiteSchema):
         Default relative band size for a time unit. If set to ``1``, the bandwidth of the
         marks will be equal to the time unit band step. If set to ``0.5``, bandwidth of the
         marks will be half of the time unit band step.
-    tooltip : str, bool, dict, None, float, :class:`ExprRef`, :class:`TooltipContent`
+    tooltip : str, bool, dict, float, :class:`ExprRef`, :class:`TooltipContent`, None
         The tooltip text string to show upon mouse hover or an object defining which fields
         should the tooltip be derived from.
 
@@ -14516,7 +14516,7 @@ class OverlayMarkDef(VegaLiteSchema):
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         endAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -14528,7 +14528,7 @@ class OverlayMarkDef(VegaLiteSchema):
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         lineHeight: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -14546,7 +14546,7 @@ class OverlayMarkDef(VegaLiteSchema):
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         startAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -14568,7 +14568,7 @@ class OverlayMarkDef(VegaLiteSchema):
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -15068,9 +15068,9 @@ class DatumDef(LatLongDef, Position2Def):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -15164,9 +15164,9 @@ class DatumDef(LatLongDef, Position2Def):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -15185,9 +15185,9 @@ class PositionDatumDefBase(PolarDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -15200,7 +15200,7 @@ class PositionDatumDefBase(PolarDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -15230,7 +15230,7 @@ class PositionDatumDefBase(PolarDef):
 
         **See also:** `stack <https://vega.github.io/vega-lite/docs/stack.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -15324,11 +15324,11 @@ class PositionDatumDefBase(PolarDef):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -15358,7 +15358,7 @@ class PositionDatumDef(PositionDef):
 
     Parameters
     ----------
-    axis : dict, None, :class:`Axis`
+    axis : dict, :class:`Axis`, None
         An object defining properties of axis's gridlines, ticks and labels. If ``null``,
         the axis for the encoding channel will be removed.
 
@@ -15371,9 +15371,9 @@ class PositionDatumDef(PositionDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    impute : dict, None, :class:`ImputeParams`
+    impute : dict, :class:`ImputeParams`, None
         An object defining the properties of the Impute Operation to be applied. The field
         value of the other positional channel is taken as ``key`` of the ``Impute``
         Operation. The field of the ``color`` channel if specified is used as ``groupby`` of
@@ -15381,7 +15381,7 @@ class PositionDatumDef(PositionDef):
 
         **See also:** `impute <https://vega.github.io/vega-lite/docs/impute.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -15394,7 +15394,7 @@ class PositionDatumDef(PositionDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -15424,7 +15424,7 @@ class PositionDatumDef(PositionDef):
 
         **See also:** `stack <https://vega.github.io/vega-lite/docs/stack.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -15516,15 +15516,15 @@ class PositionDatumDef(PositionDef):
 
     def __init__(
         self,
-        axis: Optional[None | SchemaBase | Map] = Undefined,
+        axis: Optional[SchemaBase | Map | None] = Undefined,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        impute: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        impute: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -15557,7 +15557,7 @@ class PositionFieldDef(PositionDef):
 
         **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
         documentation.
-    axis : dict, None, :class:`Axis`
+    axis : dict, :class:`Axis`, None
         An object defining properties of axis's gridlines, ticks and labels. If ``null``,
         the axis for the encoding channel will be removed.
 
@@ -15570,7 +15570,7 @@ class PositionFieldDef(PositionDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -15606,7 +15606,7 @@ class PositionFieldDef(PositionDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    impute : dict, None, :class:`ImputeParams`
+    impute : dict, :class:`ImputeParams`, None
         An object defining the properties of the Impute Operation to be applied. The field
         value of the other positional channel is taken as ``key`` of the ``Impute``
         Operation. The field of the ``color`` channel if specified is used as ``groupby`` of
@@ -15614,7 +15614,7 @@ class PositionFieldDef(PositionDef):
 
         **See also:** `impute <https://vega.github.io/vega-lite/docs/impute.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -15627,7 +15627,7 @@ class PositionFieldDef(PositionDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -15665,7 +15665,7 @@ class PositionFieldDef(PositionDef):
 
         **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -15704,7 +15704,7 @@ class PositionFieldDef(PositionDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -15798,27 +15798,27 @@ class PositionFieldDef(PositionDef):
         self,
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
-        axis: Optional[None | SchemaBase | Map] = Undefined,
+        axis: Optional[SchemaBase | Map | None] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        impute: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        impute: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -15860,7 +15860,7 @@ class PositionFieldDefBase(PolarDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -15896,7 +15896,7 @@ class PositionFieldDefBase(PolarDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -15909,7 +15909,7 @@ class PositionFieldDefBase(PolarDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -15947,7 +15947,7 @@ class PositionFieldDefBase(PolarDef):
 
         **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
         documentation.
-    stack : bool, None, :class:`StackOffset`, Literal['zero', 'center', 'normalize']
+    stack : bool, :class:`StackOffset`, Literal['zero', 'center', 'normalize'], None
         Type of stacking offset if the field should be stacked. ``stack`` is only applicable
         for ``x``, ``y``, ``theta``, and ``radius`` channels with continuous domains. For
         example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
@@ -15986,7 +15986,7 @@ class PositionFieldDefBase(PolarDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -16081,24 +16081,24 @@ class PositionFieldDefBase(PolarDef):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
-        stack: Optional[bool | None | SchemaBase | StackOffset_T] = Undefined,
+        stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -16393,7 +16393,7 @@ class FieldRangePredicate(Predicate):
     ----------
     field : str, :class:`FieldName`
         Field to be tested.
-    range : dict, :class:`ExprRef`, Sequence[dict, None, float, :class:`ExprRef`, :class:`DateTime`]
+    range : dict, :class:`ExprRef`, Sequence[dict, float, :class:`ExprRef`, :class:`DateTime`, None]
         An array of inclusive minimum and maximum values for a field value of a data item to
         be included in the filtered data.
     timeUnit : dict, :class:`TimeUnit`, :class:`MultiTimeUnit`, :class:`BinnedTimeUnit`, :class:`SingleTimeUnit`, :class:`TimeUnitParams`, :class:`UtcMultiTimeUnit`, :class:`UtcSingleTimeUnit`, :class:`LocalMultiTimeUnit`, :class:`LocalSingleTimeUnit`, Literal['binnedutcyear', 'binnedutcyearquarter', 'binnedutcyearquartermonth', 'binnedutcyearmonth', 'binnedutcyearmonthdate', 'binnedutcyearmonthdatehours', 'binnedutcyearmonthdatehoursminutes', 'binnedutcyearmonthdatehoursminutesseconds', 'binnedutcyearweek', 'binnedutcyearweekday', 'binnedutcyearweekdayhours', 'binnedutcyearweekdayhoursminutes', 'binnedutcyearweekdayhoursminutesseconds', 'binnedutcyeardayofyear', 'binnedyear', 'binnedyearquarter', 'binnedyearquartermonth', 'binnedyearmonth', 'binnedyearmonthdate', 'binnedyearmonthdatehours', 'binnedyearmonthdatehoursminutes', 'binnedyearmonthdatehoursminutesseconds', 'binnedyearweek', 'binnedyearweekday', 'binnedyearweekdayhours', 'binnedyearweekdayhoursminutes', 'binnedyearweekdayhoursminutesseconds', 'binnedyeardayofyear', 'utcyear', 'utcquarter', 'utcmonth', 'utcweek', 'utcday', 'utcdayofyear', 'utcdate', 'utchours', 'utcminutes', 'utcseconds', 'utcmilliseconds', 'year', 'quarter', 'month', 'week', 'day', 'dayofyear', 'date', 'hours', 'minutes', 'seconds', 'milliseconds', 'utcyearquarter', 'utcyearquartermonth', 'utcyearmonth', 'utcyearmonthdate', 'utcyearmonthdatehours', 'utcyearmonthdatehoursminutes', 'utcyearmonthdatehoursminutesseconds', 'utcyearweek', 'utcyearweekday', 'utcyearweekdayhours', 'utcyearweekdayhoursminutes', 'utcyearweekdayhoursminutesseconds', 'utcyeardayofyear', 'utcquartermonth', 'utcmonthdate', 'utcmonthdatehours', 'utcmonthdatehoursminutes', 'utcmonthdatehoursminutesseconds', 'utcweekday', 'utcweekdayhours', 'utcweekdayhoursminutes', 'utcweekdayhoursminutesseconds', 'utcdayhours', 'utcdayhoursminutes', 'utcdayhoursminutesseconds', 'utchoursminutes', 'utchoursminutesseconds', 'utcminutesseconds', 'utcsecondsmilliseconds', 'yearquarter', 'yearquartermonth', 'yearmonth', 'yearmonthdate', 'yearmonthdatehours', 'yearmonthdatehoursminutes', 'yearmonthdatehoursminutesseconds', 'yearweek', 'yearweekday', 'yearweekdayhours', 'yearweekdayhoursminutes', 'yearweekdayhoursminutesseconds', 'yeardayofyear', 'quartermonth', 'monthdate', 'monthdatehours', 'monthdatehoursminutes', 'monthdatehoursminutesseconds', 'weekday', 'weekdayhours', 'weekdayhoursminutes', 'weekdayhoursminutesseconds', 'dayhours', 'dayhoursminutes', 'dayhoursminutesseconds', 'hoursminutes', 'hoursminutesseconds', 'minutesseconds', 'secondsmilliseconds']
@@ -16408,7 +16408,7 @@ class FieldRangePredicate(Predicate):
         range: Optional[
             Parameter
             | SchemaBase
-            | Sequence[None | float | Parameter | SchemaBase | Map]
+            | Sequence[float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         timeUnit: Optional[
@@ -16915,19 +16915,19 @@ class RangeConfig(VegaLiteSchema):
 
     Parameters
     ----------
-    category : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, None, float, Sequence[float], :class:`RangeRawArray`], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
+    category : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, float, Sequence[float], :class:`RangeRawArray`, None], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
         Default `color scheme <https://vega.github.io/vega/docs/schemes/>`__ for categorical
         data.
-    diverging : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, None, float, Sequence[float], :class:`RangeRawArray`], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
+    diverging : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, float, Sequence[float], :class:`RangeRawArray`, None], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
         Default `color scheme <https://vega.github.io/vega/docs/schemes/>`__ for diverging
         quantitative ramps.
-    heatmap : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, None, float, Sequence[float], :class:`RangeRawArray`], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
+    heatmap : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, float, Sequence[float], :class:`RangeRawArray`, None], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
         Default `color scheme <https://vega.github.io/vega/docs/schemes/>`__ for
         quantitative heatmaps.
-    ordinal : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, None, float, Sequence[float], :class:`RangeRawArray`], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
+    ordinal : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, float, Sequence[float], :class:`RangeRawArray`, None], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
         Default `color scheme <https://vega.github.io/vega/docs/schemes/>`__ for
         rank-ordered data.
-    ramp : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, None, float, Sequence[float], :class:`RangeRawArray`], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
+    ramp : dict, :class:`RangeRaw`, :class:`RangeEnum`, :class:`RangeScheme`, Sequence[str, bool, float, Sequence[float], :class:`RangeRawArray`, None], Literal['width', 'height', 'symbol', 'category', 'ordinal', 'ramp', 'diverging', 'heatmap'], Sequence[str, :class:`Color`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']]
         Default `color scheme <https://vega.github.io/vega/docs/schemes/>`__ for sequential
         quantitative ramps.
     symbol : Sequence[str, :class:`SymbolShape`]
@@ -16942,35 +16942,35 @@ class RangeConfig(VegaLiteSchema):
         category: Optional[
             SchemaBase
             | Sequence[str | SchemaBase | ColorName_T]
-            | Sequence[str | bool | None | float | SchemaBase | Sequence[float]]
+            | Sequence[str | bool | float | SchemaBase | Sequence[float] | None]
             | Map
             | RangeEnum_T
         ] = Undefined,
         diverging: Optional[
             SchemaBase
             | Sequence[str | SchemaBase | ColorName_T]
-            | Sequence[str | bool | None | float | SchemaBase | Sequence[float]]
+            | Sequence[str | bool | float | SchemaBase | Sequence[float] | None]
             | Map
             | RangeEnum_T
         ] = Undefined,
         heatmap: Optional[
             SchemaBase
             | Sequence[str | SchemaBase | ColorName_T]
-            | Sequence[str | bool | None | float | SchemaBase | Sequence[float]]
+            | Sequence[str | bool | float | SchemaBase | Sequence[float] | None]
             | Map
             | RangeEnum_T
         ] = Undefined,
         ordinal: Optional[
             SchemaBase
             | Sequence[str | SchemaBase | ColorName_T]
-            | Sequence[str | bool | None | float | SchemaBase | Sequence[float]]
+            | Sequence[str | bool | float | SchemaBase | Sequence[float] | None]
             | Map
             | RangeEnum_T
         ] = Undefined,
         ramp: Optional[
             SchemaBase
             | Sequence[str | SchemaBase | ColorName_T]
-            | Sequence[str | bool | None | float | SchemaBase | Sequence[float]]
+            | Sequence[str | bool | float | SchemaBase | Sequence[float] | None]
             | Map
             | RangeEnum_T
         ] = Undefined,
@@ -17143,7 +17143,7 @@ class RectConfig(AnyMarkConfig):
     endAngle : dict, float, :class:`ExprRef`
         The end angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
@@ -17204,7 +17204,7 @@ class RectConfig(AnyMarkConfig):
         * ``"bundle"``: equivalent to basis, except the tension parameter is used to
           straighten the spline.
         * ``"monotone"``: cubic interpolation that preserves monotonicity in y.
-    invalid : None, :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show']
+    invalid : :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show'], None
         Invalid data mode, which defines how the marks and corresponding scales should
         represent invalid values (``null`` and ``NaN`` in continuous scales *without*
         defined output for invalid values).
@@ -17321,7 +17321,7 @@ class RectConfig(AnyMarkConfig):
     startAngle : dict, float, :class:`ExprRef`
         The start angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
@@ -17373,7 +17373,7 @@ class RectConfig(AnyMarkConfig):
         Default relative band size for a time unit. If set to ``1``, the bandwidth of the
         marks will be equal to the time unit band step. If set to ``0.5``, bandwidth of the
         marks will be half of the time unit band step.
-    tooltip : str, bool, dict, None, float, :class:`ExprRef`, :class:`TooltipContent`
+    tooltip : str, bool, dict, float, :class:`ExprRef`, :class:`TooltipContent`, None
         The tooltip text string to show upon mouse hover or an object defining which fields
         should the tooltip be derived from.
 
@@ -17450,7 +17450,7 @@ class RectConfig(AnyMarkConfig):
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         endAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -17462,7 +17462,7 @@ class RectConfig(AnyMarkConfig):
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         lineHeight: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -17479,7 +17479,7 @@ class RectConfig(AnyMarkConfig):
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         startAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -17498,7 +17498,7 @@ class RectConfig(AnyMarkConfig):
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -17797,7 +17797,7 @@ class RowColumnEncodingFieldDef(VegaLiteSchema):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -17838,9 +17838,9 @@ class RowColumnEncodingFieldDef(VegaLiteSchema):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    header : dict, None, :class:`Header`
+    header : dict, :class:`Header`, None
         An object defining properties of a facet's header.
-    sort : dict, None, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending']
+    sort : dict, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`EncodingSortField`, Sequence[dict, :class:`DateTime`], Literal['ascending', 'descending'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -17881,7 +17881,7 @@ class RowColumnEncodingFieldDef(VegaLiteSchema):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -17977,25 +17977,25 @@ class RowColumnEncodingFieldDef(VegaLiteSchema):
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         align: Optional[SchemaBase | LayoutAlign_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         center: Optional[bool] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        header: Optional[None | SchemaBase | Map] = Undefined,
+        header: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | SortOrder_T
+            | None
         ] = Undefined,
         spacing: Optional[float] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -18059,7 +18059,7 @@ class Scale(VegaLiteSchema):
         ``symlog`` scales.
 
         **Default value:** ``1``
-    domain : dict, :class:`ExprRef`, Literal['unaggregated'], :class:`DomainUnionWith`, :class:`ParameterExtent`, Sequence[str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`]
+    domain : dict, :class:`ExprRef`, Literal['unaggregated'], :class:`DomainUnionWith`, :class:`ParameterExtent`, Sequence[str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, None]
         Customized domain values in the form of constant values or dynamic values driven by
         a parameter.
 
@@ -18290,7 +18290,7 @@ class Scale(VegaLiteSchema):
             Parameter
             | SchemaBase
             | Literal["unaggregated"]
-            | Sequence[str | bool | None | float | Parameter | SchemaBase | Map]
+            | Sequence[str | bool | float | Parameter | SchemaBase | Map | None]
             | Map
         ] = Undefined,
         domainMax: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -18633,9 +18633,9 @@ class ScaleDatumDef(OffsetDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -18648,7 +18648,7 @@ class ScaleDatumDef(OffsetDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -18742,10 +18742,10 @@ class ScaleDatumDef(OffsetDef):
         self,
         bandPosition: Optional[float] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -18779,7 +18779,7 @@ class ScaleFieldDef(OffsetDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -18815,7 +18815,7 @@ class ScaleFieldDef(OffsetDef):
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -18828,7 +18828,7 @@ class ScaleFieldDef(OffsetDef):
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -18875,7 +18875,7 @@ class ScaleFieldDef(OffsetDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -18970,23 +18970,23 @@ class ScaleFieldDef(OffsetDef):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -19201,7 +19201,7 @@ class ScaleInvalidDataShowAsValuefill(ScaleInvalidDataShowAsfill):
 
     Parameters
     ----------
-    value : str, dict, None, :class:`Color`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    value : str, dict, :class:`Color`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
@@ -19212,7 +19212,7 @@ class ScaleInvalidDataShowAsValuefill(ScaleInvalidDataShowAsfill):
 
     def __init__(
         self,
-        value: Optional[str | None | SchemaBase | Map | ColorName_T] = Undefined,
+        value: Optional[str | SchemaBase | Map | ColorName_T | None] = Undefined,
         **kwds,
     ):
         super().__init__(value=value, **kwds)
@@ -19393,7 +19393,7 @@ class ScaleInvalidDataShowAsValuestroke(ScaleInvalidDataShowAsstroke):
 
     Parameters
     ----------
-    value : str, dict, None, :class:`Color`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    value : str, dict, :class:`Color`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
@@ -19404,7 +19404,7 @@ class ScaleInvalidDataShowAsValuestroke(ScaleInvalidDataShowAsstroke):
 
     def __init__(
         self,
-        value: Optional[str | None | SchemaBase | Map | ColorName_T] = Undefined,
+        value: Optional[str | SchemaBase | Map | ColorName_T | None] = Undefined,
         **kwds,
     ):
         super().__init__(value=value, **kwds)
@@ -19821,7 +19821,7 @@ class SecondaryFieldDef(Position2Def):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -19855,7 +19855,7 @@ class SecondaryFieldDef(Position2Def):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         **kwds,
     ):
         super().__init__(
@@ -20055,7 +20055,7 @@ class SelectionParameter(VegaLiteSchema):
 
         **See also:** `bind <https://vega.github.io/vega-lite/docs/bind.html>`__
         documentation.
-    value : str, bool, dict, None, float, :class:`DateTime`, :class:`SelectionInit`, :class:`PrimitiveValue`, :class:`SelectionInitIntervalMapping`, Sequence[dict, :class:`SelectionInitMapping`]
+    value : str, bool, dict, float, :class:`DateTime`, :class:`SelectionInit`, :class:`PrimitiveValue`, :class:`SelectionInitIntervalMapping`, Sequence[dict, :class:`SelectionInitMapping`], None
         Initialize the selection with a mapping between `projected channels or field names
         <https://vega.github.io/vega-lite/docs/selection.html#project>`__ and initial
         values.
@@ -20072,7 +20072,7 @@ class SelectionParameter(VegaLiteSchema):
         select: Optional[SchemaBase | Map | SelectionType_T] = Undefined,
         bind: Optional[SchemaBase | Literal["legend", "scales"] | Map] = Undefined,
         value: Optional[
-            str | bool | None | float | SchemaBase | Sequence[SchemaBase | Map] | Map
+            str | bool | float | SchemaBase | Sequence[SchemaBase | Map] | Map | None
         ] = Undefined,
         **kwds,
     ):
@@ -20198,9 +20198,9 @@ class FieldOrDatumDefWithConditionDatumDefstringnull(
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -20297,9 +20297,9 @@ class FieldOrDatumDefWithConditionDatumDefstringnull(
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -20335,7 +20335,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, :class:`BinParams`
+    bin : bool, dict, :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -20378,7 +20378,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(
         about escaping in the `field documentation
         <https://vega.github.io/vega-lite/docs/field.html>`__. 2) ``field`` is not required
         if ``aggregate`` is ``count``.
-    legend : dict, None, :class:`Legend`
+    legend : dict, :class:`Legend`, None
         An object defining properties of the legend. If ``null``, the legend for the
         encoding channel will be removed.
 
@@ -20387,7 +20387,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(
 
         **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
         documentation.
-    scale : dict, None, :class:`Scale`
+    scale : dict, :class:`Scale`, None
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
         (pixels, colors, sizes) of the encoding channels.
@@ -20400,7 +20400,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(
 
         **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
         documentation.
-    sort : dict, None, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text']
+    sort : dict, :class:`Sort`, Sequence[str], Sequence[bool], Sequence[float], :class:`SortArray`, :class:`SortOrder`, :class:`AllSortString`, :class:`SortByChannel`, :class:`SortByEncoding`, :class:`EncodingSortField`, :class:`SortByChannelDesc`, Sequence[dict, :class:`DateTime`], Literal['-x', '-y', '-color', '-fill', '-stroke', '-strokeWidth', '-size', '-shape', '-fillOpacity', '-strokeOpacity', '-opacity', '-text', 'ascending', 'descending', 'x', 'y', 'color', 'fill', 'stroke', 'strokeWidth', 'size', 'shape', 'fillOpacity', 'strokeOpacity', 'opacity', 'text'], None
         Sort order for the encoded field.
 
         For continuous fields (quantitative or temporal), ``sort`` can be either
@@ -20447,7 +20447,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -20544,25 +20544,25 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
-        legend: Optional[None | SchemaBase | Map] = Undefined,
-        scale: Optional[None | SchemaBase | Map] = Undefined,
+        legend: Optional[SchemaBase | Map | None] = Undefined,
+        scale: Optional[SchemaBase | Map | None] = Undefined,
         sort: Optional[
-            None
-            | SchemaBase
+            SchemaBase
             | Sequence[str]
             | Sequence[bool]
             | Sequence[float]
             | Sequence[SchemaBase | Map]
             | Map
             | AllSortString_T
+            | None
         ] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | TypeForShape_T] = Undefined,
         **kwds,
     ):
@@ -20652,7 +20652,7 @@ class SharedEncoding(VegaLiteSchema):
 
     theta2 : dict
 
-    tooltip : dict, None, :class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`, Sequence[dict, :class:`StringFieldDef`]
+    tooltip : dict, :class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`, Sequence[dict, :class:`StringFieldDef`], None
         The tooltip text to show upon mouse hover. Specifying ``tooltip`` encoding overrides
         `the tooltip property in the mark definition
         <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
@@ -20713,7 +20713,7 @@ class SharedEncoding(VegaLiteSchema):
         theta: Optional[Map] = Undefined,
         theta2: Optional[Map] = Undefined,
         tooltip: Optional[
-            None | SchemaBase | Sequence[SchemaBase | Map] | Map
+            SchemaBase | Sequence[SchemaBase | Map] | Map | None
         ] = Undefined,
         url: Optional[Map] = Undefined,
         x: Optional[Map] = Undefined,
@@ -20822,7 +20822,7 @@ class EncodingSortField(Sort):
         <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__.
 
         **Default value:** ``"sum"`` for stacked plots. Otherwise, ``"min"``.
-    order : None, :class:`SortOrder`, Literal['ascending', 'descending']
+    order : :class:`SortOrder`, Literal['ascending', 'descending'], None
         The sort order. One of ``"ascending"`` (default), ``"descending"``, or ``null`` (no
         not sort).
     """
@@ -20833,7 +20833,7 @@ class EncodingSortField(Sort):
         self,
         field: Optional[str | SchemaBase | Map] = Undefined,
         op: Optional[SchemaBase | NonArgAggregateOp_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ):
         super().__init__(field=field, op=op, order=order, **kwds)
@@ -20876,7 +20876,7 @@ class SortByEncoding(Sort):
         The `encoding channel
         <https://vega.github.io/vega-lite/docs/encoding.html#channels>`__ to sort by (e.g.,
         ``"x"``, ``"y"``)
-    order : None, :class:`SortOrder`, Literal['ascending', 'descending']
+    order : :class:`SortOrder`, Literal['ascending', 'descending'], None
         The sort order. One of ``"ascending"`` (default), ``"descending"``, or ``null`` (no
         not sort).
     """
@@ -20886,7 +20886,7 @@ class SortByEncoding(Sort):
     def __init__(
         self,
         encoding: Optional[SchemaBase | SortByChannel_T] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ):
         super().__init__(encoding=encoding, order=order, **kwds)
@@ -20902,7 +20902,7 @@ class SortField(VegaLiteSchema):
     ----------
     field : str, :class:`FieldName`
         The name of the field to sort.
-    order : None, :class:`SortOrder`, Literal['ascending', 'descending']
+    order : :class:`SortOrder`, Literal['ascending', 'descending'], None
         Whether to sort the field in ascending or descending order. One of ``"ascending"``
         (default), ``"descending"``, or ``null`` (no not sort).
     """
@@ -20912,7 +20912,7 @@ class SortField(VegaLiteSchema):
     def __init__(
         self,
         field: Optional[str | SchemaBase] = Undefined,
-        order: Optional[None | SchemaBase | SortOrder_T] = Undefined,
+        order: Optional[SchemaBase | SortOrder_T | None] = Undefined,
         **kwds,
     ):
         super().__init__(field=field, order=order, **kwds)
@@ -21002,7 +21002,7 @@ class ConcatSpecGenericSpec(Spec, NonNormalizedSpec):
 
         2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat``)
         and to using the ``row`` channel (for ``facet`` and ``repeat``).
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -21034,7 +21034,7 @@ class ConcatSpecGenericSpec(Spec, NonNormalizedSpec):
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool | SchemaBase | Map] = Undefined,
         columns: Optional[float] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         name: Optional[str] = Undefined,
         resolve: Optional[SchemaBase | Map] = Undefined,
@@ -21128,7 +21128,7 @@ class FacetSpec(Spec, NonNormalizedSpec):
 
         2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat``)
         and to using the ``row`` channel (for ``facet`` and ``repeat``).
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -21161,7 +21161,7 @@ class FacetSpec(Spec, NonNormalizedSpec):
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool | SchemaBase | Map] = Undefined,
         columns: Optional[float] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         name: Optional[str] = Undefined,
         resolve: Optional[SchemaBase | Map] = Undefined,
@@ -21237,7 +21237,7 @@ class FacetedUnitSpec(Spec, NonNormalizedSpec):
         supply different centering values for rows and columns.
 
         **Default value:** ``false``
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -21319,7 +21319,7 @@ class FacetedUnitSpec(Spec, NonNormalizedSpec):
         align: Optional[SchemaBase | Map | LayoutAlign_T] = Undefined,
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool | SchemaBase | Map] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         encoding: Optional[SchemaBase | Map] = Undefined,
         height: Optional[float | SchemaBase | Literal["container"] | Map] = Undefined,
@@ -21382,7 +21382,7 @@ class HConcatSpecGenericSpec(Spec, NonNormalizedSpec):
         rows or columns.
 
         **Default value:** ``false``
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -21408,7 +21408,7 @@ class HConcatSpecGenericSpec(Spec, NonNormalizedSpec):
         hconcat: Optional[Sequence[SchemaBase | Map]] = Undefined,
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         name: Optional[str] = Undefined,
         resolve: Optional[SchemaBase | Map] = Undefined,
@@ -21448,7 +21448,7 @@ class LayerSpec(Spec, NonNormalizedSpec):
         as layering facet specifications is not allowed. Instead, use the `facet operator
         <https://vega.github.io/vega-lite/docs/facet.html>`__ and place a layer inside a
         facet.
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -21516,7 +21516,7 @@ class LayerSpec(Spec, NonNormalizedSpec):
     def __init__(
         self,
         layer: Optional[Sequence[SchemaBase | Map]] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         encoding: Optional[SchemaBase | Map] = Undefined,
         height: Optional[float | SchemaBase | Literal["container"] | Map] = Undefined,
@@ -21623,7 +21623,7 @@ class LayerRepeatSpec(RepeatSpec):
 
         2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat``)
         and to using the ``row`` channel (for ``facet`` and ``repeat``).
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -21656,7 +21656,7 @@ class LayerRepeatSpec(RepeatSpec):
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool | SchemaBase | Map] = Undefined,
         columns: Optional[float] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         name: Optional[str] = Undefined,
         resolve: Optional[SchemaBase | Map] = Undefined,
@@ -21753,7 +21753,7 @@ class NonLayerRepeatSpec(RepeatSpec):
 
         2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat``)
         and to using the ``row`` channel (for ``facet`` and ``repeat``).
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -21786,7 +21786,7 @@ class NonLayerRepeatSpec(RepeatSpec):
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool | SchemaBase | Map] = Undefined,
         columns: Optional[float] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         name: Optional[str] = Undefined,
         resolve: Optional[SchemaBase | Map] = Undefined,
@@ -22020,7 +22020,7 @@ class StringFieldDef(VegaLiteSchema):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -22097,7 +22097,7 @@ class StringFieldDef(VegaLiteSchema):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -22191,14 +22191,14 @@ class StringFieldDef(VegaLiteSchema):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -22236,7 +22236,7 @@ class StringFieldDefWithCondition(VegaLiteSchema):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -22320,7 +22320,7 @@ class StringFieldDefWithCondition(VegaLiteSchema):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -22415,7 +22415,7 @@ class StringFieldDefWithCondition(VegaLiteSchema):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -22423,7 +22423,7 @@ class StringFieldDefWithCondition(VegaLiteSchema):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -22451,7 +22451,7 @@ class StringValueDefWithCondition(VegaLiteSchema):
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -22462,7 +22462,7 @@ class StringValueDefWithCondition(VegaLiteSchema):
     def __init__(
         self,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ):
         super().__init__(condition=condition, value=value, **kwds)
@@ -22635,7 +22635,7 @@ class FieldOrDatumDefWithConditionStringDatumDefText(TextDef):
         **Note:** A field definition's ``condition`` property can only contain `conditional
         value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
         since Vega-Lite only allows at most one encoded field per encoding channel.
-    datum : str, bool, dict, None, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`
+    datum : str, bool, dict, float, :class:`ExprRef`, :class:`DateTime`, :class:`RepeatRef`, :class:`PrimitiveValue`, None
         A constant value in data domain.
     format : str, dict, :class:`Dict`
         When used with the default ``"number"`` and ``"time"`` format type, the text
@@ -22669,7 +22669,7 @@ class FieldOrDatumDefWithConditionStringDatumDefText(TextDef):
         * ``"time"`` for temporal fields and ordinal and nominal fields with ``timeUnit``.
         * ``"number"`` for quantitative fields as well as ordinal and nominal fields without
           ``timeUnit``.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -22766,11 +22766,11 @@ class FieldOrDatumDefWithConditionStringDatumDefText(TextDef):
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         datum: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
     ):
@@ -22806,7 +22806,7 @@ class FieldOrDatumDefWithConditionStringFieldDefText(TextDef):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -22890,7 +22890,7 @@ class FieldOrDatumDefWithConditionStringFieldDefText(TextDef):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -22987,7 +22987,7 @@ class FieldOrDatumDefWithConditionStringFieldDefText(TextDef):
         shorthand: Optional[str | SchemaBase | Sequence[str] | Map] = Undefined,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
@@ -22995,7 +22995,7 @@ class FieldOrDatumDefWithConditionStringFieldDefText(TextDef):
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -23136,7 +23136,7 @@ class TickConfig(AnyMarkConfig):
     endAngle : dict, float, :class:`ExprRef`
         The end angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
@@ -23197,7 +23197,7 @@ class TickConfig(AnyMarkConfig):
         * ``"bundle"``: equivalent to basis, except the tension parameter is used to
           straighten the spline.
         * ``"monotone"``: cubic interpolation that preserves monotonicity in y.
-    invalid : None, :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show']
+    invalid : :class:`MarkInvalidDataMode`, Literal['filter', 'break-paths-filter-domains', 'break-paths-show-domains', 'break-paths-show-path-domains', 'show'], None
         Invalid data mode, which defines how the marks and corresponding scales should
         represent invalid values (``null`` and ``NaN`` in continuous scales *without*
         defined output for invalid values).
@@ -23312,7 +23312,7 @@ class TickConfig(AnyMarkConfig):
     startAngle : dict, float, :class:`ExprRef`
         The start angle in radians for arc marks. A value of ``0`` indicates up (north),
         increasing values proceed clockwise.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`Gradient`, :class:`HexColor`, :class:`ColorName`, :class:`LinearGradient`, :class:`RadialGradient`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
@@ -23368,7 +23368,7 @@ class TickConfig(AnyMarkConfig):
         Default relative band size for a time unit. If set to ``1``, the bandwidth of the
         marks will be equal to the time unit band step. If set to ``0.5``, bandwidth of the
         marks will be half of the time unit band step.
-    tooltip : str, bool, dict, None, float, :class:`ExprRef`, :class:`TooltipContent`
+    tooltip : str, bool, dict, float, :class:`ExprRef`, :class:`TooltipContent`, None
         The tooltip text string to show upon mouse hover or an object defining which fields
         should the tooltip be derived from.
 
@@ -23443,7 +23443,7 @@ class TickConfig(AnyMarkConfig):
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         endAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -23455,7 +23455,7 @@ class TickConfig(AnyMarkConfig):
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         lineHeight: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -23471,7 +23471,7 @@ class TickConfig(AnyMarkConfig):
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         startAngle: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -23491,7 +23491,7 @@ class TickConfig(AnyMarkConfig):
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -23829,7 +23829,7 @@ class TitleConfig(VegaLiteSchema):
         ``"line-bottom"``. The ``"line-top"`` and ``"line-bottom"`` values operate similarly
         to ``"top"`` and ``"bottom"``, but are calculated relative to the *lineHeight*
         rather than *fontSize* alone.
-    color : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    color : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Text color for title text.
     dx : dict, float, :class:`ExprRef`
         Delta offset for title and subtitle text x-coordinate.
@@ -23859,7 +23859,7 @@ class TitleConfig(VegaLiteSchema):
         position along the edge of the chart.
     orient : dict, :class:`ExprRef`, :class:`TitleOrient`, Literal['none', 'left', 'right', 'top', 'bottom']
         Default title orientation (``"top"``, ``"bottom"``, ``"left"``, or ``"right"``)
-    subtitleColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    subtitleColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Text color for subtitle text.
     subtitleFont : str, dict, :class:`ExprRef`
         Font name for subtitle text.
@@ -23892,7 +23892,7 @@ class TitleConfig(VegaLiteSchema):
         aria: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         baseline: Optional[SchemaBase | TextBaseline_T] = Undefined,
         color: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         dx: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -23906,7 +23906,7 @@ class TitleConfig(VegaLiteSchema):
         offset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         orient: Optional[Parameter | SchemaBase | Map | TitleOrient_T] = Undefined,
         subtitleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         subtitleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         subtitleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -24008,7 +24008,7 @@ class TitleParams(VegaLiteSchema):
         ``"line-bottom"``. The ``"line-top"`` and ``"line-bottom"`` values operate similarly
         to ``"top"`` and ``"bottom"``, but are calculated relative to the *lineHeight*
         rather than *fontSize* alone.
-    color : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    color : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Text color for title text.
     dx : dict, float, :class:`ExprRef`
         Delta offset for title and subtitle text x-coordinate.
@@ -24045,7 +24045,7 @@ class TitleParams(VegaLiteSchema):
         **Default value:** ``"group-title"``.
     subtitle : str, :class:`Text`, Sequence[str]
         The subtitle Text.
-    subtitleColor : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    subtitleColor : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         Text color for subtitle text.
     subtitleFont : str, dict, :class:`ExprRef`
         Font name for subtitle text.
@@ -24079,7 +24079,7 @@ class TitleParams(VegaLiteSchema):
         aria: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         baseline: Optional[SchemaBase | TextBaseline_T] = Undefined,
         color: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         dx: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -24095,7 +24095,7 @@ class TitleParams(VegaLiteSchema):
         style: Optional[str | Sequence[str]] = Undefined,
         subtitle: Optional[str | SchemaBase | Sequence[str]] = Undefined,
         subtitleColor: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         subtitleFont: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         subtitleFontSize: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -24202,7 +24202,7 @@ class TopLevelSelectionParameter(TopLevelParameter):
 
         **See also:** `bind <https://vega.github.io/vega-lite/docs/bind.html>`__
         documentation.
-    value : str, bool, dict, None, float, :class:`DateTime`, :class:`SelectionInit`, :class:`PrimitiveValue`, :class:`SelectionInitIntervalMapping`, Sequence[dict, :class:`SelectionInitMapping`]
+    value : str, bool, dict, float, :class:`DateTime`, :class:`SelectionInit`, :class:`PrimitiveValue`, :class:`SelectionInitIntervalMapping`, Sequence[dict, :class:`SelectionInitMapping`], None
         Initialize the selection with a mapping between `projected channels or field names
         <https://vega.github.io/vega-lite/docs/selection.html#project>`__ and initial
         values.
@@ -24223,7 +24223,7 @@ class TopLevelSelectionParameter(TopLevelParameter):
         select: Optional[SchemaBase | Map | SelectionType_T] = Undefined,
         bind: Optional[SchemaBase | Literal["legend", "scales"] | Map] = Undefined,
         value: Optional[
-            str | bool | None | float | SchemaBase | Sequence[SchemaBase | Map] | Map
+            str | bool | float | SchemaBase | Sequence[SchemaBase | Map] | Map | None
         ] = Undefined,
         views: Optional[Sequence[str]] = Undefined,
         **kwds,
@@ -24320,7 +24320,7 @@ class TopLevelConcatSpec(TopLevelSpec):
     config : dict, :class:`Config`
         Vega-Lite configuration object. This property can only be defined at the top-level
         of a specification.
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     datasets : dict, :class:`Datasets`
@@ -24379,7 +24379,7 @@ class TopLevelConcatSpec(TopLevelSpec):
         center: Optional[bool | SchemaBase | Map] = Undefined,
         columns: Optional[float] = Undefined,
         config: Optional[SchemaBase | Map] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         datasets: Optional[SchemaBase | Map] = Undefined,
         description: Optional[str] = Undefined,
         name: Optional[str] = Undefined,
@@ -24422,7 +24422,7 @@ class TopLevelFacetSpec(TopLevelSpec):
 
     Parameters
     ----------
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     facet : dict, :class:`FacetMapping`, :class:`FacetFieldDef`
@@ -24544,7 +24544,7 @@ class TopLevelFacetSpec(TopLevelSpec):
 
     def __init__(
         self,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         facet: Optional[SchemaBase | Map] = Undefined,
         spec: Optional[SchemaBase | Map] = Undefined,
         align: Optional[SchemaBase | Map | LayoutAlign_T] = Undefined,
@@ -24630,7 +24630,7 @@ class TopLevelHConcatSpec(TopLevelSpec):
     config : dict, :class:`Config`
         Vega-Lite configuration object. This property can only be defined at the top-level
         of a specification.
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     datasets : dict, :class:`Datasets`
@@ -24683,7 +24683,7 @@ class TopLevelHConcatSpec(TopLevelSpec):
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool] = Undefined,
         config: Optional[SchemaBase | Map] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         datasets: Optional[SchemaBase | Map] = Undefined,
         description: Optional[str] = Undefined,
         name: Optional[str] = Undefined,
@@ -24744,7 +24744,7 @@ class TopLevelLayerSpec(TopLevelSpec):
     config : dict, :class:`Config`
         Vega-Lite configuration object. This property can only be defined at the top-level
         of a specification.
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     datasets : dict, :class:`Datasets`
@@ -24839,7 +24839,7 @@ class TopLevelLayerSpec(TopLevelSpec):
             str | Parameter | SchemaBase | Map | ColorName_T
         ] = Undefined,
         config: Optional[SchemaBase | Map] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         datasets: Optional[SchemaBase | Map] = Undefined,
         description: Optional[str] = Undefined,
         encoding: Optional[SchemaBase | Map] = Undefined,
@@ -24895,7 +24895,7 @@ class TopLevelUnitSpec(TopLevelSpec):
 
     Parameters
     ----------
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     mark : dict, :class:`Mark`, :class:`AnyMark`, :class:`BoxPlot`, :class:`MarkDef`, :class:`ErrorBar`, :class:`ErrorBand`, :class:`BoxPlotDef`, :class:`ErrorBarDef`, :class:`ErrorBandDef`, :class:`CompositeMark`, :class:`CompositeMarkDef`, Literal['arc', 'area', 'bar', 'image', 'line', 'point', 'rect', 'rule', 'text', 'tick', 'trail', 'circle', 'square', 'geoshape', 'boxplot', 'errorband', 'errorbar']
@@ -25046,7 +25046,7 @@ class TopLevelUnitSpec(TopLevelSpec):
 
     def __init__(
         self,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         mark: Optional[SchemaBase | Map | Mark_T | CompositeMark_T] = Undefined,
         align: Optional[SchemaBase | Map | LayoutAlign_T] = Undefined,
         autosize: Optional[SchemaBase | Map | AutosizeType_T] = Undefined,
@@ -25138,7 +25138,7 @@ class TopLevelVConcatSpec(TopLevelSpec):
     config : dict, :class:`Config`
         Vega-Lite configuration object. This property can only be defined at the top-level
         of a specification.
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     datasets : dict, :class:`Datasets`
@@ -25191,7 +25191,7 @@ class TopLevelVConcatSpec(TopLevelSpec):
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool] = Undefined,
         config: Optional[SchemaBase | Map] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         datasets: Optional[SchemaBase | Map] = Undefined,
         description: Optional[str] = Undefined,
         name: Optional[str] = Undefined,
@@ -25244,7 +25244,7 @@ class TopoDataFormat(DataFormat):
         not as individual GeoJSON features. Extracting a mesh is useful for more efficiently
         drawing borders or other geographic elements that you do not need to associate with
         specific regions such as individual countries, states or counties.
-    parse : dict, None, :class:`Parse`
+    parse : dict, :class:`Parse`, None
         If set to ``null``, disable type inference based on the spec and only use type
         inference based on the data. Alternatively, a parsing directive object can be
         provided for explicit data types. Each property of the object corresponds to a field
@@ -25273,7 +25273,7 @@ class TopoDataFormat(DataFormat):
         self,
         feature: Optional[str] = Undefined,
         mesh: Optional[str] = Undefined,
-        parse: Optional[None | SchemaBase | Map] = Undefined,
+        parse: Optional[SchemaBase | Map | None] = Undefined,
         type: Optional[Literal["topojson"]] = Undefined,
         **kwds,
     ):
@@ -25569,7 +25569,7 @@ class ImputeTransform(Transform):
     key : str, :class:`FieldName`
         A key field that uniquely identifies data objects within a group. Missing key values
         (those occurring in the data but not in the current group) will be imputed.
-    frame : Sequence[None, float]
+    frame : Sequence[float, None]
         A frame specification as a two-element array used to control the window over which
         the specified method is applied. The array entries should either be a number
         indicating the offset from the current data object, or null to indicate unbounded
@@ -25608,7 +25608,7 @@ class ImputeTransform(Transform):
         self,
         impute: Optional[str | SchemaBase] = Undefined,
         key: Optional[str | SchemaBase] = Undefined,
-        frame: Optional[Sequence[None | float]] = Undefined,
+        frame: Optional[Sequence[float | None]] = Undefined,
         groupby: Optional[Sequence[str | SchemaBase]] = Undefined,
         keyvals: Optional[SchemaBase | Sequence[Any] | Map] = Undefined,
         method: Optional[SchemaBase | ImputeMethod_T] = Undefined,
@@ -25999,7 +25999,7 @@ class TypedFieldDef(VegaLiteSchema):
         Relative position on a band of a stacked, binned, time unit, or band scale. For
         example, the marks will be positioned at the beginning of the band if set to ``0``,
         and at the middle of the band if set to ``0.5``.
-    bin : bool, dict, None, Literal['binned'], :class:`BinParams`
+    bin : bool, dict, Literal['binned'], :class:`BinParams`, None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
         <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
         that the data for ``x`` or ``y`` channel are binned before they are imported into
@@ -26044,7 +26044,7 @@ class TypedFieldDef(VegaLiteSchema):
 
         **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
         documentation.
-    title : str, None, :class:`Text`, Sequence[str]
+    title : str, :class:`Text`, Sequence[str], None
         A title for the field. If ``null``, the title will be removed.
 
         **Default value:**  derived from the field's name and transformation function
@@ -26138,12 +26138,12 @@ class TypedFieldDef(VegaLiteSchema):
         self,
         aggregate: Optional[SchemaBase | Map | NonArgAggregateOp_T] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        bin: Optional[bool | None | SchemaBase | Literal["binned"] | Map] = Undefined,
+        bin: Optional[bool | SchemaBase | Literal["binned"] | Map | None] = Undefined,
         field: Optional[str | SchemaBase | Map] = Undefined,
         timeUnit: Optional[
             SchemaBase | Map | MultiTimeUnit_T | BinnedTimeUnit_T | SingleTimeUnit_T
         ] = Undefined,
-        title: Optional[str | None | SchemaBase | Sequence[str]] = Undefined,
+        title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | StandardType_T] = Undefined,
         **kwds,
     ):
@@ -26181,7 +26181,7 @@ class UnitSpec(VegaLiteSchema):
         ``"tick"``, ``"line"``, ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and
         ``"text"``) or a `mark definition object
         <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -26208,7 +26208,7 @@ class UnitSpec(VegaLiteSchema):
     def __init__(
         self,
         mark: Optional[SchemaBase | Map | Mark_T | CompositeMark_T] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         encoding: Optional[SchemaBase | Map] = Undefined,
         name: Optional[str] = Undefined,
@@ -26243,7 +26243,7 @@ class UnitSpecWithFrame(VegaLiteSchema):
         ``"tick"``, ``"line"``, ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and
         ``"text"``) or a `mark definition object
         <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -26312,7 +26312,7 @@ class UnitSpecWithFrame(VegaLiteSchema):
     def __init__(
         self,
         mark: Optional[SchemaBase | Map | Mark_T | CompositeMark_T] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         encoding: Optional[SchemaBase | Map] = Undefined,
         height: Optional[float | SchemaBase | Literal["container"] | Map] = Undefined,
@@ -26413,7 +26413,7 @@ class VConcatSpecGenericSpec(Spec, NonNormalizedSpec):
         rows or columns.
 
         **Default value:** ``false``
-    data : dict, None, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`
+    data : dict, :class:`Data`, :class:`UrlData`, :class:`Generator`, :class:`NamedData`, :class:`DataSource`, :class:`InlineData`, :class:`SphereGenerator`, :class:`SequenceGenerator`, :class:`GraticuleGenerator`, None
         An object describing the data source. Set to ``null`` to ignore the parent's data
         source. If no data is set, it is derived from the parent.
     description : str
@@ -26439,7 +26439,7 @@ class VConcatSpecGenericSpec(Spec, NonNormalizedSpec):
         vconcat: Optional[Sequence[SchemaBase | Map]] = Undefined,
         bounds: Optional[Literal["full", "flush"]] = Undefined,
         center: Optional[bool] = Undefined,
-        data: Optional[None | SchemaBase | Map] = Undefined,
+        data: Optional[SchemaBase | Map | None] = Undefined,
         description: Optional[str] = Undefined,
         name: Optional[str] = Undefined,
         resolve: Optional[SchemaBase | Map] = Undefined,
@@ -26473,7 +26473,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefGradientstringnull(
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefGradientstringnullExprRef`, :class:`ConditionalParameterValueDefGradientstringnullExprRef`, :class:`ConditionalPredicateValueDefGradientstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefGradientstringnullExprRef`, :class:`ConditionalParameterValueDefGradientstringnullExprRef`, :class:`ConditionalPredicateValueDefGradientstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`
+    value : str, dict, :class:`ExprRef`, :class:`Gradient`, :class:`LinearGradient`, :class:`RadialGradient`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -26486,7 +26486,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefGradientstringnull(
     def __init__(
         self,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ):
         super().__init__(condition=condition, value=value, **kwds)
@@ -26502,7 +26502,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefTypeForShapestringnull(
     ----------
     condition : dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`, :class:`ConditionalMarkPropFieldOrDatumDefTypeForShape`, :class:`ConditionalParameterMarkPropFieldOrDatumDefTypeForShape`, :class:`ConditionalPredicateMarkPropFieldOrDatumDefTypeForShape`, Sequence[dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -26515,7 +26515,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefTypeForShapestringnull(
     def __init__(
         self,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ):
         super().__init__(condition=condition, value=value, **kwds)
@@ -26587,7 +26587,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefstringnull(VegaLiteSchema):
     ----------
     condition : dict, :class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterMarkPropFieldOrDatumDef`, :class:`ConditionalPredicateMarkPropFieldOrDatumDef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`, Sequence[dict, :class:`ConditionalValueDefstringnullExprRef`, :class:`ConditionalParameterValueDefstringnullExprRef`, :class:`ConditionalPredicateValueDefstringnullExprRef`]
         A field definition or one or more value definition(s) with a parameter predicate.
-    value : str, dict, None, :class:`ExprRef`
+    value : str, dict, :class:`ExprRef`, None
         A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"`` / `gradient
         definition <https://vega.github.io/vega-lite/docs/types.html#gradient>`__ for color,
         values between ``0`` to ``1`` for opacity).
@@ -26600,7 +26600,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefstringnull(VegaLiteSchema):
     def __init__(
         self,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        value: Optional[str | None | Parameter | SchemaBase | Map] = Undefined,
+        value: Optional[str | Parameter | SchemaBase | Map | None] = Undefined,
         **kwds,
     ):
         super().__init__(condition=condition, value=value, **kwds)
@@ -26821,7 +26821,7 @@ class ViewBackground(VegaLiteSchema):
     cursor : :class:`Cursor`, Literal['auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress', 'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop', 'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize', 'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize', 'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing']
         The mouse cursor used over the view. Any valid `CSS cursor type
         <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The fill color.
 
         **Default value:** ``undefined``
@@ -26834,7 +26834,7 @@ class ViewBackground(VegaLiteSchema):
 
         **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
         ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The stroke color.
 
         **Default value:** ``"#ddd"``
@@ -26877,12 +26877,12 @@ class ViewBackground(VegaLiteSchema):
         cornerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         cursor: Optional[SchemaBase | Cursor_T] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         opacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -26952,7 +26952,7 @@ class ViewConfig(VegaLiteSchema):
         in the form of ``{step: number}`` defining the width per discrete step.
 
         **Default value:** a step size based on ``config.view.step``.
-    fill : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    fill : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The fill color.
 
         **Default value:** ``undefined``
@@ -26967,7 +26967,7 @@ class ViewConfig(VegaLiteSchema):
         ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
     step : float
         Default step size for x-/y- discrete fields.
-    stroke : str, dict, None, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple']
+    stroke : str, dict, :class:`Color`, :class:`ExprRef`, :class:`HexColor`, :class:`ColorName`, Literal['black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue', 'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen', 'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen', 'rebeccapurple'], None
         The stroke color.
 
         **Default value:** ``"#ddd"``
@@ -27006,13 +27006,13 @@ class ViewConfig(VegaLiteSchema):
         discreteHeight: Optional[float | Map] = Undefined,
         discreteWidth: Optional[float | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         opacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         step: Optional[float] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -27120,7 +27120,7 @@ class WindowTransform(Transform):
     ----------
     window : Sequence[dict, :class:`WindowFieldDef`]
         The definition of the fields in the window, and what calculations to use.
-    frame : Sequence[None, float]
+    frame : Sequence[float, None]
         A frame specification as a two-element array indicating how the sliding window
         should proceed. The array entries should either be a number indicating the offset
         from the current data object, or null to indicate unbounded rows preceding or
@@ -27162,7 +27162,7 @@ class WindowTransform(Transform):
     def __init__(
         self,
         window: Optional[Sequence[SchemaBase | Map]] = Undefined,
-        frame: Optional[Sequence[None | float]] = Undefined,
+        frame: Optional[Sequence[float | None]] = Undefined,
         groupby: Optional[Sequence[str | SchemaBase]] = Undefined,
         ignorePeers: Optional[bool] = Undefined,
         sort: Optional[Sequence[SchemaBase | Map]] = Undefined,

--- a/altair/vegalite/v5/schema/mixins.py
+++ b/altair/vegalite/v5/schema/mixins.py
@@ -64,7 +64,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -76,7 +76,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -96,7 +96,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -119,7 +119,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -273,7 +273,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -285,7 +285,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -305,7 +305,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -328,7 +328,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -482,7 +482,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -494,7 +494,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -514,7 +514,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -537,7 +537,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -691,7 +691,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -703,7 +703,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -723,7 +723,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -746,7 +746,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -900,7 +900,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -912,7 +912,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -932,7 +932,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -955,7 +955,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1109,7 +1109,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -1121,7 +1121,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -1141,7 +1141,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -1164,7 +1164,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1318,7 +1318,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -1330,7 +1330,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -1350,7 +1350,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -1373,7 +1373,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1527,7 +1527,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -1539,7 +1539,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -1559,7 +1559,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -1582,7 +1582,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1736,7 +1736,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -1748,7 +1748,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -1768,7 +1768,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -1791,7 +1791,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -1945,7 +1945,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -1957,7 +1957,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -1977,7 +1977,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -2000,7 +2000,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -2154,7 +2154,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -2166,7 +2166,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -2186,7 +2186,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -2209,7 +2209,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -2363,7 +2363,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -2375,7 +2375,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -2395,7 +2395,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -2418,7 +2418,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -2572,7 +2572,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -2584,7 +2584,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -2604,7 +2604,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -2627,7 +2627,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -2781,7 +2781,7 @@ class MarkMethodMixin:
         dy: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         ellipsis: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         fill: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         fillOpacity: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         filled: Optional[bool] = Undefined,
@@ -2793,7 +2793,7 @@ class MarkMethodMixin:
         href: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         innerRadius: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         interpolate: Optional[Parameter | SchemaBase | Map | Interpolate_T] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         limit: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         line: Optional[bool | SchemaBase | Map] = Undefined,
         lineBreak: Optional[str | Parameter | SchemaBase | Map] = Undefined,
@@ -2813,7 +2813,7 @@ class MarkMethodMixin:
         size: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         smooth: Optional[bool | Parameter | SchemaBase | Map] = Undefined,
         stroke: Optional[
-            str | None | Parameter | SchemaBase | Map | ColorName_T
+            str | Parameter | SchemaBase | Map | ColorName_T | None
         ] = Undefined,
         strokeCap: Optional[Parameter | SchemaBase | Map | StrokeCap_T] = Undefined,
         strokeDash: Optional[
@@ -2836,7 +2836,7 @@ class MarkMethodMixin:
         timeUnitBandPosition: Optional[float] = Undefined,
         timeUnitBandSize: Optional[float] = Undefined,
         tooltip: Optional[
-            str | bool | None | float | Parameter | SchemaBase | Map
+            str | bool | float | Parameter | SchemaBase | Map | None
         ] = Undefined,
         url: Optional[str | Parameter | SchemaBase | Map] = Undefined,
         width: Optional[float | Parameter | SchemaBase | Map] = Undefined,
@@ -2961,7 +2961,7 @@ class MarkMethodMixin:
         clip: Optional[bool] = Undefined,
         color: Optional[str | Parameter | SchemaBase | Map | ColorName_T] = Undefined,
         extent: Optional[float | Literal["min-max"]] = Undefined,
-        invalid: Optional[None | SchemaBase | MarkInvalidDataMode_T] = Undefined,
+        invalid: Optional[SchemaBase | MarkInvalidDataMode_T | None] = Undefined,
         median: Optional[bool | SchemaBase | Map] = Undefined,
         opacity: Optional[float] = Undefined,
         orient: Optional[SchemaBase | Orientation_T] = Undefined,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ test = [
     "ruff check .",
     "ruff format --diff --check .",
     "mypy altair tests",
-    "python -m pytest --pyargs --numprocesses=logical --doctest-modules tests altair",
+    "python -m pytest --pyargs --numprocesses=logical --doctest-modules tests altair tools",
 ]
 test-coverage = "python -m pytest --pyargs --doctest-modules --cov=altair --cov-report term altair"
 test-coverage-html = "python -m pytest --pyargs --doctest-modules --cov=altair --cov-report html altair"
@@ -130,18 +130,18 @@ update-init-file = [
 ]
 test-fast = [
     "ruff check .", "ruff format .",
-    "pytest -p no:randomly -n logical --numprocesses=logical --doctest-modules tests altair -m \"not slow\" {args}"
+    "pytest -p no:randomly -n logical --numprocesses=logical --doctest-modules tests altair tools -m \"not slow\" {args}"
 ]
 test-slow = [
     "ruff check .", "ruff format .",
-    "pytest -p no:randomly -n logical --numprocesses=logical --doctest-modules tests altair -m \"slow\" {args}"
+    "pytest -p no:randomly -n logical --numprocesses=logical --doctest-modules tests altair tools -m \"slow\" {args}"
 ]
 
 [tool.hatch.envs.hatch-test]
 # https://hatch.pypa.io/latest/tutorials/testing/overview/
 features = ["all", "dev", "doc"]
 # https://pytest-xdist.readthedocs.io/en/latest/distribution.html#running-tests-across-multiple-cpus
-default-args = ["--numprocesses=logical","--doctest-modules", "tests", "altair"]
+default-args = ["--numprocesses=logical","--doctest-modules", "tests", "altair", "tools"]
 parallel = true
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -885,6 +885,17 @@ def sort_type_reprs(tps: Iterable[str], /) -> list[str]:
     -------
     - https://github.com/vega/altair/pull/3573#discussion_r1747121600
 
+    Examples
+    --------
+    >>> sort_type_reprs(["float", "None", "bool", "Chart", "float", "bool", "Chart", "str"])
+    ['str', 'bool', 'float', 'Chart', 'None']
+
+    >>> sort_type_reprs(("None", "int", "Literal[5]", "int", "float"))
+    ['int', 'float', 'Literal[5]', 'None']
+
+    >>> sort_type_reprs({"date", "int", "str", "datetime", "Date"})
+    ['int', 'str', 'date', 'datetime', 'Date']
+
     .. _set:
         https://docs.python.org/3/tutorial/datastructures.html#sets
     .. _sort-stability:

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -58,6 +58,23 @@ jsonschema_to_python_types: dict[str, str] = {
     "array": "list",
     "null": "None",
 }
+_STDLIB_TYPE_NAMES = frozenset(
+    (
+        "int",
+        "float",
+        "str",
+        "None",
+        "bool",
+        "date",
+        "datetime",
+        "time",
+        "tuple",
+        "list",
+        "deque",
+        "dict",
+        "set",
+    )
+)
 
 _VALID_IDENT: Pattern[str] = re.compile(r"^[^\d\W]\w*\Z", re.ASCII)
 
@@ -859,9 +876,10 @@ def sort_type_reprs(tps: Iterable[str], /) -> list[str]:
     We use `set`_ for unique elements, but the lack of ordering requires additional sorts:
     - If types have same length names, order would still be non-deterministic
     - Hence, we sort as well by type name as a tie-breaker, see `sort-stability`_.
-    - Using ``str.lower`` gives priority to `builtins`_ over ``None``.
-    - Lowest priority is given to generated aliases from ``TypeAliasTracer``.
+    - Using ``str.lower`` gives priority to `builtins`_.
+    - Lower priority is given to generated aliases from ``TypeAliasTracer``.
         - These are purely to improve autocompletion
+    - ``None`` will always appear last.
 
     Related
     -------
@@ -875,9 +893,30 @@ def sort_type_reprs(tps: Iterable[str], /) -> list[str]:
         https://docs.python.org/3/library/functions.html
     """
     dedup = tps if isinstance(tps, set) else set(tps)
-    it = sorted(dedup, key=str.lower)  # Tertiary sort
-    it = sorted(it, key=len)  # Secondary sort
-    return sorted(it, key=TypeAliasTracer.is_cached)  # Primary sort
+    it = sorted(dedup, key=str.lower)  # Quinary sort
+    it = sorted(it, key=len)  # Quaternary sort
+    it = sorted(it, key=TypeAliasTracer.is_cached)  # Tertiary sort
+    it = sorted(it, key=is_not_stdlib)  # Secondary sort
+    it = sorted(it, key=is_none)  # Primary sort
+    return it
+
+
+def is_not_stdlib(s: str, /) -> bool:
+    """
+    Sort key.
+
+    Places a subset of stdlib types at the **start** of list.
+    """
+    return s not in _STDLIB_TYPE_NAMES
+
+
+def is_none(s: str, /) -> bool:
+    """
+    Sort key.
+
+    Always places ``None`` at the **end** of list.
+    """
+    return s == "None"
 
 
 def spell_nested_sequence(

--- a/tools/vega_expr.py
+++ b/tools/vega_expr.py
@@ -318,14 +318,14 @@ class ReplaceMany:
     --------
     Providing a mapping during construction:
 
-        string = "The dog chased the cat, chasing the mouse. Poor mouse"
-        animal_replacer = ReplaceMany({"dog": "cat"})
+        >>> string = "The dog chased the cat, chasing the mouse. Poor mouse"
+        >>> animal_replacer = ReplaceMany({"dog": "cat"})
         >>> animal_replacer(string)
         'The cat chased the cat, chasing the mouse. Poor mouse'
 
     Updating with new replacements:
 
-        animal_replacer.update({"cat": "mouse", "mouse": "dog"}, duck="rabbit")
+        >>> animal_replacer.update({"cat": "mouse", "mouse": "dog"}, duck="rabbit")
         >>> animal_replacer(string, refresh=True)
         'The cat chased the mouse, chasing the dog. Poor dog'
 
@@ -911,7 +911,7 @@ def italics_to_backticks(s: str, names: Iterable[str], /) -> str:
     ...     "some text and *name* and more text but also *other* text",
     ...     ("name", "other"),
     ... )
-    "some text and ``name`` and more text but also ``other`` text"
+    'some text and ``name`` and more text but also ``other`` text'
     """
     pattern = rf"(?P<not_link_start>[^`_])\*(?P<name>{'|'.join(names)})\*(?P<not_link_end>[^`])"
     return re.sub(pattern, r"\g<not_link_start>``\g<name>``\g<not_link_end>", s)


### PR DESCRIPTION
# Description
The doc stated that `None` would appear after builtins. 

https://github.com/vega/altair/blob/2ba89d508f3eac2d0bfaea53dc74a13c105a0452/tools/schemapi/utils.py#L855-L864

However, this assertion doesn't hold for any `builtin` with a name length greater than 4.

The issue is not new, but became more apparent to me while writing https://github.com/vega/altair/pull/3653#discussion_r1810884346

# Example
Below `float` appears after `None`

## Before
https://github.com/vega/altair/blob/2ba89d508f3eac2d0bfaea53dc74a13c105a0452/altair/vegalite/v5/schema/_config.py#L5004

## After
https://github.com/vega/altair/blob/e656661e6abe0c84dc548289f62b38dfc7663091/altair/vegalite/v5/schema/_config.py#L5004

# Note
I was unable to work out a sorting strategy to achieve what the doc had intended.

Instead, I've opted to always place `None` **last in the context it appears**.
This is much easier to do, and is generally what most people would write (*and expect to see*).

In the non-generated code, this is already the pattern we use:

https://github.com/vega/altair/blob/2ba89d508f3eac2d0bfaea53dc74a13c105a0452/altair/vegalite/v5/api.py#L2091

https://github.com/vega/altair/blob/2ba89d508f3eac2d0bfaea53dc74a13c105a0452/altair/vegalite/v5/api.py#L3494

https://github.com/vega/altair/blob/2ba89d508f3eac2d0bfaea53dc74a13c105a0452/altair/vegalite/v5/api.py#L3859

## Preventing regressions
I've started small, but have included a few doctests (https://github.com/vega/altair/pull/3655/commits/f9f0a53fd1f5ca8bfc7a3c8b10a01a8be6e325f5) that are now run alongside (https://github.com/vega/altair/pull/3655/commits/20d5c17e8862d8711d12630d34dda98217c76728) those in `altair`, `tests`.

