### PR TITLE
chore: bump narwhals to v1.13.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # If you update the minimum required jsonschema version, also update it in build.yml
     "jsonschema>=3.0",
     "packaging",
-    "narwhals>=1.5.2"
+    "narwhals>=1.13.1"
 ]
 description = "Vega-Altair: A declarative statistical visualization library for Python."
 readme = "README.md"


### PR DESCRIPTION
fix https://github.com/vega/altair/issues/3688.

The mxing of direct import and stable.v1 import of narwhals modules is not included in this PR.