### PR TITLE
chore: bump narwhals to v1.14.2

### DIFF
--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -7,8 +7,8 @@ import warnings
 from importlib.util import find_spec
 from typing import Any
 
-import narwhals.stable.v1 as nw
 from IPython.core import magic_arguments
+from narwhals.stable.v1.dependencies import is_pandas_dataframe
 
 from altair.vegalite import v5 as vegalite_v5
 
@@ -32,7 +32,7 @@ def _prepare_data(data, data_transformers):
     """Convert input data to data for use within schema."""
     if data is None or isinstance(data, dict):
         return data
-    elif nw.dependencies.is_pandas_dataframe(data):
+    elif is_pandas_dataframe(data):
         if func := data_transformers.get():
             data = func(data)
         return data

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -5,7 +5,7 @@ from importlib.metadata import version as importlib_version
 from typing import TYPE_CHECKING, Any, Callable, Final, TypedDict, Union, overload
 from weakref import WeakValueDictionary
 
-import narwhals.stable.v1 as nw
+from narwhals.stable.v1.dependencies import is_into_dataframe
 from packaging.version import Version
 
 from altair.utils._importers import import_vegafusion
@@ -54,9 +54,7 @@ if VEGAFUSION_VERSION and Version("2.0.0a0") <= VEGAFUSION_VERSION:
     def is_supported_by_vf(data: Any) -> TypeIs[DataFrameLike]:
         # Test whether VegaFusion supports the data type
         # VegaFusion v2 support narwhals-compatible DataFrames
-        return isinstance(data, DataFrameLike) or nw.dependencies.is_into_dataframe(
-            data
-        )
+        return isinstance(data, DataFrameLike) or is_into_dataframe(data)
 
 else:
 

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, cast, overloa
 
 import jsonschema
 import narwhals.stable.v1 as nw
+from narwhals.stable.v1.dependencies import is_pandas_dataframe, is_polars_dataframe
 from narwhals.stable.v1.typing import IntoDataFrame
 
 from altair.utils.schemapi import SchemaBase, SchemaLike, Undefined
@@ -469,9 +470,9 @@ def sanitize_narwhals_dataframe(
     columns: list[IntoExpr] = []
     # See https://github.com/vega/altair/issues/1027 for why this is necessary.
     local_iso_fmt_string = "%Y-%m-%dT%H:%M:%S"
-    is_polars_dataframe = nw.dependencies.is_polars_dataframe(data.to_native())
+    is_polars = is_polars_dataframe(data.to_native())
     for name, dtype in schema.items():
-        if dtype == nw.Date and is_polars_dataframe:
+        if dtype == nw.Date and is_polars:
             # Polars doesn't allow formatting `Date` with time directives.
             # The date -> datetime cast is extremely fast compared with `to_string`
             columns.append(
@@ -673,7 +674,7 @@ def parse_shorthand(  # noqa: C901
             if schema[unescaped_field] in {
                 nw.Object,
                 nw.Unknown,
-            } and nw.dependencies.is_pandas_dataframe(data_nw.to_native()):
+            } and is_pandas_dataframe(data_nw.to_native()):
                 attrs["type"] = infer_vegalite_type_for_pandas(column.to_native())
             else:
                 attrs["type"] = infer_vegalite_type_for_narwhals(column)

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 import narwhals.stable.v1 as nw
+from narwhals.stable.v1.dependencies import is_pandas_dataframe
 from narwhals.stable.v1.typing import IntoDataFrame
 
 from ._importers import import_pyarrow_interchange
@@ -187,7 +188,7 @@ def sample(
     if data is None:
         return partial(sample, n=n, frac=frac)
     check_data_type(data)
-    if nw.dependencies.is_pandas_dataframe(data):
+    if is_pandas_dataframe(data):
         return data.sample(n=n, frac=frac)
     elif isinstance(data, dict):
         if "values" in data:
@@ -322,7 +323,7 @@ def to_values(data: DataType) -> ToValuesReturnType:
     data_native = nw.to_native(data, pass_through=True)
     if isinstance(data_native, SupportsGeoInterface):
         return {"values": _from_geo_interface(data_native)}
-    elif nw.dependencies.is_pandas_dataframe(data_native):
+    elif is_pandas_dataframe(data_native):
         data_native = sanitize_pandas_dataframe(data_native)
         return {"values": data_native.to_dict(orient="records")}
     elif isinstance(data_native, dict):
@@ -363,7 +364,7 @@ def _from_geo_interface(data: SupportsGeoInterface | Any) -> dict[str, Any]:
     - ``typing.TypeGuard``
     - ``pd.DataFrame.__getattr__``
     """
-    if nw.dependencies.is_pandas_dataframe(data):
+    if is_pandas_dataframe(data):
         data = sanitize_pandas_dataframe(data)
     return sanitize_geo_interface(data.__geo_interface__)
 
@@ -373,7 +374,7 @@ def _data_to_json_string(data: DataType) -> str:
     check_data_type(data)
     if isinstance(data, SupportsGeoInterface):
         return json.dumps(_from_geo_interface(data))
-    elif nw.dependencies.is_pandas_dataframe(data):
+    elif is_pandas_dataframe(data):
         data = sanitize_pandas_dataframe(data)
         return data.to_json(orient="records", double_precision=15)
     elif isinstance(data, dict):
@@ -400,7 +401,7 @@ def _data_to_csv_string(data: DataType) -> str:
             f"See https://github.com/vega/altair/issues/3441"
         )
         raise NotImplementedError(msg)
-    elif nw.dependencies.is_pandas_dataframe(data):
+    elif is_pandas_dataframe(data):
         data = sanitize_pandas_dataframe(data)
         return data.to_csv(index=False)
     elif isinstance(data, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # If you update the minimum required jsonschema version, also update it in build.yml
     "jsonschema>=3.0",
     "packaging",
-    "narwhals>=1.13.1"
+    "narwhals>=1.14.2"
 ]
 description = "Vega-Altair: A declarative statistical visualization library for Python."
 readme = "README.md"


### PR DESCRIPTION
This PR updates pyproject.toml to update narwhals to v1.14.2.
Note: v1.14.2 is not yet on conda-forge (https://anaconda.org/conda-forge/narwhals/files)