### PR TITLE
fix: Include `*(Datum|Value)` in `SchemaValidationError`

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -701,15 +701,15 @@ Existing parameter names are:
 See the help for `{altair_cls.__name__}` to read the full description of these parameters"""
         return message
 
-    def _maybe_channel(self, tp: type[Any], candidate: str, obj: Any) -> type[Any]:
+    def _maybe_channel(self, tp: type[Any], candidate: str, spec: Any) -> type[Any]:
         """https://github.com/vega/altair/issues/2913#issuecomment-2571762700."""
         vl = vegalite
         channel_attrs = "datum", "value"
-        if isinstance(obj, dict) and not (set(channel_attrs).isdisjoint(obj)):
+        if isinstance(spec, dict) and not (set(channel_attrs).isdisjoint(spec)):
             it: Iterator[type[Any]] = (
                 narrower
                 for chan in channel_attrs
-                if chan in obj
+                if chan in spec
                 and (narrower := getattr(vl, f"{candidate}{chan.capitalize()}", None))
             )
             return next(it, tp)

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -739,6 +739,9 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
         Try to get the lowest class possible in the chart hierarchy so it can be displayed in the error message.
 
         This should lead to more informative error messages pointing the user closer to the source of the issue.
+
+        If we did not find a suitable class based on traversing the path so we fall
+        back on the class of the top-level object which created the SchemaValidationError
         """
         from altair import vegalite
 
@@ -747,14 +750,8 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
             if isinstance(prop_name, str):
                 candidate = prop_name[0].upper() + prop_name[1:]
                 if tp := getattr(vegalite, candidate, None):
-                    cls = _maybe_channel(tp, self.instance)
-                    break
-        else:
-            # Did not find a suitable class based on traversing the path so we fall
-            # back on the class of the top-level object which created
-            # the SchemaValidationError
-            cls = self.obj.__class__
-        return cls
+                    return _maybe_channel(tp, self.instance)
+        return type(self.obj)
 
     @staticmethod
     def _format_params_as_table(param_dict_keys: Iterable[str]) -> str:

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -698,7 +698,8 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
 
     def _maybe_channel(self, tp: type[Any], candidate: str, spec: Any) -> type[Any]:
         """https://github.com/vega/altair/issues/2913#issuecomment-2571762700."""
