### PR TITLE
fix: Correct tooltip field for faceted choropleth example

### DIFF
--- a/tests/examples_arguments_syntax/maps_faceted_species.py
+++ b/tests/examples_arguments_syntax/maps_faceted_species.py
@@ -25,7 +25,7 @@ chart = alt.Chart(csv_data).mark_geoshape().encode(
         legend=alt.Legend(format='.0%')
     ),
     tooltip=[
-        alt.Tooltip('id:N', title='County ID'),
+        alt.Tooltip('county_id:N', title='County ID'),
         alt.Tooltip('habitat_yearround_pct:Q', title='Habitat %', format='.2%')
     ],
     facet=alt.Facet('common_name:N', columns=2, title=None),


### PR DESCRIPTION
Fix #3919.

This PR aims to provide the required changes to the tooltip reference in order to display the correct County id