### PR TITLE
ci(typing): Disable `mypy` `[annotation-unchecked]` on examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,6 +320,13 @@ module = [
 ignore_missing_imports = true
 disable_error_code = ["import-untyped"]
 
+[[tool.mypy.overrides]]
+module = [
+    "tests/examples_arguments_syntax.*",
+    "tests/examples_methods_syntax.*",
+]
+disable_error_code = ["annotation-unchecked"]
+
 [tool.pyright]
 enableExperimentalFeatures=true
 extraPaths=["./tools"]


### PR DESCRIPTION
Disables the non-blocking warning that appeared since (https://github.com/vega/altair/pull/3747/commits/1d01fa047638d879c0c93c1d8023a8e547824945)

- [Before](https://github.com/vega/altair/actions/runs/12843721674/job/35815966648?pr=3747#step:8:13)
- [After](https://github.com/vega/altair/actions/runs/12844184300/job/35816910571?pr=3775#step:8:13)

> tests\examples_methods_syntax\deviation_ellipses.py:56: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
> tests\examples_arguments_syntax\deviation_ellipses.py:56: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]

I don't consider this useful because:
1. The signature annotations were removed deliberately.
Prior to this, they already did the dance of making the stubs of `pandas`, `numpy` and `scipy` happy.
2. The default of `mypy` is the opposite of [(`pyright`|`pylance`)](https://microsoft.github.io/pyright/#/mypy-comparison?id=type-checking-unannotated-code).
I'm not planning to enable `--check-untyped-defs` - but I do want to avoid having warnings in VSCode.
4. Annotations within examples are helpful for getting the correct completions, in cases where inference fails.
This is why `pd.Series[float]` was added - to resolve `pandas` complex indexing `@overload`(s)