### PR TITLE
ci: bump `narwhals>=1.26.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # If you update the minimum required jsonschema version, also update it in build.yml
     "jsonschema>=3.0",
     "packaging",
-    "narwhals>=1.25.1"
+    "narwhals>=1.26.0"
 ]
 description = "Vega-Altair: A declarative statistical visualization library for Python."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ requires-dist = [
     { name = "mistune", marker = "extra == 'dev'" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "myst-parser", marker = "extra == 'doc'" },
-    { name = "narwhals", specifier = ">=1.25.1" },
+    { name = "narwhals", specifier = ">=1.26.0" },
     { name = "numpy", marker = "extra == 'all'" },
     { name = "numpydoc", marker = "extra == 'doc'" },
     { name = "packaging" },
@@ -1431,11 +1431,11 @@ wheels = [
 
 [[package]]
 name = "narwhals"
-version = "1.25.1"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/bc/a68ccd9619518bd49bc27665b34aec3a308f717647802ee9f55f9493a212/narwhals-1.25.1.tar.gz", hash = "sha256:9c0e27be46e186526878286b442a3dd2ee9fe723456457feff42316288732b96", size = 247291 }
+sdist = { url = "https://files.pythonhosted.org/packages/18/6f/75929abaac73088fe34c788ecb40db20252174bcd00b8612381aebb954ee/narwhals-1.26.0.tar.gz", hash = "sha256:b9d7605bf1d97a9d87783a69748c39150964e2a1ab0e5a6fef3e59e56772639e", size = 248933 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/e3/74722453c3fc4fc3e1c135050db2f302abe85942e054261931a6bda23727/narwhals-1.25.1-py3-none-any.whl", hash = "sha256:a1838f2725523da54c093849e93a8b2a57d2310f0bbc26be35d223f5eef60417", size = 305590 },
+    { url = "https://files.pythonhosted.org/packages/15/fc/420680ad8b0cf81372eee7a213a7b7173ec5a628f0d5b2426047fe55c3b3/narwhals-1.26.0-py3-none-any.whl", hash = "sha256:4af8bbdea9e45638bb9a981568a8dfa880e40eb7dcf740d19fd32aea79223c6f", size = 306574 },
 ]
 
 [[package]]


### PR DESCRIPTION
Will unblock (https://github.com/vega/altair/pull/3631#discussion_r1937953187)

Upstreamed some of #3631 to `narwhals` in https://github.com/narwhals-dev/narwhals/issues/1912