### PR TITLE
refactor: Replace unconditional `typing_extensions` imports

### DIFF
--- a/altair/utils/_transformed_data.py
+++ b/altair/utils/_transformed_data.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, overload
-from typing_extensions import TypeAlias
 
 from altair import (
     Chart,
@@ -31,7 +30,13 @@ from altair.utils._vegafusion_data import get_inline_tables, import_vegafusion
 from altair.utils.schemapi import Undefined
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Iterable
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
     from altair.typing import ChartType
     from altair.utils.core import DataFrameLike

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -12,14 +12,11 @@ from typing import (
     Any,
     Callable,
     Literal,
-    Protocol,
     TypedDict,
     TypeVar,
     Union,
     overload,
-    runtime_checkable,
 )
-from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
 import narwhals.stable.v1 as nw
 from narwhals.dependencies import is_pandas_dataframe as _is_pandas_dataframe
@@ -36,11 +33,24 @@ from .core import (
 from .plugin_registry import PluginRegistry
 
 if sys.version_info >= (3, 13):
-    from typing import TypeIs
+    from typing import Protocol, runtime_checkable
 else:
-    from typing_extensions import TypeIs
+    from typing_extensions import Protocol, runtime_checkable
+if sys.version_info >= (3, 10):
+    from typing import Concatenate, ParamSpec
+else:
+    from typing_extensions import Concatenate, ParamSpec
 
 if TYPE_CHECKING:
+    if sys.version_info >= (3, 13):
+        from typing import TypeIs
+    else:
+        from typing_extensions import TypeIs
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
     import pandas as pd
     import pyarrow as pa
 

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -4,13 +4,20 @@ import json
 import pkgutil
 import textwrap
 import uuid
-from typing import Any, Callable, Union
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, Union
 
 from ._vegafusion_data import compile_with_vegafusion, using_vegafusion
 from .mimebundle import spec_to_mimebundle
 from .plugin_registry import PluginEnabler, PluginRegistry
 from .schemapi import validate_jsonschema
+
+if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
 # ==============================================================================
 # Renderer registry

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import struct
-from typing import Any, Literal, cast, overload
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from ._importers import import_vl_convert, vl_version_for_vl_convert
 from .html import spec_to_html
+
+if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
 MimeBundleFormat: TypeAlias = Literal[
     "html", "json", "png", "svg", "pdf", "vega", "vega-lite"

--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+import sys
 from functools import partial
 from importlib.metadata import entry_points
-from typing import TYPE_CHECKING, Any, Callable, Generic, cast
-from typing_extensions import TypeAliasType, TypeIs, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, cast
 
 from altair.utils.deprecation import deprecated_warn
+
+if sys.version_info >= (3, 13):
+    from typing import TypeIs
+else:
+    from typing_extensions import TypeIs
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+else:
+    from typing_extensions import TypeAliasType
 
 if TYPE_CHECKING:
     from types import TracebackType


### PR DESCRIPTION
# Related
- https://github.com/vega/altair/pull/3591
- https://github.com/vega/altair/issues/3620
- https://github.com/vega/altair/pull/3593
- https://github.com/vega/altair/issues/3615

# Description
This PR moves the remaining `typing_extensions` imports into version-gated blocks.

I'd been doing this over the past month or so in any PRs that I noticed them in, but these are the last ones.

For anyone new to this issue, this aligns with the dependency spec listed in:

https://github.com/vega/altair/blob/1d576a8e3b8b47bdeae92f09d1733a93afd49fbd/pyproject.toml#L14-L18