### PR TITLE
ci(ruff): move `exclude` to `extend-exclude`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ features = ["all", "dev", "doc"]
 matrix   = [{ python = ["3.9", "3.10", "3.11", "3.12", "3.13"] }]
 
 [tool.ruff]
-exclude = [
+extend-exclude = [
     ".git",
     "__pycache__",
     "build",


### PR DESCRIPTION
## Description

Moving the config here allows for inheriting **user-specific** excludes - which are currently overriden.
I've been having issues with `ruff` wanting to fix my `.venv` and this lets me remove those warnings (without polluting our `pyproject.toml`).

Can always add to our excludes *later* if anyone else encounters the same issue

## Example

<details><summary>Screenshot</summary>
<p>

Without local config

![image](https://github.com/user-attachments/assets/17a77209-32ad-4899-9fb5-793588808b9f)

</p>
</details> 


### Local fix
```toml
extend-exclude = [
    "AppData/**/*.py", ".python", ".venv", "../../../**/Lib"
]
```

## Related
- https://docs.astral.sh/ruff/settings/#extend-exclude
- https://docs.astral.sh/ruff/configuration/#config-file-discovery
