### PR TITLE
chore: Remove deprecated `nw.from_native(..., strict=True)`

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -494,7 +494,7 @@ def _subclasses(cls: type[Any]) -> Iterator[type[Any]]:
 
 def _from_array_like(obj: Iterable[Any], /) -> list[Any]:
     try:
-        ser = nw.from_native(obj, strict=True, series_only=True)
+        ser = nw.from_native(obj, series_only=True)
         return ser.to_list()
     except TypeError:
         return list(obj)

--- a/tests/test_transformed_data.py
+++ b/tests/test_transformed_data.py
@@ -92,7 +92,7 @@ def test_primitive_chart_examples(filename, rows, cols, to_reconstruct):
         chart = alt.Chart.from_dict(chart.to_dict())
     df = chart.transformed_data()
     assert df is not None
-    nw_df = nw.from_native(df, eager_only=True, strict=True)
+    nw_df = nw.from_native(df, eager_only=True)
 
     assert len(nw_df) == rows
     assert set(cols).issubset(set(nw_df.columns))
@@ -157,7 +157,7 @@ def test_compound_chart_examples(filename, all_rows, all_cols, to_reconstruct):
         # is that for some charts, the original chart contained duplicated datasets
         # which disappear when reconstructing the chart.
 
-        nw_dfs = (nw.from_native(d, eager_only=True, strict=True) for d in dfs)
+        nw_dfs = (nw.from_native(d, eager_only=True) for d in dfs)
         assert len(dfs) == len(all_rows)
         for df, rows, cols in zip(nw_dfs, all_rows, all_cols):
             assert len(df) == rows
@@ -185,7 +185,7 @@ def test_transformed_data_exclude(to_reconstruct):
     assert isinstance(chart, alt.LayerChart)
     datasets = chart.transformed_data(exclude=["some_annotation"])
 
-    _datasets = [nw.from_native(d, eager_only=True, strict=True) for d in datasets]
+    _datasets = [nw.from_native(d, eager_only=True) for d in datasets]
     assert len(datasets) == len(_datasets)
     assert len(_datasets) == 2
     assert len(_datasets[0]) == 52

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -492,7 +492,7 @@ def _subclasses(cls: type[Any]) -> Iterator[type[Any]]:
 
 def _from_array_like(obj: Iterable[Any], /) -> list[Any]:
     try:
-        ser = nw.from_native(obj, strict=True, series_only=True)
+        ser = nw.from_native(obj, series_only=True)
         return ser.to_list()
     except TypeError:
         return list(obj)


### PR DESCRIPTION
Spotted during an upstream integration test
- https://github.com/narwhals-dev/narwhals/pull/2110#issuecomment-2687936504

IIRC, I added `strict` before it was [deprecated](https://narwhals-dev.github.io/narwhals/backcompat/#breaking-changes-carried-out-so-far) to help match an `@overload`.
Since then, the `@overload` definitions in `narwhals` have improved - meaning the default **doesn't** need to be passed in for us to get it typing correctly

# Related
- #3693
- https://github.com/narwhals-dev/narwhals/pull/2110