### PR TITLE
ci: use duckdb instead of ibis to test interchange-only support

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -65,8 +65,9 @@ SampleReturnType = Union[IntoDataFrame, dict[str, Sequence], None]
 
 
 def is_data_type(obj: Any) -> TypeIs[DataType]:
-    return _is_pandas_dataframe(obj) or isinstance(
-        obj, (dict, DataFrameLike, SupportsGeoInterface, nw.DataFrame)
+    return isinstance(obj, (dict, SupportsGeoInterface)) or isinstance(
+        nw.from_native(obj, eager_or_interchange_only=True, strict=False),
+        nw.DataFrame,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ all = [
 dev = [
     "hatch",
     "ruff>=0.6.0",
-    "ibis-framework[polars]",
+    "duckdb>=1.0",
     "ipython[kernel]",
     "pandas>=1.1.3",
     "pytest",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import pkgutil
 import re
+import sys
 from importlib.util import find_spec
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from tests import examples_arguments_syntax, examples_methods_syntax
 
 if TYPE_CHECKING:
-    import sys
-    from collections.abc import Collection, Iterator, Mapping
+    from collections.abc import Callable, Collection, Iterator, Mapping
     from re import Pattern
 
     if sys.version_info >= (3, 11):
@@ -23,6 +24,21 @@ if TYPE_CHECKING:
     MarksType: TypeAlias = (
         "pytest.MarkDecorator | Collection[pytest.MarkDecorator | pytest.Mark]"
     )
+
+
+def windows_has_tzdata() -> bool:
+    """
+    From PyArrow: python/pyarrow/tests/util.py.
+
+    This is the default location where tz.cpp will look for (until we make
+    this configurable at run-time)
+
+    Skip test on Windows when the tz database is not configured.
+
+    See https://github.com/vega/altair/issues/3050.
+    """
+    return (Path.home() / "Downloads" / "tzdata").exists()
+
 
 slow: pytest.MarkDecorator = pytest.mark.slow()
 """
@@ -69,17 +85,37 @@ Applies when `vegafusion`_ import would fail.
 """
 
 
-skip_requires_pyarrow: pytest.MarkDecorator = pytest.mark.skipif(
-    find_spec("pyarrow") is None, reason="`pyarrow` not installed."
-)
-"""
-``pytest.mark.skipif`` decorator.
+def skip_requires_pyarrow(
+    fn: Callable[..., Any] | None = None, /, *, requires_tzdata: bool = False
+) -> Callable[..., Any]:
+    """
+    ``pytest.mark.skipif`` decorator.
 
-Applies when `pyarrow`_ import would fail.
+    Applies when `pyarrow`_ import would fail.
 
-.. _pyarrow:
-   https://pypi.org/project/pyarrow/
-"""
+    Additionally, we mark as expected to fail on `Windows`.
+
+    https://github.com/vega/altair/issues/3050
+
+    .. _pyarrow:
+    https://pypi.org/project/pyarrow/
+    """
+    composed = pytest.mark.skipif(
+        find_spec("pyarrow") is None, reason="`pyarrow` not installed."
+    )
+    if requires_tzdata:
+        composed = pytest.mark.xfail(
+            sys.platform == "win32" and not windows_has_tzdata(),
+            reason="Timezone database is not installed on Windows",
+        )(composed)
+
+    def wrap(test_fn: Callable[..., Any], /) -> Callable[..., Any]:
+        return composed(test_fn)
+
+    if fn is None:
+        return wrap
+    else:
+        return wrap(fn)
 
 
 def id_func_str_only(val) -> str:

--- a/tests/utils/test_to_values_narwhals.py
+++ b/tests/utils/test_to_values_narwhals.py
@@ -1,7 +1,5 @@
 import re
-import sys
 from datetime import datetime
-from pathlib import Path
 
 import narwhals.stable.v1 as nw
 import pandas as pd
@@ -11,23 +9,7 @@ from altair.utils.data import to_values
 from tests import skip_requires_pyarrow
 
 
-def windows_has_tzdata():
-    """
-    From PyArrow: python/pyarrow/tests/util.py.
-
-    This is the default location where tz.cpp will look for (until we make
-    this configurable at run-time)
-    """
-    return Path.home().joinpath("Downloads", "tzdata").exists()
-
-
-# Skip test on Windows when the tz database is not configured.
-# See https://github.com/vega/altair/issues/3050.
-@pytest.mark.skipif(
-    sys.platform == "win32" and not windows_has_tzdata(),
-    reason="Timezone database is not installed on Windows",
-)
-@skip_requires_pyarrow
+@skip_requires_pyarrow(requires_tzdata=True)
 def test_arrow_timestamp_conversion():
     """Test that arrow timestamp values are converted to ISO-8601 strings."""
     import pyarrow as pa

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,6 +1,5 @@
 import io
 import json
-import sys
 
 import narwhals.stable.v1 as nw
 import numpy as np
@@ -121,9 +120,6 @@ def test_sanitize_dataframe_arrow_columns():
 
 
 @skip_requires_pyarrow
-@pytest.mark.xfail(
-    sys.platform == "win32", reason="Timezone database is not installed on Windows"
-)
 def test_sanitize_pyarrow_table_columns() -> None:
     import pyarrow as pa
 

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -1607,7 +1607,7 @@ def test_polars_with_pandas_nor_pyarrow(monkeypatch: pytest.MonkeyPatch):
     assert "numpy" not in sys.modules
 
 
-@skip_requires_pyarrow
+@skip_requires_pyarrow(requires_tzdata=True)
 def test_interchange_with_date_32():
     # Test that objects which Narwhals only supports at the interchange
     # level can be plotted when they contain date32 columns.
@@ -1623,7 +1623,7 @@ def test_interchange_with_date_32():
     ]
 
 
-@skip_requires_pyarrow
+@skip_requires_pyarrow(requires_tzdata=True)
 def test_interchange_with_vegafusion(monkeypatch: pytest.MonkeyPatch):
     # Test that objects which Narwhals only supports at the interchange
     # level don't get converted to PyArrow unnecessarily when plotted


### PR DESCRIPTION
as discussed in https://github.com/vega/altair/pull/3591#issuecomment-2453480628

