### PR TITLE
chore: Run `typos` and `codespell` against the codebase

### DIFF
--- a/altair/utils/_transformed_data.py
+++ b/altair/utils/_transformed_data.py
@@ -283,7 +283,7 @@ def get_datasets_for_scope(vega_spec: dict[str, Any], scope: Scope) -> list[str]
     Parameters
     ----------
     vega_spec : dict
-        Top-leve Vega specification
+        Top-level Vega specification
     scope : tuple of int
         Scope tuple. If empty, the names of top-level datasets are returned
         Otherwise, the names of the datasets defined in the nested group mark

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -289,7 +289,7 @@ def merge_props_geom(feat: dict[str, Any]) -> dict[str, Any]:
 
 def sanitize_geo_interface(geo: MutableMapping[Any, Any]) -> dict[str, Any]:
     """
-    Santize a geo_interface to prepare it for serialization.
+    Sanitize a geo_interface to prepare it for serialization.
 
     * Make a copy
     * Convert type array or _Array to list

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -352,7 +352,7 @@ def _compute_data_hash(data_str: str) -> str:
 
 def _from_geo_interface(data: SupportsGeoInterface) -> dict[str, Any]:
     """
-    Santize a ``__geo_interface__`` w/ pre-santize step for ``pandas`` if needed.
+    Sanitize a ``__geo_interface__`` w/ pre-sanitize step for ``pandas`` if needed.
 
     Introduces an intersection type::
 

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -414,7 +414,7 @@ def _is_required_value_error(err: jsonschema.exceptions.ValidationError) -> bool
 
 def _group_errors_by_validator(errors: ValidationErrorList) -> GroupedValidationErrors:
     """
-    Groups the errors by the json schema "validator" that casued the error.
+    Groups the errors by the json schema "validator" that caused the error.
 
     For example if the error is that a value is not one of an enumeration in the json schema
     then the "validator" is `"enum"`, if the error is due to an unknown property that
@@ -1425,7 +1425,7 @@ def _replace_parsed_shorthand(
     not passed to child `to_dict` function calls.
     """
     # Prevent that pandas categorical data is automatically sorted
