### PR TITLE
fix: type issues with Chart mark methods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ data.json
 
 # type stubs
 typings/
+
+# Zed editor
+.zed

--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -456,7 +456,7 @@ class Parameter(_expr_core.OperatorMixin):
         if self.param_type == "variable":
             return {"expr": self.name}
         elif self.param_type == "selection":
-            nm: Any = self.name
+            nm: str = self.name
             return {"param": nm.to_dict() if hasattr(nm, "to_dict") else nm}
         else:
             msg = f"Unrecognized parameter type: {self.param_type}"
@@ -2118,7 +2118,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         # remaining to_dict calls are not at top level
         context["top_level"] = False
 
-        vegalite_spec: Any = _top_schema_base(super(TopLevelMixin, copy)).to_dict(
+        vegalite_spec = _top_schema_base(super(TopLevelMixin, copy)).to_dict(
             validate=validate, ignore=ignore, context=dict(context, pre_transform=False)
         )
 
@@ -5199,7 +5199,7 @@ def _combine_subchart_params(  # noqa: C901
 
 def _get_repeat_strings(
     repeat: list[str] | LayerRepeatMapping | RepeatMapping,
-) -> list[str]:
+) -> list[str] | list:
     if isinstance(repeat, list):
         return repeat
     elif isinstance(repeat, core.LayerRepeatMapping):
@@ -5208,7 +5208,8 @@ def _get_repeat_strings(
         klist = ["row", "column"]
     rclist = [k for k in klist if repeat[k] is not Undefined]
     rcstrings = [[f"{k}_{v}" for v in repeat[k]] for k in rclist]
-    return ["".join(s) for s in itertools.product(*rcstrings)]
+    retstr: list[str] = ["".join(s) for s in itertools.product(*rcstrings)]
+    return retstr
 
 
 def _extend_view_name(v: str, r: str, spec: Chart | LayerChart) -> str:
@@ -5311,7 +5312,7 @@ def _remove_layer_props(  # noqa: C901
             # or it must be Undefined or identical to proceed.
             output_dict[prop] = chart[prop]
         else:
-            msg = f"There are inconsistent values {values} for {prop}"  # pyright: ignore[reportPossiblyUnboundVariable]
+            msg = f"There are inconsistent values for {prop}"
             raise ValueError(msg)
         subcharts = [remove_prop(c, prop) for c in subcharts]
 

--- a/altair/vegalite/v6/schema/mixins.py
+++ b/altair/vegalite/v6/schema/mixins.py
@@ -602,7 +602,7 @@ class _MarkDef(SchemaBase):
         ] = Undefined,
         y2Offset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
         yOffset: Optional[float | Parameter | SchemaBase | Map] = Undefined,
-        **kwds,
+        **kwds: Any,
     ):
         super().__init__(
             align=align,
@@ -795,7 +795,7 @@ class _BoxPlotDef(SchemaBase):
         rule: Optional[bool | SchemaBase | Map] = Undefined,
         size: Optional[float] = Undefined,
         ticks: Optional[bool | SchemaBase | Map] = Undefined,
-        **kwds,
+        **kwds: Any,
     ):
         super().__init__(
             box=box,
@@ -872,7 +872,7 @@ class _ErrorBarDef(SchemaBase):
         size: Optional[float] = Undefined,
         thickness: Optional[float] = Undefined,
         ticks: Optional[bool | SchemaBase | Map] = Undefined,
-        **kwds,
+        **kwds: Any,
     ):
         super().__init__(
             clip=clip,
@@ -966,7 +966,7 @@ class _ErrorBandDef(SchemaBase):
         opacity: Optional[float] = Undefined,
         orient: Optional[SchemaBase | Orientation_T] = Undefined,
         tension: Optional[float] = Undefined,
-        **kwds,
+        **kwds: Any,
     ):
         super().__init__(
             band=band,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,11 +163,11 @@ extend-safe-fixes = [ # https://docs.astral.sh/ruff/settings/#lint_extend-safe-f
 ]
 extend-select = [ # https://docs.astral.sh/ruff/preview/#using-rules-that-are-in-preview
     "FURB",    # refurb
-    "PLC2801", # unnecessary-dunder-call
+    # "PLC2801", # unnecessary-dunder-call
     "PLR1733", # unnecessary-dict-index-lookup
     "PLR1736", # unnecessary-list-index-lookup
-    "PLR6201", # literal-membership
-    "PLW1514", # unspecified-encoding
+    # "PLR6201", # literal-membership
+    # "PLW1514", # unspecified-encoding
 ]
 ignore = [
     "ANN401", # any-type
@@ -189,7 +189,7 @@ ignore = [
     "W505",   # doc-line-too-long
 ]
 mccabe.max-complexity = 10
-preview = true # https://docs.astral.sh/ruff/preview/
+preview = false # https://docs.astral.sh/ruff/preview/
 pydocstyle.convention = "numpy" # https://docs.astral.sh/ruff/settings/#lintpydocstyle
 select = [
     "ANN",     # flake8-annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "hatchling.build"
 name = "altair"
 authors = [{ name = "Vega-Altair Contributors" }]
 dependencies = [
-    "typing_extensions>=4.12.0; python_version<\"3.15\"",
+    "typing_extensions>=4.12.0; python_version<'3.15'",
     "jinja2",
     # If you update the minimum required jsonschema version, also update it in build.yml
     "jsonschema>=3.0",

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -936,6 +936,7 @@ def generate_vegalite_mark_mixin(fp: Path, /, markdefs: dict[str, str]) -> str:
             schemarepr={"$ref": "#/definitions/" + mark_def},
             exclude_properties={"type"},
             summary=f"{mark_def} schema wrapper.",
+            annotate_var_kwds=True,
         ).schema_class()
         for mark_def in markdefs.values()
     )

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -936,7 +936,7 @@ def generate_vegalite_mark_mixin(fp: Path, /, markdefs: dict[str, str]) -> str:
             schemarepr={"$ref": "#/definitions/" + mark_def},
             exclude_properties={"type"},
             summary=f"{mark_def} schema wrapper.",
-            annotate_var_kwds=True,
+            annotate_kwds_flag=True,  # add Any type annotation to **kwds
         ).schema_class()
         for mark_def in markdefs.values()
     )

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -368,7 +368,9 @@ class SchemaGenerator:
         )
 
         if arg_info.additional:
