### PR TITLE
ci: Unpin `pillow`, allow `>=10.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ doc = [
     "sphinxext_altair",
     "jinja2",
     "numpydoc",
-    "pillow>=9,<10",
+    "pillow",
     "pydata-sphinx-theme>=0.14.1",
     "myst-parser",
     "sphinx_copybutton",

--- a/sphinxext/utils.py
+++ b/sphinxext/utils.py
@@ -30,7 +30,7 @@ def create_thumbnail(
         final_height = height
         final_width = int(im_width * height_factor)
 
-    thumb = im.resize((final_width, final_height), Image.ANTIALIAS)
+    thumb = im.resize((final_width, final_height), Image.Resampling.LANCZOS)
     thumb.save(thumb_filename)
 
 


### PR DESCRIPTION
Fixes #3762

This is only a doc dependency, no user-facing changes

# Related
- #3095
- #3099
- https://github.com/python-pillow/Pillow/issues/7275#issuecomment-1629754198

# Log
Now installs latest version with no issues

https://github.com/vega/altair/actions/runs/12689910049/job/35369638575?pr=3764#step:5:90

```log
+ pillow==11.1.0
```