### PR TITLE
ci: fix ci warning for pivot.rst

### DIFF
--- a/doc/user_guide/transform/pivot.rst
+++ b/doc/user_guide/transform/pivot.rst
@@ -43,18 +43,18 @@ values on multiple lines:
 
 .. altair-plot::
 
-    import altair as alt
-    from vega_datasets import data
+   import altair as alt
+   from vega_datasets import data
 
-    source = data.stocks()
-    base = alt.Chart(source).encode(x='date:T')
-    columns = sorted(source.symbol.unique())
-    selection = alt.selection_point(
-        fields=['date'], nearest=True, on='pointerover', empty=False, clear='pointerout'
-    )
+   source = data.stocks()
+   base = alt.Chart(source).encode(x='date:T')
+   columns = sorted(source.symbol.unique())
+   selection = alt.selection_point(
+       fields=['date'], nearest=True, on='pointerover', empty=False, clear='pointerout'
+   )
 
-    lines = base.mark_line().encode(y='price:Q', color='symbol:N')
-    points = lines.mark_point().transform_filter(selection)
+   lines = base.mark_line().encode(y='price:Q', color='symbol:N')
+   points = lines.mark_point().transform_filter(selection)
 
    rule = base.transform_pivot(
        'symbol', value='price', groupby=['date']
@@ -63,7 +63,7 @@ values on multiple lines:
        tooltip=[alt.Tooltip(c, type='quantitative') for c in columns]
    ).add_params(selection)
 
-    lines + points + rule
+   lines + points + rule
 
 
 Transform Options


### PR DESCRIPTION
This warning appeared in the CI:
```cmd
/home/runner/.local/share/hatch/env/virtual/altair/801ceKDt/doc/lib/python3.12/site-packages/sphinxext_altair/altairplot.py:261: UserWarning: altair-plot: /home/runner/work/altair/altair/doc/user_guide/transform/pivot.rst:44 Code Execution failed:IndentationError: unexpected indent (<ast>, line 1)
  warnings.warn(message, stacklevel=1)
```

It's because indentation is currently mixed.