### PR TITLE
docs: Fix "Layered chart with Dual-Axis" (Method syntax)

### DIFF
--- a/tests/examples_methods_syntax/layered_chart_with_dual_axis.py
+++ b/tests/examples_methods_syntax/layered_chart_with_dual_axis.py
@@ -15,12 +15,12 @@ base = alt.Chart(source).encode(
 )
 
 area = base.mark_area(opacity=0.3, color='#57A44C').encode(
-    alt.Y('average(temp_max)').title('Avg. Temperature (°C)', titleColor='#57A44C'),
+    alt.Y('average(temp_max)').axis(title='Avg. Temperature (°C)', titleColor='#57A44C'),
     alt.Y2('average(temp_min)')
 )
 
 line = base.mark_line(stroke='#5276A7', interpolate='monotone').encode(
-    alt.Y('average(precipitation)').title('Precipitation (inches)', titleColor='#5276A7')
+    alt.Y('average(precipitation)').axis(title='Precipitation (inches)', titleColor='#5276A7')
 )
 
 alt.layer(area, line).resolve_scale(


### PR DESCRIPTION
Discovered while writing tests for #3659.

The [User Guide](https://altair-viz.github.io/gallery/layered_chart_with_dual_axis.html) displays the attribute syntax, but the method syntax one was not equivalent.

Results in no `titleColor` being applied and is silently ignored during validation.

# Previous
**Note**: the warning from `pylance` is only showing due to some local changes I have *on-top* of (https://github.com/vega/altair/pull/3659/commits/1a390194352fd5a21631b363cbd1a75dde430beb)

<details><summary>Code block</summary>
<p>

```py
import altair as alt
from vega_datasets import data

source = data.seattle_weather()

base = alt.Chart(source).encode(alt.X("month(date):T").title(None))

area = base.mark_area(opacity=0.3, color="#57A44C").encode(
    alt.Y("average(temp_max)").title("Avg. Temperature (°C)", titleColor="#57A44C"),
    alt.Y2("average(temp_min)"),
)

line = base.mark_line(stroke="#5276A7", interpolate="monotone").encode(
    alt.Y("average(precipitation)").title(
        "Precipitation (inches)", titleColor="#5276A7"
    )
)

alt.layer(area, line).resolve_scale(y="independent")
```

</p>
</details> 

![image](https://github.com/user-attachments/assets/bc04b23d-6a56-4c10-ab07-e612556596ac)


# Fixed
<details><summary>Code block</summary>
<p>

```py
import altair as alt
from vega_datasets import data

source = data.seattle_weather()

base = alt.Chart(source).encode(alt.X("month(date):T").title(None))
area = base.mark_area(opacity=0.3, color="#57A44C").encode(
    alt.Y("average(temp_max)").axis(
        title="Avg. Temperature (°C)", titleColor="#57A44C"
    ),
    alt.Y2("average(temp_min)"),
)

line = base.mark_line(stroke="#5276A7", interpolate="monotone").encode(
    alt.Y("average(precipitation)").axis(
        title="Precipitation (inches)", titleColor="#5276A7"
    )
)

alt.layer(area, line).resolve_scale(y="independent")
```

</p>
</details> 

![image](https://github.com/user-attachments/assets/5575d355-bf22-4e1f-a0bd-64ba889084fd)
