### PR TITLE
docs: fix broken external reference URLs in examples

### DIFF
--- a/tests/examples_methods_syntax/beckers_barley_facet.py
+++ b/tests/examples_methods_syntax/beckers_barley_facet.py
@@ -7,7 +7,7 @@ where each row is a different site (i.e. the chart is faceted by site),
 they identified an anomaly in a widely used agriculatural dataset,
 where the "Morris" site accidentally had the years 1931 and 1932 swapped.
 They named this
-`"The Morris Mistake." <http://ml.stat.purdue.edu/stat695t/writings/Trellis.User.pdf>`_.
+`"The Morris Mistake." <https://www.stat.auckland.ac.nz/~ihaka/courses/120/trellis.user.pdf>`_.
 """
 # category: case studies
 import altair as alt

--- a/tests/examples_methods_syntax/beckers_barley_wrapped_facet.py
+++ b/tests/examples_methods_syntax/beckers_barley_wrapped_facet.py
@@ -7,7 +7,7 @@ where each row is a different site (i.e. the chart is faceted by site),
 they identified an anomaly in a widely used agriculatural dataset,
 where the "Morris" site accidentally had the years 1931 and 1932 swapped.
 They named this
-`"The Morris Mistake." <http://ml.stat.purdue.edu/stat695t/writings/Trellis.User.pdf>`_.
+`"The Morris Mistake." <https://www.stat.auckland.ac.nz/~ihaka/courses/120/trellis.user.pdf>`_.
 """
 # category: case studies
 import altair as alt

--- a/tests/examples_methods_syntax/comet_chart.py
+++ b/tests/examples_methods_syntax/comet_chart.py
@@ -1,7 +1,7 @@
 """
 Comet Chart
 -----------
-Inspired by `Zan Armstrong's comet chart <https://www.zanarmstrong.com/infovisresearch>`_
+Inspired by `Zan Armstrong's comet chart <https://www.zanarmstrong.com/>`_
 this plot uses ``mark_trail`` to visualize change of grouped data over time.
 A more elaborate example and explanation of creating comet charts in Altair
 is shown in `this blogpost <https://medium.com/de-dataverbinders/comet-charts-in-python-visualizing-statistical-mix-effects-and-simpsons-paradox-with-altair-6cd51fb58b7c>`_.

--- a/tests/examples_methods_syntax/ridgeline_plot.py
+++ b/tests/examples_methods_syntax/ridgeline_plot.py
@@ -1,7 +1,7 @@
 """
 Ridgeline plot
 --------------
-A `Ridgeline plot <https://serialmentor.com/blog/2017/9/15/goodbye-joyplots>`_
+A `Ridgeline plot <https://clauswilke.com/blog/2017/09/15/goodbye-joyplots/>`_
 lets you visualize distribution of a numeric value for different
 subsets of data (what we call "facets" in Altair).
 


### PR DESCRIPTION
Updates several broken URLs in example docstrings, identified during link check for https://github.com/vega/vega-datasets/pull/724:
- Trellis User PDF: Update to Auckland University host (beckers_barley_facet.py, beckers_barley_wrapped_facet.py)
- Joyplots blog: Update to clauswilke.com domain (ridgeline_plot.py)
- Zan Armstrong: Update to homepage (comet_chart.py)

All original URLs returned 404 errors or connection failures. New URLs verified accessible.