### PR TITLE
docs(typing): Fix inaccurate `selection_interval` signature

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
     )
     from altair.utils.display import MimeBundleType
 
+    from .schema._config import BrushConfigKwds, DerivedStreamKwds, MergedStreamKwds
     from .schema._typing import (
         AggregateOp_T,
         AutosizeType_T,
@@ -107,6 +108,7 @@ if TYPE_CHECKING:
         BindRadioSelect,
         BindRange,
         BinParams,
+        BrushConfig,
         DateTime,
         Expr,
         ExprRef,
@@ -122,7 +124,6 @@ if TYPE_CHECKING:
         JoinAggregateFieldDef,
         LayerRepeatMapping,
         LookupSelection,
-        Mark,
         NamedData,
         ParameterName,
         PointSelectionConfig,
@@ -1503,11 +1504,11 @@ def selection_interval(
     bind: Optional[Binding | str] = Undefined,
     empty: Optional[bool] = Undefined,
     expr: Optional[str | Expr | Expression] = Undefined,
-    encodings: Optional[list[SingleDefUnitChannel_T]] = Undefined,
-    on: Optional[str] = Undefined,
-    clear: Optional[str | bool] = Undefined,
+    encodings: Optional[Sequence[SingleDefUnitChannel_T]] = Undefined,
+    on: Optional[str | MergedStreamKwds | DerivedStreamKwds] = Undefined,
+    clear: Optional[str | bool | MergedStreamKwds | DerivedStreamKwds] = Undefined,
     resolve: Optional[SelectionResolution_T] = Undefined,
-    mark: Optional[Mark] = Undefined,
+    mark: Optional[BrushConfig | BrushConfigKwds] = Undefined,
     translate: Optional[str | bool] = Undefined,
     zoom: Optional[str | bool] = Undefined,
     **kwds: Any,
@@ -1517,16 +1518,16 @@ def selection_interval(
 
     Parameters
     ----------
-    name : string (optional)
+    name : str (optional)
         The name of the parameter. If not specified, a unique name will be
         created.
-    value : any (optional)
+    value : Any (optional)
         The default value of the parameter. If not specified, the parameter
         will be created without a default value.
     bind : :class:`Binding`, str (optional)
         Binds the parameter to an external input element such as a slider,
         selection list or radio button group.
-    empty : boolean (optional)
+    empty : bool (optional)
         For selection parameters, the predicate of empty selections returns
         True by default. Override this behavior, by setting this property
         'empty=False'.
@@ -1534,16 +1535,16 @@ def selection_interval(
         An expression for the value of the parameter. This expression may
         include other parameters, in which case the parameter will
         automatically update in response to upstream parameter changes.
-    encodings : List[str] (optional)
+    encodings : Sequence[str] (optional)
         A list of encoding channels. The corresponding data field values
         must match for a data tuple to fall within the selection.
-    on : string (optional)
+    on : str (optional)
         A Vega event stream (object or selector) that triggers the selection.
         For interval selections, the event stream must specify a start and end.
-    clear : string or boolean (optional)
+    clear : str, bool (optional)
         Clears the selection, emptying it of all values. This property can
         be an Event Stream or False to disable clear.  Default is 'dblclick'.
-    resolve : enum('global', 'union', 'intersect') (optional)
+    resolve : Literal['global', 'union', 'intersect'] (optional)
         With layered and multi-view displays, a strategy that determines
         how selections' data queries are resolved when applied in a filter
         transform, conditional encoding rule, or scale domain.
@@ -1559,11 +1560,11 @@ def selection_interval(
           brushes.
 
         The default is 'global'.
-    mark : :class:`Mark` (optional)
+    mark : :class:`BrushConfig` (optional)
         An interval selection also adds a rectangle mark to depict the
-        extents of the interval. The mark property can be used to
+        extents of the interval. The ``mark`` property can be used to
         customize the appearance of the mark.
-    translate : string or boolean (optional)
+    translate : str, bool (optional)
         When truthy, allows a user to interactively move an interval
         selection back-and-forth. Can be True, False (to disable panning),
         or a Vega event stream definition which must include a start and
@@ -1574,7 +1575,7 @@ def selection_interval(
         [pointerdown, window:pointerup] > window:pointermove!
         This default allows users to click and drag within an interval
         selection to reposition it.
-    zoom : string or boolean (optional)
+    zoom : str, bool (optional)
         When truthy, allows a user to interactively resize an interval
         selection. Can be True, False (to disable zooming), or a Vega
         event stream definition. Currently, only wheel events are supported,
@@ -1584,7 +1585,7 @@ def selection_interval(
         The default value is True, which corresponds to wheel!. This
         default allows users to use the mouse wheel to resize an interval
         selection.
-    **kwds :
+    **kwds : Any
         Additional keywords to control the selection.
 
     Returns


### PR DESCRIPTION
Resolves https://github.com/vega/altair/pull/3653#issuecomment-2437209166

Primarily addresses `mark: Mark`, which should be `mark: BrushConfig`.

As @mattijn noted, [interactions-parameter-composition](https://altair-viz.github.io/user_guide/interactions.html#parameter-composition) would produce this waring:

```py
Argument of type "BrushConfig" cannot be assigned to parameter "mark" of type "Optional[Mark]" in function "selection_interval"
  Type "BrushConfig" is not assignable to type "Optional[Mark]"
    "BrushConfig" is not assignable to "Mark"
    "BrushConfig" is not assignable to "UndefinedType"
```
I traced this back to:
- https://github.com/vega/altair/blame/374a07f0aa7605b1d5ef96f9bfd32d73723f3ca9/altair/vegalite/v5/api.py#L523
    - Introduction of the annotation
- https://github.com/vega/altair/blame/374a07f0aa7605b1d5ef96f9bfd32d73723f3ca9/altair/vegalite/v5/api.py#L574
    - The docstring it appears to have been based on

---

It was also [asked](https://github.com/vega/altair/pull/3653#issuecomment-2437416207) was whether this can be set within a theme.
I found that indeed this **would be possible** (`BrushConfigKwds`).

I spotted some others which seemed useful to include (`MergedStreamKwds`, `DerivedStreamKwds`).
> [!NOTE]
> I think the [strange docs](https://github.com/vega/altair/blob/2d812aff97d6e2d53bc569a03408c68041d72008/altair/vegalite/v5/schema/_config.py#L4399) these have is due to being defined recursively.

---

Finally, this PR updates/corrects the typing embedded within the docstring

