### PR TITLE
fix: wrong tooltip variable id -> county_id

### DIFF
--- a/tests/examples_methods_syntax/maps_faceted_species.py
+++ b/tests/examples_methods_syntax/maps_faceted_species.py
@@ -23,7 +23,7 @@ chart = alt.Chart(csv_data).mark_geoshape().encode(
     .title(['Suitable Habitat', '% of County'])
     .legend(format='.0%'),
     tooltip=[
-        alt.Tooltip('id:N').title('County ID'),
+        alt.Tooltip('county_id:N').title('County ID'),
         alt.Tooltip('habitat_yearround_pct:Q').title('Habitat %').format('.2%')
     ],
     facet=alt.Facet('common_name:N', columns=2).title(None),


### PR DESCRIPTION
The changes made  in commit [ae5579b](https://github.com/vega/altair/commit/ae5579b775e4bee74019f4efb580e53d8a989dfa) should have likely been made two both implementations, the one in `tests/examples_arguments_syntax/maps_faceted_species.py` and the one in `tests/examples_methods_syntax/maps_faceted_species.py`. This PR adds the change for `tests/examples_methods_syntax/maps_faceted_species.py`.