### PR TITLE
chore(typing): fix `mypy>=1.14.0` warnings

### DIFF
--- a/tools/markup.py
+++ b/tools/markup.py
@@ -68,8 +68,11 @@ class RSTParse(_Markdown):
         super().__init__(renderer, block, inline, plugins)
 
     def __call__(self, s: str) -> str:
-        s = super().__call__(s)  # pyright: ignore[reportAssignmentType]
-        return unescape(s).replace(r"\ ,", ",").replace(r"\ ", " ")
+        r = super().__call__(s)
+        if isinstance(r, str):
+            return unescape(r).replace(r"\ ,", ",").replace(r"\ ", " ")
+        msg = f"Expected `str` but got {type(r).__name__!r}"
+        raise TypeError(msg)
 
     def render_tokens(self, tokens: Iterable[Token], /) -> str:
         """


### PR DESCRIPTION
Resolves 2 new warnings that appeared after updating my env.

## Warnings

```py
tools/markup.py:71: error: Incompatible types in assignment (expression has type "str | list[dict[str, Any]]", variable has type "str")  [assignment]
            s = super().__call__(s)  # pyright: ignore[reportAssignmentType]
                ^~~~~~~~~~~~~~~~~~~
tools/markup.py:158: error: Incompatible return value type (got "str | list[dict[str, Any]]", expected "list[dict[str, Any]]")  [return-value]
        return tokens[0]
               ^~~~~~~~~
Found 2 errors in 1 file (checked 11 source files)
```

## Additional
The second warning reminded me of (https://github.com/vega/altair/discussions/3687#discussioncomment-11360253), so I've done some tidying up and opened a PR upstream
-  https://github.com/vega/vega/pull/3996