-        vl = vegalite
+        from altair import vegalite as vl
+
         channel_attrs = "datum", "value"
         if isinstance(spec, dict) and not (set(channel_attrs).isdisjoint(spec)):
             it: Iterator[type[Any]] = (

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -812,15 +812,14 @@ chart_funcs_error_message: list[tuple[Callable[..., Any], str]] = [
     ),
     (
         chart_error_example__additional_datum_argument,
-        r"""`X` has no parameter named 'wrong_argument'
+        r"""`XDatum` has no parameter named 'wrong_argument'
 
                 Existing parameter names are:
-                shorthand      bin      scale   timeUnit   
-                aggregate      field    sort    title      
-                axis           impute   stack   type       
-                bandPosition                               
+                datum          impute   title   
+                axis           scale    type    
+                bandPosition   stack            
 
-                See the help for `X` to read the full description of these parameters$""",
+                See the help for `XDatum` to read the full description of these parameters$""",
     ),
     (
         chart_error_example__invalid_value_type,

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -522,6 +522,11 @@ def chart_error_example__additional_datum_argument():
     return alt.Chart().mark_point().encode(x=alt.datum(1, wrong_argument=1))
 
 
+def chart_error_example__additional_value_argument():
+    # Error: `ColorValue` has no parameter named 'predicate'
+    return alt.Chart().mark_point().encode(color=alt.value("red", predicate=True))
+
+
 def chart_error_example__invalid_value_type():
     # Error: Value cannot be an integer in this case
     return (
@@ -820,6 +825,15 @@ chart_funcs_error_message: list[tuple[Callable[..., Any], str]] = [
                 bandPosition   stack            
 
                 See the help for `XDatum` to read the full description of these parameters$""",
+    ),
+    (
+        chart_error_example__additional_value_argument,
+        r"""`ColorValue` has no parameter named 'predicate'
+
+                Existing parameter names are:
+                value   condition   
+
+                See the help for `ColorValue` to read the full description of these parameters$""",
     ),
     (
         chart_error_example__invalid_value_type,

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -696,7 +696,8 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
 
     def _maybe_channel(self, tp: type[Any], candidate: str, spec: Any) -> type[Any]:
         """https://github.com/vega/altair/issues/2913#issuecomment-2571762700."""
-        vl = vegalite
+        from altair import vegalite as vl
+
         channel_attrs = "datum", "value"
         if isinstance(spec, dict) and not (set(channel_attrs).isdisjoint(spec)):
             it: Iterator[type[Any]] = (

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -699,15 +699,15 @@ Existing parameter names are:
 See the help for `{altair_cls.__name__}` to read the full description of these parameters"""
         return message
 
-    def _maybe_channel(self, tp: type[Any], candidate: str, obj: Any) -> type[Any]:
+    def _maybe_channel(self, tp: type[Any], candidate: str, spec: Any) -> type[Any]:
         """https://github.com/vega/altair/issues/2913#issuecomment-2571762700."""
         vl = vegalite
         channel_attrs = "datum", "value"
-        if isinstance(obj, dict) and not (set(channel_attrs).isdisjoint(obj)):
+        if isinstance(spec, dict) and not (set(channel_attrs).isdisjoint(spec)):
             it: Iterator[type[Any]] = (
                 narrower
                 for chan in channel_attrs
-                if chan in obj
+                if chan in spec
                 and (narrower := getattr(vl, f"{candidate}{chan.capitalize()}", None))
             )
             return next(it, tp)

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -699,6 +699,20 @@ Existing parameter names are:
 See the help for `{altair_cls.__name__}` to read the full description of these parameters"""
         return message
 
+    def _maybe_channel(self, tp: type[Any], candidate: str, obj: Any) -> type[Any]:
+        """https://github.com/vega/altair/issues/2913#issuecomment-2571762700."""
+        vl = vegalite
+        channel_attrs = "datum", "value"
+        if isinstance(obj, dict) and not (set(channel_attrs).isdisjoint(obj)):
+            it: Iterator[type[Any]] = (
+                narrower
+                for chan in channel_attrs
+                if chan in obj
+                and (narrower := getattr(vl, f"{candidate}{chan.capitalize()}", None))
+            )
+            return next(it, tp)
+        return tp
+
     def _get_altair_class_for_error(
         self, error: jsonschema.exceptions.ValidationError
     ) -> type[SchemaBase]:
@@ -710,9 +724,9 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
         for prop_name in reversed(error.absolute_path):
             # Check if str as e.g. first item can be a 0
             if isinstance(prop_name, str):
-                potential_class_name = prop_name[0].upper() + prop_name[1:]
-                cls = getattr(vegalite, potential_class_name, None)
-                if cls is not None:
+                candidate = prop_name[0].upper() + prop_name[1:]
+                if tp := getattr(vegalite, candidate, None):
+                    cls = self._maybe_channel(tp, candidate, self.instance)
                     break
         else:
             # Did not find a suitable class based on traversing the path so we fall

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -737,6 +737,9 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
         Try to get the lowest class possible in the chart hierarchy so it can be displayed in the error message.
 
         This should lead to more informative error messages pointing the user closer to the source of the issue.
+
+        If we did not find a suitable class based on traversing the path so we fall
+        back on the class of the top-level object which created the SchemaValidationError
         """
         from altair import vegalite
 
@@ -745,14 +748,8 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
             if isinstance(prop_name, str):
                 candidate = prop_name[0].upper() + prop_name[1:]
                 if tp := getattr(vegalite, candidate, None):
-                    cls = _maybe_channel(tp, self.instance)
-                    break
-        else:
-            # Did not find a suitable class based on traversing the path so we fall
-            # back on the class of the top-level object which created
-            # the SchemaValidationError
-            cls = self.obj.__class__
-        return cls
+                    return _maybe_channel(tp, self.instance)
+        return type(self.obj)
 
     @staticmethod
     def _format_params_as_table(param_dict_keys: Iterable[str]) -> str:

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -590,6 +590,42 @@ def _validator_values(errors: Iterable[ValidationError], /) -> Iterator[str]:
         yield cast("str", err.validator_value)
 
 
+def _iter_channels(tp: type[Any], spec: Mapping[str, Any], /) -> Iterator[type[Any]]:
+    from altair import vegalite
+
+    for channel_type in ("datum", "value"):
+        if channel_type in spec:
+            name = f"{tp.__name__}{channel_type.capitalize()}"
+            if narrower := getattr(vegalite, name, None):
+                yield narrower
+
+
+def _is_channel(obj: Any) -> TypeIs[dict[str, Any]]:
+    props = {"datum", "value"}
+    return (
+        _is_dict(obj)
+        and all(isinstance(k, str) for k in obj)
+        and not (props.isdisjoint(obj))
+    )
+
+
+def _maybe_channel(tp: type[Any], spec: Any, /) -> type[Any]:
+    """
+    Replace a channel type with a `more specific`_ one or passthrough unchanged.
+
+    Parameters
+    ----------
+    tp
+        An imported ``SchemaBase`` class.
+    spec
+        The instance that failed validation.
+
+    .. _more specific:
+        https://github.com/vega/altair/issues/2913#issuecomment-2571762700
+    """
+    return next(_iter_channels(tp, spec), tp) if _is_channel(spec) else tp
+
+
 class SchemaValidationError(jsonschema.ValidationError):
     _JS_TO_PY: ClassVar[Mapping[str, str]] = {
         "boolean": "bool",
@@ -694,21 +730,6 @@ Existing parameter names are:
 See the help for `{altair_cls.__name__}` to read the full description of these parameters"""
         return message
 
-    def _maybe_channel(self, tp: type[Any], candidate: str, spec: Any) -> type[Any]:
-        """https://github.com/vega/altair/issues/2913#issuecomment-2571762700."""
-        from altair import vegalite as vl
-
-        channel_attrs = "datum", "value"
-        if isinstance(spec, dict) and not (set(channel_attrs).isdisjoint(spec)):
-            it: Iterator[type[Any]] = (
-                narrower
-                for chan in channel_attrs
-                if chan in spec
-                and (narrower := getattr(vl, f"{candidate}{chan.capitalize()}", None))
-            )
-            return next(it, tp)
-        return tp
-
     def _get_altair_class_for_error(
         self, error: jsonschema.exceptions.ValidationError
     ) -> type[SchemaBase]:
@@ -724,7 +745,7 @@ See the help for `{altair_cls.__name__}` to read the full description of these p
             if isinstance(prop_name, str):
                 candidate = prop_name[0].upper() + prop_name[1:]
                 if tp := getattr(vegalite, candidate, None):
-                    cls = self._maybe_channel(tp, candidate, self.instance)
+                    cls = _maybe_channel(tp, self.instance)
                     break
         else:
             # Did not find a suitable class based on traversing the path so we fall


### PR DESCRIPTION
Fixes #2913

# Examples
```py
import altair as alt

>>> alt.Chart().mark_point().encode(x=alt.datum(1, wrong_argument=1))
SchemaValidationError: `XDatum` has no parameter named 'wrong_argument'

Existing parameter names are:
datum          impute   title   
axis           scale    type    
bandPosition   stack            

See the help for `XDatum` to read the full description of these parameters
```

```py
import altair as alt

>>> alt.Chart().mark_point().encode(color=alt.value("red", predicate=True))
SchemaValidationError: `ColorValue` has no parameter named 'predicate'

Existing parameter names are:
value   condition   

See the help for `ColorValue` to read the full description of these parameters
```

# Tasks
- [x] Demonstrate on existing tests (https://github.com/vega/altair/pull/3750/commits/8fb2661555ff9f70db381b27506fdb3eb31b5a6d)
- [x] Add/Update tests (https://github.com/vega/altair/pull/3750/commits/8fb2661555ff9f70db381b27506fdb3eb31b5a6d), (https://github.com/vega/altair/pull/3750/commits/1d6c84488633b680c4bc486933c53efbbd4bb28c)
- [x] Clean up new `SchemaValidationError` code ([commits](https://github.com/vega/altair/pull/3750#commits-pushed-45a42c2))

# Future Work
- #3752 