### PR TITLE
chore: Prep for VegaFusion 2.0

### DIFF
--- a/altair/utils/_importers.py
+++ b/altair/utils/_importers.py
@@ -15,18 +15,21 @@ def import_vegafusion() -> ModuleType:
         import vegafusion as vf
 
         version = importlib_version("vegafusion")
-        embed_version = importlib_version("vegafusion-python-embed")
-        if version != embed_version or Version(version) < Version(min_version):
-            msg = (
-                "The versions of the vegafusion and vegafusion-python-embed packages must match\n"
-                f"and must be version {min_version} or greater.\n"
-                f"Found:\n"
-                f" - vegafusion=={version}\n"
-                f" - vegafusion-python-embed=={embed_version}\n"
-            )
-            raise RuntimeError(msg)
-
-        return vf
+        if Version(version) >= Version("2.0.0a0"):
+            # In VegaFusion 2.0 there is no vegafusion-python-embed package
+            return vf
+        else:
+            embed_version = importlib_version("vegafusion-python-embed")
+            if version != embed_version or Version(version) < Version(min_version):
+                msg = (
+                    "The versions of the vegafusion and vegafusion-python-embed packages must match\n"
+                    f"and must be version {min_version} or greater.\n"
+                    f"Found:\n"
+                    f" - vegafusion=={version}\n"
+                    f" - vegafusion-python-embed=={embed_version}\n"
+                )
+                raise RuntimeError(msg)
+            return vf
     except ImportError as err:
         msg = (
             'The "vegafusion" data transformer and chart.transformed_data feature requires\n'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ all = [
     "pandas>=1.1.3",
     "numpy",
     "pyarrow>=11",
-    "vegafusion[embed]>=1.6.6,<2",
+    "vegafusion[embed]>=1.6.6",
     "anywidget>=0.9.0",
     "altair_tiles>=0.3.0"
 ]


### PR DESCRIPTION
Small update that supersedes https://github.com/vega/altair/pull/3638.  VegaFusion 2.0 isn't going to break any of the functionality that Altair depends on, so the only update needed is to not check for the `vegafusion-python-embed` package when the `vegafusion` package is >2 (becuase the functionality this is being merged into the vegafusion package).

In terms of sequencing, I want this update to be released in Altair before I publish VegaFusion 2.0 so that installing `altair[all]` will never pull in a version of VegaFusion that's not compatible with altair.