### PR TITLE
fix: import TypedDict from typing from python 3.15

### DIFF
--- a/altair/datasets/_typing.py
+++ b/altair/datasets/_typing.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import sys
 from typing import Literal
 
-if sys.version_info >= (3, 14):
+if sys.version_info >= (3, 15):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict

--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -38,7 +38,7 @@ from .schema.core import (
     VariableParameter,
 )
 
-if sys.version_info >= (3, 14):
+if sys.version_info >= (3, 15):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict

--- a/altair/vegalite/v6/schema/_config.py
+++ b/altair/vegalite/v6/schema/_config.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ._typing import *  # noqa: F403
 
 
-if sys.version_info >= (3, 14):
+if sys.version_info >= (3, 15):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict

--- a/altair/vegalite/v6/schema/_typing.py
+++ b/altair/vegalite/v6/schema/_typing.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping, Sequence
 from datetime import date, datetime
 from typing import Annotated, Any, Generic, Literal, TypeVar, Union, get_args
 
-if sys.version_info >= (3, 14):  # https://peps.python.org/pep-0728/
+if sys.version_info >= (3, 15):  # https://peps.python.org/pep-0728/
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict

--- a/tools/datasets/__init__.py
+++ b/tools/datasets/__init__.py
@@ -183,7 +183,7 @@ class Application:
             "from __future__ import annotations\n",
             "import sys",
             "from typing import Literal, TYPE_CHECKING",
-            utils.import_typing_extensions((3, 14), "TypedDict"),
+            utils.import_typing_extensions((3, 15), "TypedDict"),
             utils.import_typing_extensions((3, 11), "LiteralString"),
             utils.import_typing_extensions((3, 10), "TypeAlias"),
             "\n",

--- a/tools/datasets/models.py
+++ b/tools/datasets/models.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Literal
 
-if sys.version_info >= (3, 14):
+if sys.version_info >= (3, 15):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Generic, Literal, TypeVar
 from urllib import request
 
-if sys.version_info >= (3, 14):
+if sys.version_info >= (3, 15):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict
@@ -1273,7 +1273,7 @@ def vegalite_main(skip_download: bool = False) -> None:
             "from collections.abc import Sequence",
             "from ._typing import * # noqa: F403",
         ),
-        import_typing_extensions((3, 14), "TypedDict"),
+        import_typing_extensions((3, 15), "TypedDict"),
         "\n\n",
         *generate_config_typed_dicts(schemafile),
     ]

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -128,7 +128,7 @@ class _TypeAliasTracer:
             "from typing import Annotated, Any, Generic, Literal, TypeVar, Union, get_args",
             "import re",
             import_typing_extensions(
-                (3, 14), "TypedDict", reason="https://peps.python.org/pep-0728/"
+                (3, 15), "TypedDict", reason="https://peps.python.org/pep-0728/"
             ),
             import_typing_extensions((3, 13), "TypeIs"),
             import_typing_extensions((3, 12), "TypeAliasType"),


### PR DESCRIPTION
We were a bit too enthusiastic regarding https://peps.python.org/pep-0728/ and expecting it to be included within python 3.14. This PR imports `TypedDict` from `typing_extensions` for python 3.14 and from `typing` for python 3.15.

Close: https://github.com/vega/altair/issues/3874