### PR TITLE
chore: fix `ruff`, `mypy` warnings

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -325,7 +325,7 @@ def numpy_is_subtype(dtype: Any, subtype: Any) -> bool:
     import numpy as np
 
     try:
-        return np.issubdtype(dtype, subtype)
+        return cast("bool", np.issubdtype(dtype, subtype))
     except (NotImplementedError, TypeError):
         return False
 

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -336,7 +336,7 @@ def _validate_normalize_engine(
 
 def _pngxy(data):
     """
-    read the (width, height) from a PNG header.
+    Read the (width, height) from a PNG header.
 
     Taken from IPython.display
     """

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -723,7 +723,7 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
         max_column_width = 80
         # Output a square table if not too big (since it is easier to read)
         num_param_names = len(param_names)
-        square_columns = int(ceil(num_param_names**0.5))
+        square_columns = ceil(num_param_names**0.5)
         columns = min(max_column_width // max_name_length, square_columns)
 
         # Compute roughly equal column heights to evenly divide the param names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ all = [
 ]
 dev = [
     "hatch>=1.13.0",
-    "ruff>=0.6.0",
+    "ruff>=0.8.4",
     "duckdb>=1.0",
     "ipython[kernel]",
     "pandas>=1.1.3",
@@ -341,6 +341,8 @@ ignore = [
     "B905",
     # mutable-class-default
     "RUF012",
+    # used-dummy-variable
+    "RUF052",
     # suppressible-exception
     # https://github.com/vega/altair/pull/3431#discussion_r1629808660
     "SIM105",

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -177,7 +177,7 @@ def test_sanitize_dataframe_colnames():
 
     # Test that non-string columns result in an error
     df.columns = [4, "foo", "bar"]
-    with pytest.raises(ValueError, match="Dataframe contains invalid column name: 4."):
+    with pytest.raises(ValueError, match=r"Dataframe contains invalid column name: 4."):
         sanitize_pandas_dataframe(df)
 
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -721,7 +721,7 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
         max_column_width = 80
         # Output a square table if not too big (since it is easier to read)
         num_param_names = len(param_names)
-        square_columns = int(ceil(num_param_names**0.5))
+        square_columns = ceil(num_param_names**0.5)
         columns = min(max_column_width // max_name_length, square_columns)
 
         # Compute roughly equal column heights to evenly divide the param names


### PR DESCRIPTION
Updating my env revealed a range of *minor* issues.

## `ruff`
I'm ignoring (`RUF052`[https://docs.astral.sh/ruff/rules/used-dummy-variable/]), which is a new rule I wouldn't have selected.

```cmd
hatch run ruff check --statistics
17     RUF052  [*] used-dummy-variable
 2      RUF046  [*] unnecessary-cast-to-int
 1      D403    [*] first-word-uncapitalized
 1      RUF043  [ ] pytest-raises-ambiguous-pattern
[*] fixable with `ruff check --fix`
```

## `mypy`
Not sure where `numpy.bool[builtins.bool]` is coming from, didn't see it in the stubs

```py
altair\utils\core.py:328: error: Incompatible return value type (got "numpy.bool[builtins.bool]", expected "builtins.bool")  [return-value]
            return np.issubdtype(dtype, subtype)
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 381 source files)
```