### PR TITLE
feat: Support `&`, `|`, `~` on all `...Predicate` classes

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -457,15 +457,7 @@ class Parameter(_expr_core.OperatorMixin):
 
 
 # Enables use of ~, &, | with compositions of selection objects.
-class SelectionPredicateComposition(core.PredicateComposition):
-    def __invert__(self) -> SelectionPredicateComposition:
-        return SelectionPredicateComposition({"not": self.to_dict()})
-
-    def __and__(self, other: SchemaBase) -> SelectionPredicateComposition:
-        return SelectionPredicateComposition({"and": [self.to_dict(), other.to_dict()]})
-
-    def __or__(self, other: SchemaBase) -> SelectionPredicateComposition:
-        return SelectionPredicateComposition({"or": [self.to_dict(), other.to_dict()]})
+SelectionPredicateComposition = core.PredicateComposition
 
 
 class ParameterExpression(_expr_core.OperatorMixin):

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -409,25 +409,25 @@ class Parameter(_expr_core.OperatorMixin):
             msg = f"Unrecognized parameter type: {self.param_type}"
             raise ValueError(msg)
 
-    def __invert__(self) -> SelectionPredicateComposition | Any:
+    def __invert__(self) -> PredicateComposition | Any:
         if self.param_type == "selection":
-            return SelectionPredicateComposition({"not": {"param": self.name}})
+            return core.PredicateComposition({"not": {"param": self.name}})
         else:
             return _expr_core.OperatorMixin.__invert__(self)
 
-    def __and__(self, other: Any) -> SelectionPredicateComposition | Any:
+    def __and__(self, other: Any) -> PredicateComposition | Any:
         if self.param_type == "selection":
             if isinstance(other, Parameter):
                 other = {"param": other.name}
-            return SelectionPredicateComposition({"and": [{"param": self.name}, other]})
+            return core.PredicateComposition({"and": [{"param": self.name}, other]})
         else:
             return _expr_core.OperatorMixin.__and__(self, other)
 
-    def __or__(self, other: Any) -> SelectionPredicateComposition | Any:
+    def __or__(self, other: Any) -> PredicateComposition | Any:
         if self.param_type == "selection":
             if isinstance(other, Parameter):
                 other = {"param": other.name}
-            return SelectionPredicateComposition({"or": [{"param": self.name}, other]})
+            return core.PredicateComposition({"or": [{"param": self.name}, other]})
         else:
             return _expr_core.OperatorMixin.__or__(self, other)
 
