### PR TITLE
chore(typing): Follow-up fix `_from_array_like`

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -27,12 +27,12 @@ from typing import (
     cast,
     overload,
 )
-from typing_extensions import TypeAlias
 
 import jsonschema
 import jsonschema.exceptions
 import jsonschema.validators
 import narwhals.stable.v1 as nw
+from narwhals.stable.v1.dependencies import is_narwhals_series
 from packaging.version import Version
 
 if sys.version_info >= (3, 12):
@@ -58,6 +58,11 @@ if TYPE_CHECKING:
         from typing import Never, Self
     else:
         from typing_extensions import Never, Self
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+
     _OptionalModule: TypeAlias = "ModuleType | None"
 
 ValidationErrorList: TypeAlias = list[jsonschema.exceptions.ValidationError]
@@ -493,11 +498,10 @@ def _subclasses(cls: type[Any]) -> Iterator[type[Any]]:
 
 
 def _from_array_like(obj: Iterable[Any], /) -> list[Any]:
-    try:
-        ser = nw.from_native(obj, series_only=True)
-        return ser.to_list()
-    except TypeError:
-        return list(obj)
+    # TODO @dangotbanned: Review after available (https://github.com/narwhals-dev/narwhals/pull/2110)
+    # See for what this silences for `narwhals` CI (https://github.com/narwhals-dev/narwhals/pull/2110#issuecomment-2687936504)
+    maybe_ser: Any = nw.from_native(obj, pass_through=True)
+    return maybe_ser.to_list() if is_narwhals_series(maybe_ser) else list(obj)
 
 
 def _from_date_datetime(obj: dt.date | dt.datetime, /) -> dict[str, Any]:

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -25,12 +25,12 @@ from typing import (
     cast,
     overload,
 )
-from typing_extensions import TypeAlias
 
 import jsonschema
 import jsonschema.exceptions
 import jsonschema.validators
 import narwhals.stable.v1 as nw
+from narwhals.stable.v1.dependencies import is_narwhals_series
 from packaging.version import Version
 
 if sys.version_info >= (3, 12):
@@ -56,6 +56,11 @@ if TYPE_CHECKING:
         from typing import Never, Self
     else:
         from typing_extensions import Never, Self
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+
     _OptionalModule: TypeAlias = "ModuleType | None"
 
 ValidationErrorList: TypeAlias = list[jsonschema.exceptions.ValidationError]
@@ -491,11 +496,10 @@ def _subclasses(cls: type[Any]) -> Iterator[type[Any]]:
 
 
 def _from_array_like(obj: Iterable[Any], /) -> list[Any]:
-    try:
-        ser = nw.from_native(obj, series_only=True)
-        return ser.to_list()
-    except TypeError:
-        return list(obj)
+    # TODO @dangotbanned: Review after available (https://github.com/narwhals-dev/narwhals/pull/2110)
+    # See for what this silences for `narwhals` CI (https://github.com/narwhals-dev/narwhals/pull/2110#issuecomment-2687936504)
+    maybe_ser: Any = nw.from_native(obj, pass_through=True)
+    return maybe_ser.to_list() if is_narwhals_series(maybe_ser) else list(obj)
 
 
 def _from_date_datetime(obj: dt.date | dt.datetime, /) -> dict[str, Any]:


### PR DESCRIPTION
Have a better understanding *now* of what the issue is in (https://github.com/narwhals-dev/narwhals/actions/runs/13577097131/job/37955718895).

```py
altair/utils/schemapi.py:497: error: No overload variant of "from_native"
matches argument types "Iterable[Any]", "bool"  [call-overload]
            ser = nw.from_native(obj, series_only=True)
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
altair/utils/schemapi.py:497: note: Possible overload variants:
```

- This patch is *functionally* the same - but removes the need for ignoring a (typing) warning following (https://github.com/narwhals-dev/narwhals/commit/62f8a1f1a2fc4d512ea451bc3be58b3fdf13d35a).
- Should also mean we don't need to bump our `narwhals` minimum [again](https://github.com/vega/altair/pull/3807#discussion_r1958463423).
- **Bonus**: reduced overhead for `<3.11` (https://github.com/python/cpython/issues/84403)

## Related
- https://github.com/narwhals-dev/narwhals/pull/2110
- #3811
- https://github.com/narwhals-dev/narwhals/pull/2110#issuecomment-2687936504
- https://github.com/narwhals-dev/narwhals/pull/2110#issuecomment-2689103018
- https://github.com/narwhals-dev/narwhals/issues/2111

## Update
Fixed it 🙂 (https://github.com/narwhals-dev/narwhals/pull/2114#issuecomment-2690512867)