### PR TITLE
ci(typing): Add bundled stubs to `pyright.ignore`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -476,4 +476,5 @@ ignore=[
     "./altair/jupyter/",                        # Mostly untyped
     "./tests/test_jupyter_chart.py",            # Based on untyped module
     "../../../**/Lib",                          # stdlib
+    "../../../**/typeshed*"                     # typeshed-fallback
 ]


### PR DESCRIPTION
The source of these warnings is [typeshed's config](https://github.com/python/typeshed/blob/2cdda12df78275b98a5d3cdc8a92f93d596d9d5d/pyrightconfig.json).

The new ignore pattern prevents the warnings that were ignored upstream from popping up here.

## Examples
![image](https://github.com/user-attachments/assets/5200f571-91ef-4571-8c8e-5620c237793a)


