### PR TITLE
feat: Allow numpy scalars in altair expressions

### DIFF
--- a/altair/expr/core.py
+++ b/altair/expr/core.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import datetime as dt
 from typing import TYPE_CHECKING, Any, Literal, Union
 
+import numpy as np
+
 from altair.utils import SchemaBase
 
 if TYPE_CHECKING:
@@ -50,6 +52,8 @@ def _js_repr(val) -> str:
         return val._to_expr()
     elif isinstance(val, dt.date):
         return _from_date_datetime(val)
+    elif isinstance(val, np.generic):
+        return repr(val.item())
     else:
         return repr(val)
 

--- a/altair/expr/core.py
+++ b/altair/expr/core.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
 import datetime as dt
+import sys
 from typing import TYPE_CHECKING, Any, Literal, Union
-
-import numpy as np
 
 from altair.utils import SchemaBase
 
 if TYPE_CHECKING:
-    import sys
-
     from altair.vegalite.v5.schema._typing import Map, PrimitiveValue_T
 
     if sys.version_info >= (3, 10):
@@ -52,7 +49,7 @@ def _js_repr(val) -> str:
         return val._to_expr()
     elif isinstance(val, dt.date):
         return _from_date_datetime(val)
-    elif isinstance(val, np.generic):
+    elif _is_numpy_generic(val):
         return repr(val.item())
     else:
         return repr(val)
@@ -84,6 +81,15 @@ def _from_date_datetime(obj: dt.date | dt.datetime, /) -> str:
         ms = us if us == 0 else us // 1_000
         args = *args, obj.hour, obj.minute, obj.second, ms
     return FunctionExpression(fn_name, args)._to_expr()
+
+
+def _is_numpy_generic(obj: Any) -> bool:
+    """
+    Check if an object is a numpy generic (scalar) type.
+
+    This function can be used without importing numpy when it is not available.
+    """
+    return (np := sys.modules.get("numpy")) is not None and isinstance(obj, np.generic)
 
 
 # Designed to work with Expression and VariableParameter

--- a/altair/vegalite/v5/__init__.py
+++ b/altair/vegalite/v5/__init__.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F401, F403, F405
+# ruff: noqa: F403, F405
 from altair.expr.core import datum
 from altair.vegalite.v5 import api, compiler, schema
 from altair.vegalite.v5.api import *

--- a/tests/expr/test_expr.py
+++ b/tests/expr/test_expr.py
@@ -6,6 +6,7 @@ import sys
 from inspect import classify_class_attrs, getmembers, signature
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
+import numpy as np
 import pytest
 from jsonschema.exceptions import ValidationError
 
@@ -140,6 +141,7 @@ def test_json_reprs():
     assert repr(datum.xxx == None) == "(datum.xxx === null)"  # noqa: E711
     assert repr(datum.xxx == False) == "(datum.xxx === false)"  # noqa: E712
     assert repr(datum.xxx == True) == "(datum.xxx === true)"  # noqa: E712
+    assert repr(datum.xxx == np.int64(0)) == "(datum.xxx === 0)"
 
 
 def test_to_dict():


### PR DESCRIPTION
## Use old numpy scalar representation in expressions.

Numpy 2.0 has changed the representation of scalars (e.g., `repr(np.int64(0))` used to be `'0'` but became `np.int64(0)` ([related issue](https://github.com/h5py/h5py/issues/2456)). Due to this change, numpy constants can no longer be used in altair expressions for, e.g., filtering. This is inconvenient, as iterating over a numpy array returns such scalars.

Given that numpy is such a fundamental part of the scientific Python ecosystem, and is often used in conjunction with plotting tasks, I propose that Altair could special-case numpy scalars and unpack them into Python scalars to re-enable the numpy 1.x behavior of numpy constants being usable in altair expressions. This PR implements a simple solution for this.