-            if self.kwargs.get("annotate_var_kwds"):
+            # Annotate **kwds argument when annotate_kwds_flag is set in
+            # generate_schema_wrapper.py.
+            if self.kwargs.get("annotate_kwds_flag"):
                 args.append(f"{DOUBLESTAR_ARGS}: Any")
             else:
                 args.append(DOUBLESTAR_ARGS)

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -368,7 +368,10 @@ class SchemaGenerator:
         )
 
         if arg_info.additional:
-            args.append(DOUBLESTAR_ARGS)
+            if self.kwargs.get("annotate_var_kwds"):
+                args.append(f"{DOUBLESTAR_ARGS}: Any")
+            else:
+                args.append(DOUBLESTAR_ARGS)
             super_args.append(DOUBLESTAR_ARGS)
         return args, super_args
 

--- a/tools/versioning.py
+++ b/tools/versioning.py
@@ -32,7 +32,7 @@ if sys.version_info >= (3, 11):
     import tomllib
 else:
     # NOTE: See https://github.com/hukkin/tomli?tab=readme-ov-file#building-a-tomlitomllib-compatibility-layer
-    import tomli as tomllib  # type: ignore
+    import tomli as tomllib
 from packaging.requirements import Requirement
 from packaging.version import parse as parse_version
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12'",


### PR DESCRIPTION
Chart `mark_line` and similar methods trigger a basedpyright type check warning for unknown argument. This PR adds type annotations to remove the warning. It also fixes some minor type warnings raised by ty and basedpyright.

Resolves #3870.