@@ -531,7 +531,7 @@ _PredicateType: TypeAlias = Union[
 """Permitted types for `predicate`."""
 
 _ComposablePredicateType: TypeAlias = Union[
-    _expr_core.OperatorMixin, SelectionPredicateComposition
+    _expr_core.OperatorMixin, core.PredicateComposition
 ]
 """Permitted types for `&` reduced predicates."""
 
@@ -763,7 +763,7 @@ def _validate_composables(
     predicates: Iterable[Any], /
 ) -> Iterator[_ComposablePredicateType]:
     for p in predicates:
-        if isinstance(p, (_expr_core.OperatorMixin, SelectionPredicateComposition)):
+        if isinstance(p, (_expr_core.OperatorMixin, core.PredicateComposition)):
             yield p
         else:
             msg = (

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -16153,6 +16153,15 @@ class PredicateComposition(VegaLiteSchema):
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
 
+    def __invert__(self) -> PredicateComposition:
+        return PredicateComposition({"not": self.to_dict()})
+
+    def __and__(self, other: SchemaBase) -> PredicateComposition:
+        return PredicateComposition({"and": [self.to_dict(), other.to_dict()]})
+
+    def __or__(self, other: SchemaBase) -> PredicateComposition:
+        return PredicateComposition({"or": [self.to_dict(), other.to_dict()]})
+
 
 class LogicalAndPredicate(PredicateComposition):
     """

--- a/doc/user_guide/transform/filter.rst
+++ b/doc/user_guide/transform/filter.rst
@@ -157,34 +157,44 @@ to select the data to be shown in the top chart:
 Logical Operands
 ^^^^^^^^^^^^^^^^
 At times it is useful to combine several types of predicates into a single
-selection. This can be accomplished using the various logical operand classes:
+selection. We can use ``&``, ``|`` and ``~`` for respectively 
+``AND``, ``OR`` and ``NOT`` logical composition operands.
 
-- :class:`~LogicalOrPredicate`
-- :class:`~LogicalAndPredicate`
-- :class:`~LogicalNotPredicate`
+For example, here we wish to plot US population distributions for all data *except* the years *1950-1960*.
 
-These are not yet part of the Altair interface
-(see `Issue 695 <https://github.com/vega/altair/issues/695>`_)
-but can be constructed explicitly; for example, here we plot US population
-distributions for all data *except* the years 1950-1960,
-by applying a ``LogicalNotPredicate`` schema to a ``FieldRangePredicate``:
+First, we use a :class:`~FieldRangePredicate` to select *1950-1960*:
 
 .. altair-plot::
-
+    :output: none
+    
     import altair as alt
     from vega_datasets import data
 
-    pop = data.population.url
-
-    alt.Chart(pop).mark_line().encode(
-        x='age:O',
-        y='sum(people):Q',
-        color='year:O'
+    source = data.population.url
+    chart = alt.Chart(source).mark_line().encode(
+        x="age:O",
+        y="sum(people):Q",
+        color="year:O"
     ).properties(
         width=600, height=200
-    ).transform_filter(
-        {'not': alt.FieldRangePredicate(field='year', range=[1950, 1960])}
     )
+
+    between_1950_60 = alt.FieldRangePredicate(field="year", range=[1950, 1960])
+
+Then, we can *invert* this selection using ``~``:
+
+.. altair-plot::
+
+    # NOT between 1950-1960
+    chart.transform_filter(~between_1950_60)
+
+We can further refine our filter by *composing* multiple predicates together.
+In this case, using ``alt.datum``:
+
+.. altair-plot::
+
+    chart.transform_filter(~between_1950_60 & (alt.datum.age <= 70))
+
 
 Transform Options
 ^^^^^^^^^^^^^^^^^

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -15,6 +15,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Generic, Literal, TypedDict, TypeVar
 from urllib import request
 
+if sys.version_info >= (3, 14):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
 import vl_convert as vlc
 
 sys.path.insert(0, str(Path.cwd()))

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from itertools import chain
 from operator import attrgetter
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Generic, Literal, TypedDict, TypeVar
 from urllib import request
 
 import vl_convert as vlc
@@ -317,6 +317,18 @@ class _EncodingMixin:
         return copy
 '''
 
+# Enables use of ~, &, | with compositions of selection objects.
+DUNDER_PREDICATE_COMPOSITION = """
+    def __invert__(self) -> PredicateComposition:
+        return PredicateComposition({"not": self.to_dict()})
+
+    def __and__(self, other: SchemaBase) -> PredicateComposition:
+        return PredicateComposition({"and": [self.to_dict(), other.to_dict()]})
+
+    def __or__(self, other: SchemaBase) -> PredicateComposition:
+        return PredicateComposition({"or": [self.to_dict(), other.to_dict()]})
+"""
+
 
 # NOTE: Not yet reasonable to generalize `TypeAliasType`, `TypeVar`
 # Revisit if this starts to become more common
@@ -429,6 +441,37 @@ class SchemaGenerator(codegen.SchemaGenerator):
         {init_code}
     '''
     )
+
+
+class MethodSchemaGenerator(SchemaGenerator):
+    """Base template w/ an extra slot `{method_code}` after `{init_code}`."""
+
+    schema_class_template = textwrap.dedent(
+        '''
+    class {classname}({basename}):
+        """{docstring}"""
+        _schema = {schema!r}
+
+        {init_code}
+
+        {method_code}
+    '''
+    )
+
+
+SchGen = TypeVar("SchGen", bound=SchemaGenerator)
+
+
+class OverridesItem(TypedDict, Generic[SchGen]):
+    tp: type[SchGen]
+    kwds: dict[str, Any]
+
+
+CORE_OVERRIDES: dict[str, OverridesItem[SchemaGenerator]] = {
+    "PredicateComposition": OverridesItem(
+        tp=MethodSchemaGenerator, kwds={"method_code": DUNDER_PREDICATE_COMPOSITION}
+    )
+}
 
 
 class FieldSchemaGenerator(SchemaGenerator):
@@ -656,13 +699,20 @@ def generate_vegalite_schema_wrapper(fp: Path, /) -> str:
         defschema = {"$ref": "#/definitions/" + name}
         defschema_repr = {"$ref": "#/definitions/" + name}
         name = get_valid_identifier(name)
-        definitions[name] = SchemaGenerator(
+        if overrides := CORE_OVERRIDES.get(name):
+            tp = overrides["tp"]
+            kwds = overrides["kwds"]
+        else:
+            tp = SchemaGenerator
+            kwds = {}
+        definitions[name] = tp(
             name,
             schema=defschema,
             schemarepr=defschema_repr,
             rootschema=rootschema,
             basename=basename,
             rootschemarepr=CodeSnippet(f"{basename}._rootschema"),
+            **kwds,
         )
     for name, schema in definitions.items():
         graph[name] = []

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -260,16 +260,20 @@ class SchemaGenerator:
             basename = self.basename
         else:
             basename = ", ".join(self.basename)
+        docstring = self.docstring(indent=4)
+        init_code = self.init_code(indent=4)
+        if type(self).haspropsetters:
+            method_code = self.overload_code(indent=4)
+        else:
+            method_code = self.kwargs.pop("method_code", None)
         return self.schema_class_template.format(
             classname=self.classname,
             basename=basename,
             schema=schemarepr,
             rootschema=rootschemarepr,
-            docstring=self.docstring(indent=4),
-            init_code=self.init_code(indent=4),
-            method_code=(
-                self.overload_code(indent=4) if type(self).haspropsetters else None
-            ),
+            docstring=docstring,
+            init_code=init_code,
+            method_code=method_code,
             **self.kwargs,
         )
 


### PR DESCRIPTION
Resolves #695

# Description
This PR enables the use of logical composition operators (`&`, `|`, `~`) directly on all **12** of:

<details><summary><code>...Predicate</code> classes</summary>
<p>

- `core.FieldEqualPredicate`
- `core.FieldGTEPredicate`
- `core.FieldGTPredicate`
- `core.FieldLTEPredicate`
- `core.FieldLTPredicate`
- `core.FieldOneOfPredicate`
- `core.FieldRangePredicate`
- `core.FieldValidPredicate`
- `core.LogicalAndPredicate`
- `core.LogicalOrPredicate`
- `core.LogicalNotPredicate`
- `core.ParameterPredicate`

</p>
</details> 


It appears this functionality has been desired for some time, but never implemented fully.

`api.SelectionPredicateComposition` already contained the code required to get this working - this PR moves that to `core.PredicateComposition`.

The change is fully backwards compatible, turning the old class into an alias (https://github.com/vega/altair/pull/3668/commits/1dc15b72c01fe47a5b87222d26258eb08b75cdea)

This also provides a cleaner solution to (https://github.com/vega/altair/pull/3664#discussion_r1823177593) - than any of the alternatives documented there

# Example
```py
import altair as alt
from vega_datasets import data

source = data.disasters()
columns_sorted = ["Drought", "Epidemic", "Earthquake", "Flood"]

base = (
    alt.Chart(source, height=200)
    .mark_line(interpolate="monotone")
    .encode(
        x=alt.X("Year:Q").axis(format="d"),
        color="Entity",
        column="Entity",
        y="sum(Deaths)",
    )
)

chart_old = base.transform_filter(
    {
        "and": [
            alt.FieldOneOfPredicate(field="Entity", oneOf=columns_sorted),
            alt.FieldRangePredicate(field="Year", range=[1900, 2000]),
        ]
    }
)

chart_new = base.transform_filter(
    alt.FieldOneOfPredicate(field="Entity", oneOf=columns_sorted)
    & alt.FieldRangePredicate(field="Year", range=[1900, 2000])
)
chart_old & chart_new
```

<details><summary>Output</summary>
<p>

![predicate-composition-dunder](https://github.com/user-attachments/assets/6f6e785e-1faa-4cc4-8226-af389eeac4c2)

</p>
</details> 


# User Guide
![image](https://github.com/user-attachments/assets/0b05b82f-b8d7-4671-af1e-97719792bd67)


# Tasks
- [x] Core implementation & tests ([commits](https://github.com/vega/altair/pull/3668#commits-pushed-c1d05ec))
- [x] Update [User Guide- Logical Operands](https://altair-viz.github.io/user_guide/transform/filter.html#logical-operands) ([commit](https://github.com/vega/altair/pull/3668/commits/dba2b3e26f8a3c965109e581c0c25a0ce90c8485))


# Other Future Work
- I mentioned in (https://github.com/vega/altair/pull/3668/commits/c1d05ec9f1ca5bb7382e746e5d425f98bc5e4643) that something similar could be done for `expr.core.Expression` -> `core.Expr`
	- possibly as part of #3616
- #3505
	- *That* PR features similar functionality via [`_wrap_composition`](https://github.com/dangotbanned/altair/blob/f981130be22250a09b53f33b60b2c833af5028df/altair/vegalite/v5/_api_rfc.py#L95-L96)
	- *This* PR can therefore simplify the implementation there, removing the need for that [extra step](https://github.com/dangotbanned/altair/blob/f981130be22250a09b53f33b60b2c833af5028df/altair/vegalite/v5/_api_rfc.py#L315) entirely 


# Related
- #3664
- https://github.com/vega/altair/pull/3544#issuecomment-2450700954
- https://altair-viz.github.io/user_guide/transform/filter.html#logical-operands
