### PR TITLE
docs: fix broken links

### DIFF
--- a/altair/expr/__init__.py
+++ b/altair/expr/__init__.py
@@ -91,9 +91,9 @@ class expr(_ExprRef, metaclass=_ExprMeta):
     ``ExprRef``
 
     .. _Expressions:
-        https://altair-viz.github.io/user_guide/interactions.html#expressions
+        https://altair-viz.github.io/user_guide/interactions/expressions.html
     .. _inline expression:
-       https://altair-viz.github.io/user_guide/interactions.html#inline-expressions
+       https://altair-viz.github.io/user_guide/interactions/expressions.html#inline-expressions
     .. _vega expression:
        https://vega.github.io/vega/docs/expressions/
 

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -1338,7 +1338,7 @@ def param(
     **kwds: Any,
 ) -> Parameter:
     """
-    Create a named parameter, see https://altair-viz.github.io/user_guide/interactions.html for examples.
+    Create a named parameter, see https://altair-viz.github.io/user_guide/interactions/parameters.html for examples.
 
     Although both variable parameters and selection parameters can be created using
     this 'param' function, to create a selection parameter, it is recommended to use

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -591,7 +591,7 @@ def test_when_expressions_inside_parameters() -> None:
     """
     Test for [2144026368-2](https://github.com/vega/altair/pull/3427#issuecomment-2144026368).
 
-    Original [expressions-inside-parameters](https://altair-viz.github.io/user_guide/interactions.html#expressions-inside-parameters)
+    Original [expressions-inside-parameters](https://altair-viz.github.io/user_guide/interactions/expressions.html#expressions-inside-parameters)
     """
     import polars as pl
 

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -588,11 +588,7 @@ def test_when_labels_position_based_on_condition() -> None:
 
 
 def test_when_expressions_inside_parameters() -> None:
-    """
-    Test for [2144026368-2](https://github.com/vega/altair/pull/3427#issuecomment-2144026368).
-
-    Original [expressions-inside-parameters](https://altair-viz.github.io/user_guide/interactions/expressions.html#expressions-inside-parameters)
-    """
+    """Test for [2144026368-2](https://github.com/vega/altair/pull/3427#issuecomment-2144026368)."""
     import polars as pl
 
     source = pl.DataFrame({"a": ["A", "B", "C"], "b": [28, -5, 10]})

--- a/tools/vega_expr.py
+++ b/tools/vega_expr.py
@@ -189,9 +189,9 @@ CLS_DOC = """
     ``ExprRef``
 
     .. _Expressions:
-        https://altair-viz.github.io/user_guide/interactions.html#expressions
+        https://altair-viz.github.io/user_guide/interactions/expressions.html
     .. _inline expression:
-       https://altair-viz.github.io/user_guide/interactions.html#inline-expressions
+       https://altair-viz.github.io/user_guide/interactions/expressions.html#inline-expressions
     .. _vega expression:
        https://vega.github.io/vega/docs/expressions/
 


### PR DESCRIPTION
Fixes broken links that show up e.g. [here](https://altair-viz.github.io/user_guide/generated/api/altair.param.html) after `user_guide/interactions.html` was split into separate pages.