### PR TITLE
ci(uv): Remove dynamic version from `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,6 @@ wheels = [
 
 [[package]]
 name = "altair"
-version = "5.6.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Seems to have been a bug that was resolved in https://github.com/astral-sh/uv/issues/10689

Essentially, each time I've switched branches this change keeps trying to happen.
Shouldn't be an issue following https://github.com/astral-sh/uv/releases/tag/0.5.21