-    # when a non-ordinal data type is specifed manually
+    # when a non-ordinal data type is specified manually
     # or if the encoding channel does not support sorting
     if "sort" in parsed_shorthand and (
         "sort" not in kwds or kwds["type"] not in {"ordinal", Undefined}

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -36,7 +36,7 @@ VEGA_MIME_TYPE: Final = "application/vnd.vega.v5+json"
 
 # The entry point group that can be used by other packages to declare other
 # renderers that will be auto-detected. Explicit registration is also
-# allowed by the PluginRegistery API.
+# allowed by the PluginRegistry API.
 ENTRY_POINT_GROUP: Final = "altair.vegalite.v5.renderer"
 
 # The display message when rendering fails

--- a/doc/_static/theme_overrides.css
+++ b/doc/_static/theme_overrides.css
@@ -24,7 +24,7 @@ img.logo {
     width: 120px !important;
 }
 
-/* Increas max-width of the content area slightly to accomodate larger screens */
+/* Increase max-width of the content area slightly to accommodate larger screens */
 .bd-main .bd-content .bd-article-container {
     max-width: 1000px;
 }

--- a/doc/user_guide/marks/area.rst
+++ b/doc/user_guide/marks/area.rst
@@ -4,7 +4,7 @@
 
 Area
 ~~~~~~~~~~
-``area`` represent multple data element as a single area shape.
+``area`` represent multiple data element as a single area shape.
 Area marks are often used to show change over time, using either a single area or stacked areas.
 
 Area Mark Properties

--- a/doc/user_guide/marks/text.rst
+++ b/doc/user_guide/marks/text.rst
@@ -40,7 +40,7 @@ Text Mark Properties
     align_var = alt.param(bind=align_select, value="left", name="align")
 
     baseline_select = alt.binding_select(options=["alphabetic", "top", "middle", "bottom"])
-    baseline_var = alt.param(bind=baseline_select, value="midle", name="baseline")
+    baseline_var = alt.param(bind=baseline_select, value="middle", name="baseline")
 
     font_select = alt.binding_select(options=["sans-serif", "serif", "monospace"])
     font_var = alt.param(bind=font_select, value="sans-serif", name="font")

--- a/tests/examples_arguments_syntax/bar_chart_with_mean_line.py
+++ b/tests/examples_arguments_syntax/bar_chart_with_mean_line.py
@@ -1,7 +1,7 @@
 """
 Bar Chart with Line at Mean
 ---------------------------
-This example shows the mean value overlayed on a bar chart.
+This example shows the mean value overlaid on a bar chart.
 """
 # category: bar charts
 import altair as alt

--- a/tests/examples_arguments_syntax/bar_with_rolling_mean.py
+++ b/tests/examples_arguments_syntax/bar_with_rolling_mean.py
@@ -1,7 +1,7 @@
 """
 Bar Chart with Rolling Mean
 ---------------------------
-A bar chart overlayed with a rolling mean. In this example the average of values over the previous decade is displayed as a line.
+A bar chart overlaid with a rolling mean. In this example the average of values over the previous decade is displayed as a line.
 """
 # category: bar charts
 import altair as alt

--- a/tests/examples_arguments_syntax/interactive_column_selection.py
+++ b/tests/examples_arguments_syntax/interactive_column_selection.py
@@ -68,7 +68,7 @@ dynamic_title = alt.Title(alt.expr(f'"Difference " + {select_x.name}.level_0 + "
 # We pivot transform to get each category as a column
 lines_diff = base.transform_pivot(
     'category', 'value', groupby=['date']
-# In the calculate transform we use the values from the selection to subset the columns to substract
+# In the calculate transform we use the values from the selection to subset the columns to subtract
 ).transform_calculate(
     difference = f'datum[{select_x.name}.level_0] - datum[{select_y.name}.level_1]'
 ).mark_line(color='grey').encode(

--- a/tests/examples_arguments_syntax/interval_selection_map_quakes.py
+++ b/tests/examples_arguments_syntax/interval_selection_map_quakes.py
@@ -14,7 +14,7 @@ import geopandas as gpd
 gdf_quakies = gpd.read_file(data.earthquakes.url)
 gdf_world = gpd.read_file(data.world_110m.url, layer="countries")
 
-# defintion for interactive brush
+# definition for interactive brush
 brush = alt.selection_interval(
     encodings=["longitude"], 
     empty=False, 

--- a/tests/examples_arguments_syntax/polar_bar_chart.py
+++ b/tests/examples_arguments_syntax/polar_bar_chart.py
@@ -47,7 +47,7 @@ axis_lines_labels = axis_lines.mark_text(
         color='grey',
         radiusOffset=5,
         thetaOffset=-math.pi / 4,
-        # These adjustments could be left out with a larger radius offset, but they make the label positioning a bit clearner
+        # These adjustments could be left out with a larger radius offset, but they make the label positioning a bit cleaner
         align=alt.expr('datum.hour == "18:00" ? "right" : datum.hour == "06:00" ? "left" : "center"'),
         baseline=alt.expr('datum.hour == "00:00" ? "bottom" : datum.hour == "12:00" ? "top" : "middle"'),
     ).encode(text="hour")

--- a/tests/examples_arguments_syntax/top_k_letters.py
+++ b/tests/examples_arguments_syntax/top_k_letters.py
@@ -3,7 +3,7 @@ Top K Letters
 -------------
 This example shows how to use a window transform in order to display only the
 top K categories by number of entries. In this case, we rank the characters in
-the first paragraph of Dickens' *A Tale of Two Cities* by number of occurances.
+the first paragraph of Dickens' *A Tale of Two Cities* by number of occurrences.
 """
 # category: advanced calculations
 import altair as alt

--- a/tests/examples_arguments_syntax/top_k_with_others.py
+++ b/tests/examples_arguments_syntax/top_k_with_others.py
@@ -1,7 +1,7 @@
 """
 Top-K Plot with Others
 ----------------------
-This example shows how to use aggregate, window, and calculate transfromations
+This example shows how to use aggregate, window, and calculate transformations
 to display the top-k directors by average worldwide gross while grouping the 
 remaining directors as 'All Others'.
 """

--- a/tests/examples_arguments_syntax/us_state_capitals.py
+++ b/tests/examples_arguments_syntax/us_state_capitals.py
@@ -1,8 +1,8 @@
 """
-U.S. State Capitals Overlayed on a Map of the U.S
+U.S. State Capitals Overlaid on a Map of the U.S
 -------------------------------------------------
 This is a layered geographic visualization that shows US capitals
-overlayed on a map.
+overlaid on a map.
 """
 # category: case studies
 import altair as alt

--- a/tests/examples_methods_syntax/interactive_column_selection.py
+++ b/tests/examples_methods_syntax/interactive_column_selection.py
@@ -68,7 +68,7 @@ dynamic_title = alt.Title(alt.expr(f'"Difference " + {select_x.name}.level_0 + "
 # We pivot transform to get each category as a column
 lines_diff = base.transform_pivot(
     'category', 'value', groupby=['date']
-# In the calculate transform we use the values from the selection to subset the columns to substract
+# In the calculate transform we use the values from the selection to subset the columns to subtract
 ).transform_calculate(
     difference = f'datum[{select_x.name}.level_0] - datum[{select_y.name}.level_1]'
 ).mark_line(color='grey').encode(

--- a/tests/examples_methods_syntax/interval_selection_map_quakes.py
+++ b/tests/examples_methods_syntax/interval_selection_map_quakes.py
@@ -14,7 +14,7 @@ import geopandas as gpd
 gdf_quakies = gpd.read_file(data.earthquakes.url)
 gdf_world = gpd.read_file(data.world_110m.url, layer="countries")
 
-# defintion for interactive brush
+# definition for interactive brush
 brush = alt.selection_interval(
     encodings=["longitude"], 
     empty=False, 

--- a/tests/examples_methods_syntax/line_chart_with_cumsum_faceted.py
+++ b/tests/examples_methods_syntax/line_chart_with_cumsum_faceted.py
@@ -4,7 +4,7 @@ Faceted Line Chart with Cumulative Sum
 This chart creates one facet per natural disaster and shows the cumulative number of deaths for that category.
 Note the use of different predicates to filter based on both a list and a range.
 """
-# category: advanced calcuations
+# category: advanced calculations
 import altair as alt
 from vega_datasets import data
 

--- a/tests/examples_methods_syntax/polar_bar_chart.py
+++ b/tests/examples_methods_syntax/polar_bar_chart.py
@@ -47,7 +47,7 @@ axis_lines_labels = axis_lines.mark_text(
         color='grey',
         radiusOffset=5,
         thetaOffset=-math.pi / 4,
-        # These adjustments could be left out with a larger radius offset, but they make the label positioning a bit clearner
+        # These adjustments could be left out with a larger radius offset, but they make the label positioning a bit cleaner
         align=alt.expr('datum.hour == "18:00" ? "right" : datum.hour == "06:00" ? "left" : "center"'),
         baseline=alt.expr('datum.hour == "00:00" ? "bottom" : datum.hour == "12:00" ? "top" : "middle"'),
     ).encode(text="hour")

--- a/tests/examples_methods_syntax/top_k_letters.py
+++ b/tests/examples_methods_syntax/top_k_letters.py
@@ -3,7 +3,7 @@ Top K Letters
 -------------
 This example shows how to use a window transform in order to display only the
 top K categories by number of entries. In this case, we rank the characters in
-the first paragraph of Dickens' *A Tale of Two Cities* by number of occurances.
+the first paragraph of Dickens' *A Tale of Two Cities* by number of occurrences.
 """
 # category: advanced calculations
 import altair as alt

--- a/tests/examples_methods_syntax/top_k_with_others.py
+++ b/tests/examples_methods_syntax/top_k_with_others.py
@@ -1,7 +1,7 @@
 """
 Top-K Plot with Others
 ----------------------
-This example shows how to use aggregate, window, and calculate transfromations
+This example shows how to use aggregate, window, and calculate transformations
 to display the top-k directors by average worldwide gross while grouping the 
 remaining directors as 'All Others'.
 """

--- a/tests/examples_methods_syntax/us_state_capitals.py
+++ b/tests/examples_methods_syntax/us_state_capitals.py
@@ -1,8 +1,8 @@
 """
-U.S. State Capitals Overlayed on a Map of the U.S
+U.S. State Capitals Overlaid on a Map of the U.S
 -------------------------------------------------
 This is a layered geographic visualization that shows US capitals
-overlayed on a map.
+overlaid on a map.
 """
 # category: case studies
 import altair as alt

--- a/tests/vegalite/v5/test_api.py
+++ b/tests/vegalite/v5/test_api.py
@@ -1040,7 +1040,7 @@ def test_transforms():
     kwds = {"as": "binned", "field": "field", "bin": True}
     assert chart.transform == [alt.BinTransform(**kwds)]
 
-    # calcualte transform
+    # calculate transform
     chart = alt.Chart().transform_calculate("calc", "datum.a * 4")
     kwds = {"as": "calc", "calculate": "datum.a * 4"}
     assert chart.transform == [alt.CalculateTransform(**kwds)]

--- a/tests/vegalite/v5/test_geo_interface.py
+++ b/tests/vegalite/v5/test_geo_interface.py
@@ -176,7 +176,7 @@ def test_geo_interface_feature_collection() -> None:
 
 
 # typical output of a __geo_interface__ from geopandas GeoDataFrame
-# notic that the index value is registerd as a commonly used identifier
+# notice that the index value is registered as a commonly used identifier
 # with the name "id" (in this case 49). Similar to serialization of a
 # pandas DataFrame is the index not included in the output
 def test_geo_interface_feature_collection_gdf() -> None:

--- a/tools/codemod.py
+++ b/tools/codemod.py
@@ -284,7 +284,7 @@ class Ruff(CodeMod):
         `rule codes`_ to use **on top of** the default config.
     ignore
         `rule codes`_ to `ignore`_.
-    skip_magic_traling_comma
+    skip_magic_trailing_comma
         Enables `skip-magic-trailing-comma`_ during formatting.
 
         .. note::
@@ -314,7 +314,7 @@ class Ruff(CodeMod):
         self,
         *extend_select: str,
         ignore: OneOrIterV[str] | None = None,
-        skip_magic_traling_comma: bool = False,
+        skip_magic_trailing_comma: bool = False,
     ) -> None:
         self.check_args: deque[str] = deque(self._check_args)
         self.format_args: deque[str] = deque()
@@ -324,7 +324,7 @@ class Ruff(CodeMod):
             self.check_args.extend(
                 ("--ignore", ",".join(s for s in iter_flatten(ignore)))
             )
-        if skip_magic_traling_comma:
+        if skip_magic_trailing_comma:
             self.format_args.extend(
                 ("--config", "format.skip-magic-trailing-comma = true")
             )
@@ -433,5 +433,5 @@ class Ruff(CodeMod):
         return self.format(self.check(code, decode=False))
 
 
-ruff_inline_docs = Ruff(ignore="E711", skip_magic_traling_comma=True)
+ruff_inline_docs = Ruff(ignore="E711", skip_magic_trailing_comma=True)
 ruff = Ruff()

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -1174,7 +1174,7 @@ def path_to_module_str(
     root: Literal["altair", "doc", "sphinxext", "tests", "tools"] = "altair",
 ) -> str:
     # NOTE: GH runner has 3x altair, local is 2x
-    # - Needs to be the last occurence
+    # - Needs to be the last occurrence
     idx = fp.parts.index(root)
     start = idx + fp.parts.count(root) - 1 if root == "altair" else idx
     parents = fp.parts[start:-1]

--- a/tools/markup.py
+++ b/tools/markup.py
@@ -125,7 +125,7 @@ class RSTParseVegaLite(RSTParse):
             _RE_SPECIAL.sub("", d) if i % 2 else d
             for i, d in enumerate(_RE_LINK.split(s))
         )
-        # NOTE: Some entries in the Vega-Lite schema miss the second occurence of '__'
+        # NOTE: Some entries in the Vega-Lite schema miss the second occurrence of '__'
         # (Needs to happen pre-parse to convert into `**Default value:**` for `.rst`)
         description = description.replace("__Default value: ", "__Default value:__ ")
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -412,7 +412,7 @@ def _is_required_value_error(err: jsonschema.exceptions.ValidationError) -> bool
 
 def _group_errors_by_validator(errors: ValidationErrorList) -> GroupedValidationErrors:
     """
-    Groups the errors by the json schema "validator" that casued the error.
+    Groups the errors by the json schema "validator" that caused the error.
 
     For example if the error is that a value is not one of an enumeration in the json schema
     then the "validator" is `"enum"`, if the error is due to an unknown property that
@@ -1423,7 +1423,7 @@ def _replace_parsed_shorthand(
     not passed to child `to_dict` function calls.
     """
     # Prevent that pandas categorical data is automatically sorted
-    # when a non-ordinal data type is specifed manually
+    # when a non-ordinal data type is specified manually
     # or if the encoding channel does not support sorting
     if "sort" in parsed_shorthand and (
         "sort" not in kwds or kwds["type"] not in {"ordinal", Undefined}

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -163,7 +163,7 @@ class _TypeAliasTracer:
             # Handles one very specific edge case `WindowFieldDef`
             # - Has an anonymous enum union
             # - One of the members is declared afterwards
-            # - SchemaBase needs to be first, as the union wont be internally sorted
+            # - SchemaBase needs to be first, as the union won't be internally sorted
             it = (
                 self.add_literal(el, spell_literal(el.literal), replace=True)
                 for el in info.anyOf
@@ -245,7 +245,7 @@ class _TypeAliasTracer:
 
     @property
     def n_entries(self) -> int:
-        """Number of unique `TypeAlias` defintions collected."""
+        """Number of unique `TypeAlias` definitions collected."""
         return len(self._literals)
 
 

--- a/tools/update_init_file.py
+++ b/tools/update_init_file.py
@@ -118,7 +118,7 @@ def relevant_attributes(namespace: dict[str, t.Any], /) -> list[str]:
 
 
 def _is_hashable(obj: t.Any) -> bool:
-    """Guard to prevent an `in` check occuring on mutable objects."""
+    """Guard to prevent an `in` check occurring on mutable objects."""
     try:
         return bool(hash(obj))
     except TypeError:

--- a/tools/vega_expr.py
+++ b/tools/vega_expr.py
@@ -306,7 +306,7 @@ class ReplaceMany:
             Special characters must be escaped **first**, if present.
 
     fmt_replace
-        Format string applied to a succesful match, after substition.
+        Format string applied to a successful match, after substitution.
         Receives ``self._mapping[key]`` as a positional argument.
 
     .. _dict:
@@ -873,9 +873,9 @@ def format_doc(doc: str, /) -> str:
     - Source is very different to `vega-lite`
     - There are no real sections, so these are created here
     - Single line docs are unchanged
-    - Multi-line have everything following the first line wrappped.
+    - Multi-line have everything following the first line wrapped.
         - With a double break inserted for a summary line
-    - Reference-like links section (if present) are also ommitted from wrapping
+    - Reference-like links section (if present) are also omitted from wrapping
 
     .. _summary line:
         https://numpydoc.readthedocs.io/en/latest/format.html#short-summary

--- a/tools/versioning.py
+++ b/tools/versioning.py
@@ -1,5 +1,5 @@
 """
-Versioning utils, specfic to `vega projects`_.
+Versioning utils, specific to `vega projects`_.
 
 Includes non-`python` projects.
 


### PR DESCRIPTION
Hello! I'm working to contribute to projects mentioned in SciPy 2025 talk summaries.

This PR fixes typos auto-identified by the `typos` and `codespell` tools.

These two tools found a number of spelling errors, but their results had to be manually reviewed and, in some cases, corrected.

For example, the word `ser` was corrected to `set`, which was a change that had to be undone.

For example, `clearner` required a human guess
whether "clearer" or "cleaner" was intended.
