### PR TITLE
docs: Update the waterfall_chart.py colors

### DIFF
--- a/tests/examples_arguments_syntax/waterfall_chart.py
+++ b/tests/examples_arguments_syntax/waterfall_chart.py
@@ -61,8 +61,8 @@ color_coding = (
     alt.when((label == "Begin") | (label == "End"))
     .then(alt.value("#878d96"))
     .when(calc_amount < 0)
-    .then(alt.value("#24a148"))
-    .otherwise(alt.value("#fa4d56"))
+    .then(alt.value("#fa4d56"))
+    .otherwise(alt.value("#24a148"))
 )
 
 bar = base_chart.mark_bar(size=45).encode(


### PR DESCRIPTION
Update the waterfall_chart.py colors to have green be positive and red be negative. 

Similar to the vega example ( [waterfall_chart](https://vega.github.io/vega-lite/examples/waterfall_chart.html) )

<img width="880" alt="Screenshot 2025-04-21 at 13 25 30" src="https://github.com/user-attachments/assets/abe03a7a-ac9d-4a84-bb36-c99e3c60dc5d" />


Below is the updated example

## Original 
<img width="882" alt="Screenshot 2025-04-21 at 13 51 28" src="https://github.com/user-attachments/assets/c8374987-60ba-49f4-862a-aaa546662a97" />

## Updated
<img width="878" alt="Screenshot 2025-04-21 at 13 50 37" src="https://github.com/user-attachments/assets/ea889122-45d5-4dc7-b9b9-f4e4771c7888" />
