### PR TITLE
feat: preserve the empty property for the three operators (&, |, ~)

### DIFF
--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -410,23 +410,38 @@ class Parameter(_expr_core.OperatorMixin):
 
     def __invert__(self) -> PredicateComposition | Any:
         if self.param_type == "selection":
-            return core.PredicateComposition({"not": {"param": self.name}})
+            param_dict = {"param": self.name}
+            if isinstance(self.empty, bool):
+                param_dict["empty"] = self.empty
+            return core.PredicateComposition({"not": param_dict})
         else:
             return _expr_core.OperatorMixin.__invert__(self)
 
     def __and__(self, other: Any) -> PredicateComposition | Any:
         if self.param_type == "selection":
+            self_dict = {"param": self.name}
+            if isinstance(self.empty, bool):
+                self_dict["empty"] = self.empty
             if isinstance(other, Parameter):
-                other = {"param": other.name}
-            return core.PredicateComposition({"and": [{"param": self.name}, other]})
+                other_dict = {"param": other.name}
+                if isinstance(other.empty, bool):
+                    other_dict["empty"] = other.empty
+                other = other_dict
+            return core.PredicateComposition({"and": [self_dict, other]})
         else:
             return _expr_core.OperatorMixin.__and__(self, other)
 
     def __or__(self, other: Any) -> PredicateComposition | Any:
         if self.param_type == "selection":
+            self_dict = {"param": self.name}
+            if isinstance(self.empty, bool):
+                self_dict["empty"] = self.empty
             if isinstance(other, Parameter):
-                other = {"param": other.name}
-            return core.PredicateComposition({"or": [{"param": self.name}, other]})
+                other_dict = {"param": other.name}
+                if isinstance(other.empty, bool):
+                    other_dict["empty"] = other.empty
+                other = other_dict
+            return core.PredicateComposition({"or": [self_dict, other]})
         else:
             return _expr_core.OperatorMixin.__or__(self, other)
 

--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -410,7 +410,7 @@ class Parameter(_expr_core.OperatorMixin):
 
     def __invert__(self) -> PredicateComposition | Any:
         if self.param_type == "selection":
-            param_dict = {"param": self.name}
+            param_dict: dict[str, str | bool] = {"param": self.name}
             if isinstance(self.empty, bool):
                 param_dict["empty"] = self.empty
             return core.PredicateComposition({"not": param_dict})
@@ -419,11 +419,11 @@ class Parameter(_expr_core.OperatorMixin):
 
     def __and__(self, other: Any) -> PredicateComposition | Any:
         if self.param_type == "selection":
-            self_dict = {"param": self.name}
+            self_dict: dict[str, str | bool] = {"param": self.name}
             if isinstance(self.empty, bool):
                 self_dict["empty"] = self.empty
             if isinstance(other, Parameter):
-                other_dict = {"param": other.name}
+                other_dict: dict[str, str | bool] = {"param": other.name}
                 if isinstance(other.empty, bool):
                     other_dict["empty"] = other.empty
                 other = other_dict
@@ -433,11 +433,11 @@ class Parameter(_expr_core.OperatorMixin):
 
     def __or__(self, other: Any) -> PredicateComposition | Any:
         if self.param_type == "selection":
-            self_dict = {"param": self.name}
+            self_dict: dict[str, str | bool] = {"param": self.name}
             if isinstance(self.empty, bool):
                 self_dict["empty"] = self.empty
             if isinstance(other, Parameter):
-                other_dict = {"param": other.name}
+                other_dict: dict[str, str | bool] = {"param": other.name}
                 if isinstance(other.empty, bool):
                     other_dict["empty"] = other.empty
                 other = other_dict

--- a/tests/vegalite/v6/test_api.py
+++ b/tests/vegalite/v6/test_api.py
@@ -1027,6 +1027,91 @@ def test_selection():
     assert len(names) == 3
 
 
+def test_selection_empty_property_preservation():
+    """Test that the empty property is preserved in logical operations on selections."""
+    # Test basic selection with empty=False
+    click = alt.selection_point("click", empty=False)
+    ctrl_click = alt.selection_point(
+        name="ctrl_click", on="click[event.ctrlKey]", empty=True
+    )
+
+    # Test AND operation preserves empty properties
+    and_result = (click & ctrl_click).to_dict()
+    expected_and = {
+        "and": [
+            {"param": "click", "empty": False},
+            {"param": "ctrl_click", "empty": True},
+        ]
+    }
+    assert and_result == expected_and
+
+    # Test with both selections having empty=False
+    ctrl_click_false = alt.selection_point(
+        name="ctrl_click_false", on="click[event.ctrlKey]", empty=False
+    )
+    and_result_false = (ctrl_click_false & ctrl_click).to_dict()
+    expected_and_false = {
+        "and": [
+            {"param": "ctrl_click_false", "empty": False},
+            {"param": "ctrl_click", "empty": True},
+        ]
+    }
+    assert and_result_false == expected_and_false
+
+    # Test OR operation preserves empty properties
+    or_result = (click | ctrl_click).to_dict()
+    expected_or = {
+        "or": [
+            {"param": "click", "empty": False},
+            {"param": "ctrl_click", "empty": True},
+        ]
+    }
+    assert or_result == expected_or
+
+    # Test NOT operation preserves empty property
+    not_result = (~click).to_dict()
+    expected_not = {"not": {"param": "click", "empty": False}}
+    assert not_result == expected_not
+
+    # Test complex nested operations
+    complex_result = ((click & ctrl_click) | (~ctrl_click_false)).to_dict()
+    expected_complex = {
+        "or": [
+            {
+                "and": [
+                    {"param": "click", "empty": False},
+                    {"param": "ctrl_click", "empty": True},
+                ]
+            },
+            {"not": {"param": "ctrl_click_false", "empty": False}},
+        ]
+    }
+    assert complex_result == expected_complex
+
+    # Test with interval selections
+    interval_false = alt.selection_interval(name="interval_false", empty=False)
+    interval_true = alt.selection_interval(name="interval_true", empty=True)
+
+    interval_and = (interval_false & interval_true).to_dict()
+    expected_interval_and = {
+        "and": [
+            {"param": "interval_false", "empty": False},
+            {"param": "interval_true", "empty": True},
+        ]
+    }
+    assert interval_and == expected_interval_and
+
+    # Test mixed selection types
+    mixed_result = (click & interval_true).to_dict()
+    expected_mixed = {
+        "and": [
+            {"param": "click", "empty": False},
+            {"param": "interval_true", "empty": True},
+        ]
+    }
+    assert mixed_result == expected_mixed
+
+
 def test_transforms():
     # aggregate transform
     agg1 = alt.AggregatedFieldDef(op="mean", field="y", **{"as": "x1"})


### PR DESCRIPTION
Fix https://github.com/vega/altair/issues/3598

Can you review @joelostblom?

Video from your example in raised issue

https://github.com/user-attachments/assets/2eacc34c-1d18-426f-9222-b6bf1ce657c5

Your minimal repo now returns:

```python
import altair as alt

click = alt.selection_point("click", empty=False)
ctrl_click = alt.selection_point("ctrl_click", on="click[event.ctrlKey]", empty=True)

>>> (click & ctrl_click).to_dict()
{'and': [{'param': 'click', 'empty': False},
  {'param': 'ctrl_click', 'empty': True}]}

ctrl_click_false = alt.selection_point("ctrl_click_false", on="click[event.ctrlKey]", empty=False)

>>> (ctrl_click_false & ctrl_click).to_dict()
{'and': [{'param': 'ctrl_click_false', 'empty': False},
  {'param': 'ctrl_click', 'empty': True}]}
```