### PR TITLE
chore(ruff): Fix `UP006` warnings during codegen

### DIFF
--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -753,7 +753,8 @@ def generate_vegalite_schema_wrapper(fp: Path, /) -> ModuleDef[str]:
     all_ = [*sorted(it), "Root", "VegaLiteSchema", "SchemaBase", "load_schema"]
     contents = [
         HEADER,
-        "from typing import Any, Literal, Union, Protocol, Sequence, List, Iterator, TYPE_CHECKING",
+        "from collections.abc import Iterator, Sequence",
+        "from typing import Any, Literal, Union, Protocol, TYPE_CHECKING",
         "import pkgutil",
         "import json\n",
         "import narwhals.stable.v1 as nw\n",
@@ -871,7 +872,8 @@ def generate_vegalite_channel_wrappers(fp: Path, /) -> ModuleDef[list[str]]:
     all_ = sorted(chain(it, COMPAT_EXPORTS))
     imports = [
         "import sys",
-        "from typing import Any, overload, Sequence, List, Literal, Union, TYPE_CHECKING, TypedDict",
+        "from collections.abc import Sequence",
+        "from typing import Any, overload, Literal, Union, TYPE_CHECKING, TypedDict",
         import_typing_extensions((3, 10), "TypeAlias"),
         "import narwhals.stable.v1 as nw",
         "from altair.utils.schemapi import Undefined, with_property_setters",
@@ -1226,7 +1228,8 @@ def vegalite_main(skip_download: bool = False) -> None:
     fp_mixins = schemapath / "mixins.py"
     print(f"Generating\n {schemafile!s}\n  ->{fp_mixins!s}")
     mixins_imports = (
-        "from typing import Any, Sequence, List, Literal, Union",
+        "from collections.abc import Sequence",
+        "from typing import Any, Literal, Union",
         "from altair.utils import use_signature, Undefined, SchemaBase",
         "from . import core",
     )
@@ -1256,7 +1259,8 @@ def vegalite_main(skip_download: bool = False) -> None:
     fp_theme_config: Path = schemapath / "_config.py"
     content_theme_config = [
         HEADER,
-        "from typing import Any, TYPE_CHECKING, Literal, Sequence, TypedDict, Union",
+        "from collections.abc import Sequence",
+        "from typing import Any, TYPE_CHECKING, Literal, TypedDict, Union",
         import_typing_extensions((3, 14), "TypedDict", include_sys=True),
         f"from ._typing import {ROW_COL_KWDS}, {PADDING_KWDS}",
         "\n\n",

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -124,7 +124,8 @@ class _TypeAliasTracer:
             "from __future__ import annotations\n",
             "import sys",
             "from datetime import date, datetime",
-            "from typing import Annotated, Any, Generic, Literal, Mapping, TypeVar, Sequence, Union, get_args",
+            "from collections.abc import Sequence, Mapping",
+            "from typing import Annotated, Any, Generic, Literal, TypeVar, Union, get_args",
             "import re",
             import_typing_extensions(
                 (3, 14), "TypedDict", reason="https://peps.python.org/pep-0728/"


### PR DESCRIPTION
Even after #3736, this still produced over 2k warnings in the logs

- https://github.com/vega/altair/actions/runs/12583082774/job/35069916892#step:9:39
- https://github.com/vega/altair/actions/runs/12583082774/job/35069916892#step:9:2811

> error: Failed to create fix for NonPEP585Annotation: Unable to insert `Sequence` into scope due to name conflict