### PR TITLE
feat(typing): Support generating `Union` aliases

### DIFF
--- a/altair/vegalite/v5/schema/_config.py
+++ b/altair/vegalite/v5/schema/_config.py
@@ -7399,7 +7399,7 @@ class TopLevelSelectionParameterKwds(TypedDict, total=False):
         | LegendStreamBindingKwds
         | Literal["legend", "scales"]
     )
-    value: str | bool | float | DateTimeKwds | Sequence[Map] | None
+    value: DateTimeKwds | Sequence[Map] | PrimitiveValue_T
     views: Sequence[str]
 
 

--- a/altair/vegalite/v5/schema/_typing.py
+++ b/altair/vegalite/v5/schema/_typing.py
@@ -68,6 +68,7 @@ __all__ = [
     "Orient_T",
     "Orientation_T",
     "PaddingKwds",
+    "PrimitiveValue_T",
     "ProjectionType_T",
     "RangeEnum_T",
     "ResolveMode_T",
@@ -214,6 +215,7 @@ VegaThemes: TypeAlias = Literal[
     "vox",
 ]
 Map: TypeAlias = Mapping[str, Any]
+PrimitiveValue_T: TypeAlias = Union[str, bool, float, None]
 AggregateOp_T: TypeAlias = Literal[
     "argmax",
     "argmin",

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -1092,9 +1092,7 @@ class AngleValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -1136,9 +1134,7 @@ class AngleValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -2021,9 +2017,7 @@ class ColorValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -2065,9 +2059,7 @@ class ColorValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -3019,9 +3011,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -3063,9 +3053,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -4805,9 +4793,7 @@ class FillValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -4849,9 +4835,7 @@ class FillValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -5732,9 +5716,7 @@ class FillOpacityValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -5776,9 +5758,7 @@ class FillOpacityValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -6259,9 +6239,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -6303,9 +6281,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -9106,9 +9082,7 @@ class OpacityValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -9150,9 +9124,7 @@ class OpacityValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -12031,9 +12003,7 @@ class ShapeValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -12075,9 +12045,7 @@ class ShapeValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -12954,9 +12922,7 @@ class SizeValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -12998,9 +12964,7 @@ class SizeValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -13883,9 +13847,7 @@ class StrokeValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -13927,9 +13889,7 @@ class StrokeValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -14810,9 +14770,7 @@ class StrokeDashValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -14854,9 +14812,7 @@ class StrokeDashValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -15737,9 +15693,7 @@ class StrokeOpacityValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -15781,9 +15735,7 @@ class StrokeOpacityValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -16664,9 +16616,7 @@ class StrokeWidthValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -16708,9 +16658,7 @@ class StrokeWidthValue(
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -19029,9 +18977,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -19073,9 +19019,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,
@@ -19556,9 +19500,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         test: Optional[str | SchemaBase | Map] = Undefined,
@@ -19600,9 +19542,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
     def condition(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         empty: Optional[bool] = Undefined,
         legend: Optional[SchemaBase | Map | None] = Undefined,
         param: Optional[str | SchemaBase] = Undefined,

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -12469,9 +12469,7 @@ class FieldOrDatumDefWithConditionDatumDefGradientstringnull(
         self,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
@@ -13119,9 +13117,7 @@ class FieldOrDatumDefWithConditionDatumDefnumberArray(
         self,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
@@ -13528,9 +13524,7 @@ class FieldOrDatumDefWithConditionDatumDefnumber(MarkPropDefnumber, NumericMarkP
         self,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
@@ -15163,9 +15157,7 @@ class DatumDef(LatLongDef, Position2Def):
     def __init__(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
@@ -15323,9 +15315,7 @@ class PositionDatumDefBase(PolarDef):
     def __init__(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
         title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
@@ -15518,9 +15508,7 @@ class PositionDatumDef(PositionDef):
         self,
         axis: Optional[SchemaBase | Map | None] = Undefined,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         impute: Optional[SchemaBase | Map | None] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         stack: Optional[bool | SchemaBase | StackOffset_T | None] = Undefined,
@@ -18741,9 +18729,7 @@ class ScaleDatumDef(OffsetDef):
     def __init__(
         self,
         bandPosition: Optional[float] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         scale: Optional[SchemaBase | Map | None] = Undefined,
         title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
@@ -20072,7 +20058,7 @@ class SelectionParameter(VegaLiteSchema):
         select: Optional[SchemaBase | Map | SelectionType_T] = Undefined,
         bind: Optional[SchemaBase | Literal["legend", "scales"] | Map] = Undefined,
         value: Optional[
-            str | bool | float | SchemaBase | Sequence[SchemaBase | Map] | Map | None
+            SchemaBase | Sequence[SchemaBase | Map] | Map | PrimitiveValue_T
         ] = Undefined,
         **kwds,
     ):
@@ -20296,9 +20282,7 @@ class FieldOrDatumDefWithConditionDatumDefstringnull(
         self,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
         type: Optional[SchemaBase | Type_T] = Undefined,
         **kwds,
@@ -22765,9 +22749,7 @@ class FieldOrDatumDefWithConditionStringDatumDefText(TextDef):
         self,
         bandPosition: Optional[float] = Undefined,
         condition: Optional[SchemaBase | Sequence[SchemaBase | Map] | Map] = Undefined,
-        datum: Optional[
-            str | bool | float | Parameter | SchemaBase | Map | None
-        ] = Undefined,
+        datum: Optional[Parameter | SchemaBase | Map | PrimitiveValue_T] = Undefined,
         format: Optional[str | SchemaBase | Map] = Undefined,
         formatType: Optional[str] = Undefined,
         title: Optional[str | SchemaBase | Sequence[str] | None] = Undefined,
@@ -24223,7 +24205,7 @@ class TopLevelSelectionParameter(TopLevelParameter):
         select: Optional[SchemaBase | Map | SelectionType_T] = Undefined,
         bind: Optional[SchemaBase | Literal["legend", "scales"] | Map] = Undefined,
         value: Optional[
-            str | bool | float | SchemaBase | Sequence[SchemaBase | Map] | Map | None
+            SchemaBase | Sequence[SchemaBase | Map] | Map | PrimitiveValue_T
         ] = Undefined,
         views: Optional[Sequence[str]] = Undefined,
         **kwds,

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -481,7 +481,7 @@ class SchemaInfo:
                 tp_str = TypeAliasTracer.add_literal(self, tp_str, replace=True)
             tps.add(tp_str)
         elif FOR_TYPE_HINTS and self.is_union_literal():
-            it = chain.from_iterable(el.literal for el in self.anyOf)
+            it: Iterator[str] = chain.from_iterable(el.literal for el in self.anyOf)
             tp_str = TypeAliasTracer.add_literal(self, spell_literal(it), replace=True)
             tps.add(tp_str)
         elif self.is_anyOf():

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -163,6 +163,20 @@ class _TypeAliasTracer:
             tp = f"Union[SchemaBase, {', '.join(it)}]"
         return tp
 
+    def add_union(
+        self, info: SchemaInfo, tp_iter: Iterator[str], /, *, replace: bool = False
+    ) -> str:
+        if title := info.title:
+            alias = self.fmt.format(title)
+            if alias not in self._aliases:
+                self.update_aliases(
+                    (alias, f"Union[{', '.join(sort_type_reprs(tp_iter))}]")
+                )
+            return alias if replace else title
+        else:
+            msg = f"Unsupported operation.\nRequires a title.\n\n{info!r}"
+            raise NotImplementedError(msg)
+
     def update_aliases(self, *name_statement: tuple[str, str]) -> None:
         """
         Adds `(name, statement)` pairs to the definitions.
@@ -476,6 +490,14 @@ class SchemaInfo:
                 for s in self.anyOf
             )
             tps.update(maybe_rewrap_literal(chain.from_iterable(it_nest)))
+        elif FOR_TYPE_HINTS and self.is_type_alias_union():
+            it = (
+                SchemaInfo(dict(self.schema, type=tp)).to_type_repr(
+                    target=target, use_concrete=use_concrete
+                )
+                for tp in self.type
+            )
+            tps.add(TypeAliasTracer.add_union(self, it, replace=True))
         elif isinstance(self.type, list):
             # We always use title if possible for nested objects
             tps.update(
@@ -779,6 +801,25 @@ class SchemaInfo:
             )
             and isinstance(self.type, str)
             and self.type in jsonschema_to_python_types
+        )
+
+    def is_type_alias_union(self) -> bool:
+        """
+        Represents a name assigned to a list of literal types.
+
+        Example:
+
+            {"PrimitiveValue": {"type": ["number", "string", "boolean", "null"]}}
+
+        Translating from JSON -> Python, this is the same as an ``"anyOf"`` -> ``Union``.
+
+        The distinction in the schema is purely due to these types being defined in the draft, rather than definitions.
+        """
+        TP = "type"
+        return (
+            self.schema.keys() == {TP}
+            and isinstance(self.type, list)
+            and bool(self.title)
         )
 
     def is_theme_config_target(self) -> bool:


### PR DESCRIPTION
Initially covering one very specific case, `PrimitiveValue`.

Targeting that one specifically for use in #3653, where it will be used 3 times in a single annotation.

https://github.com/vega/altair/blob/4714865658994f2cda06f765dc0d31c4a4b4b5bb/altair/vegalite/v5/schema/_typing.py#L218

Having this generated makes manually typing what will be the revision to [`30b5a3c` (#3653)](https://github.com/vega/altair/pull/3653/commits/30b5a3c1a06573366bdd14278b76f42a025a5bab) a bit easier to read.

```py
from collections.abc import Sequence, Mapping
from typing_extensions import TypeAlias, LiteralString

from altair.utils import Optional, SchemaBase, Undefined
from altair.vegalite.v5.schema._typing import PrimitiveValue_T, Temporal, SingleDefUnitChannel_T

# NOTE: These names are just for demo purposes
_AnyValue: TypeAlias = PrimitiveValue_T | Temporal | SchemaBase
_ChannelOrField: TypeAlias = SingleDefUnitChannel_T | LiteralString


def selection_interval(
    name: str | None = None,
    value: Optional[
        _AnyValue | Sequence[_AnyValue] | Mapping[_ChannelOrField, _AnyValue]
    ] = Undefined,
): ...

def selection_point(
    name: str | None = None,
    value: Optional[
        _AnyValue | Sequence[_AnyValue] | Mapping[SingleDefUnitChannel_T, _AnyValue]
    ] = Undefined,
): ...
```

# Related
- https://vega.github.io/vega-lite/docs/selection.html#current-limitations