### PR TITLE
refactor: distinct Olli renderer template

### DIFF
--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -390,7 +390,6 @@ def spec_to_html(
         OLLI_ADAPTERS_VERSION = "2"
         render_kwargs["olli_version"] = OLLI_VERSION
         render_kwargs["olli_adapters_version"] = OLLI_ADAPTERS_VERSION
-        #render_kwargs["use_olli"] = True
 
     jinja_template = TEMPLATES.get(template, template)  # type: ignore[arg-type]
     if not hasattr(jinja_template, "render"):


### PR DESCRIPTION
Follow-up of https://github.com/vega/altair/pull/3580.

I prefer to keep the `HTML_TEMPLATE_UNIVERSAL` template as is and introduce a distinct `HTML_TEMPLATE_OLLI` template for the olli renderer. Since the universal template is widely used across notebooks for almost every chart, I’d prefer to avoid mixing it with conditional jinja2 orJavaScript statements, especially when they can be avoided relatively easily.

I deeply respect those that have to rely on this type of assistive technologies to browse the Internet, for me it is easy to get lost in controls without vison.
