### PR TITLE
chore: use more robust dtype comparisons, use Narwhals stable API in tests

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -709,11 +709,14 @@ def infer_vegalite_type_for_narwhals(
         and not (categories := column.cat.get_categories()).is_empty()
     ):
         return "ordinal", categories.to_list()
-    if dtype in {nw.String, nw.Categorical, nw.Boolean}:
+    if dtype == nw.String or dtype == nw.Categorical or dtype == nw.Boolean:  # noqa: PLR1714
         return "nominal"
     elif dtype.is_numeric():
         return "quantitative"
-    elif dtype in {nw.Datetime, nw.Date}:
+    elif dtype == nw.Datetime or dtype == nw.Date:  # noqa: PLR1714
+        # We use `== nw.Datetime` to check for any kind of Datetime, regardless of time
+        # unit and time zone. Prefer this over `dtype in {nw.Datetime, nw.Date}`,
+        # see https://narwhals-dev.github.io/narwhals/backcompat.
         return "temporal"
     else:
         msg = f"Unexpected DtypeKind: {dtype}"

--- a/tests/test_transformed_data.py
+++ b/tests/test_transformed_data.py
@@ -7,7 +7,7 @@ from vega_datasets import data
 import altair as alt
 from altair.utils.execeval import eval_block
 from tests import examples_methods_syntax, slow, ignore_DataFrameGroupBy
-import narwhals as nw
+import narwhals.stable.v1 as nw
 
 try:
     import vegafusion as vf


### PR DESCRIPTION
Since Narwhals 1.9.0 (release last month), `nw.Datetime` has `time_unit` and `time_zone` metadata, which means that `hash(nw.Datetime)` has changed.
This change only affects the main Narwhals namespace - the `narwhals.stable.v1` namespace (which you're using 🙌 ) is unaffected

The fact that having `narwhals.stable.v1` allowed us to make this change without it affecting any users is a pretty good feeling 😄 

I've rewritten the dtype comparison from
```
elif dtype in {nw.Datetime, nw.Date}:
```
to
```
elif dtype == nw.Datetime or dtype == nw.Date:
```
so that it will also work in the same way if and when you decide to move to `narwhals.stable.v2` (when we get there). There'll be no obligation to perform such a move of course, we'll keep `stable.v1` working as-is, so either way, **there's no impact on users**

---

See the second bullet point at https://narwhals-dev.github.io/narwhals/backcompat/#after-stablev1 for more context