### PR TITLE
docs: note within geoshape mark page to spatial data section

### DIFF
--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -312,6 +312,7 @@ created using Altair's :func:`sphere` generator function. Here is an example:
 .. _pandas melt documentation: https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.melt.html#pandas.DataFrame.melt
 .. _Reshaping and Pivot Tables: https://pandas.pydata.org/pandas-docs/stable/reshaping.html
 
+.. _spatial-data:
 
 Spatial Data
 ~~~~~~~~~~~~

--- a/doc/user_guide/marks/geoshape.rst
+++ b/doc/user_guide/marks/geoshape.rst
@@ -111,6 +111,10 @@ In the following example the input geometry is not projected and is instead rend
         reflectY=True
     )
 
+.. note::
+
+    When working with spatial data, it's important to be aware of coordinate reference systems and geometry winding order. For detailed information on projections and winding order, see the :ref:`Spatial Data <spatial-data>` section in the data guide.
+
 Mapping Polygons
 ^^^^^^^^^^^^^^^^
 The following example maps the visual property of the ``NAME`` column using the ``color`` encoding.


### PR DESCRIPTION
suggestion from here: https://github.com/vega/vega-lite/issues/9700#issuecomment-3398941065

> My apologies for not finding that part of the documentation where it states that - I was exclusively looking at the mark_geoshape() docs instead, might be worth linking it to this section from there as well...