### PR TITLE
docs: Remove whitespace after '*' so that text is rendered italic.

### DIFF
--- a/doc/user_guide/transform/regression.rst
+++ b/doc/user_guide/transform/regression.rst
@@ -15,7 +15,7 @@ This transform supports parametric models for the following functional forms:
 
 - linear (``linear``): *y = a + b * x*
 - logarithmic (``log``): *y = a + b * log(x)*
-- exponential (``exp``): * y = a * e^(b * x)*
+- exponential (``exp``): *y = a * e^(b * x)*
 - power (``pow``): *y = a * x^b*
 - quadratic (``quad``): *y = a + b * x + c * x^2*
 - polynomial (``poly``): *y = a + b * x + … + k * x^(order)*


### PR DESCRIPTION
Fixes extra whitespace that prevents text from being rendered as italic in the transform regression docs.