### PR TITLE
ci(typing): Add `pyarrow-stubs` to `dev` dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "duckdb>=1.0",
     "ipython[kernel]",
     "pandas>=1.1.3",
+    "pyarrow-stubs",
     "pytest",
     "pytest-cov",
     "pytest-xdist[psutil]~=3.5",

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -140,7 +140,7 @@ def test_sanitize_pyarrow_table_columns() -> None:
     pa_table = pa.Table.from_pandas(
         df,
         pa.schema(
-            [
+            (
                 pa.field("s", pa.string()),
                 pa.field("f", pa.float64()),
                 pa.field("i", pa.int64()),
@@ -148,7 +148,7 @@ def test_sanitize_pyarrow_table_columns() -> None:
                 pa.field("d", pa.date32()),
                 pa.field("c", pa.dictionary(pa.int8(), pa.string())),
                 pa.field("p", pa.timestamp("ns", tz="UTC")),
-            ]
+            )
         ),
     )
     sanitized = sanitize_narwhals_dataframe(nw.from_native(pa_table, eager_only=True))


### PR DESCRIPTION
Related https://github.com/vega/altair/commit/0bb4210b5aa5ff22c345946a8e73a432373529ff

In #3631 this stub package has been a huge help in understanding `pyarrow`.


Wanted to split out this dev dependency change for visibility.

Also, the 1 minor change to satisfy `mypy` on a test:

```py
tests\utils\test_utils.py:143: error: Argument 1 to "schema" has incompatible type "list[object]"; expected "Iterable[Field[Any]] | Iterable[tuple[str, DataType]] | Mapping[str, DataType]"  [arg-type]
```