### PR TITLE
chore: Add `needs-triage` to new bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report something that is broken
-labels: ["bug"]
+labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
A simple indicator of whether or not a maintainer has responded yet

Pretty common label used in other projects https://github.com/search?q=label%3Aneeds-triage&type=issues

The two labels have a lot of contrast - so should be easy to spot 

![image](https://github.com/user-attachments/assets/f1b5efe6-0bc1-4e9f-99a9-50159d9eb83c)