### PR TITLE
ci: fix mypy unused-ignore in tests

### DIFF
--- a/tests/vegalite/v6/test_theme.py
+++ b/tests/vegalite/v6/test_theme.py
@@ -1070,8 +1070,9 @@ def test_theme_config(theme_func: Callable[[], ThemeConfig], chart) -> None:
 def config_keys() -> frozenset[str]:
     return ConfigKwds.__required_keys__.union(
         ConfigKwds.__optional_keys__,
-        ConfigKwds.__readonly_keys__,  # type: ignore[attr-defined]
-        ConfigKwds.__mutable_keys__,  # type: ignore[attr-defined]
+        # TODO: Remove [attr-defined,unused-ignore] when mypy properly supports TypedDict attributes
+        ConfigKwds.__readonly_keys__,  # type: ignore[attr-defined,unused-ignore]
+        ConfigKwds.__mutable_keys__,  # type: ignore[attr-defined,unused-ignore]
     )
 
 


### PR DESCRIPTION
Fix CI failures from stricter `--warn-unused-ignores` in mypy 1.16.1 (Python 3.13).
Update `# type: ignore[attr-defined]` to `# type: ignore[attr-defined,unused-ignore]` in tests.
Verified on Python 3.12 and 3.13 locally, rely on GitHub Actions CI to cover full version range.

Close https://github.com/vega/altair/issues/3865