### PR TITLE
feat: add ensure_ascii option to to_json() with default False

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -1245,6 +1245,7 @@ class SchemaBase:
         indent: int | str | None = 2,
         sort_keys: bool = True,
         *,
+        ensure_ascii: bool = False,
         ignore: list[str] | None = None,
         context: dict[str, Any] | None = None,
         **kwargs,
@@ -1260,6 +1261,9 @@ class SchemaBase:
             The number of spaces of indentation to use. The default is 2.
         sort_keys : bool, optional
             If True (default), sort keys in the output.
+        ensure_ascii : bool, optional
+            If False (default), non-ASCII characters are output as-is.
+            If True, non-ASCII characters are escaped as \\uXXXX sequences.
         ignore : list[str], optional
             A list of keys to ignore.
         context : dict[str, Any], optional
@@ -1282,7 +1286,9 @@ class SchemaBase:
         if context is None:
             context = {}
         dct = self.to_dict(validate=validate, ignore=ignore, context=context)
-        return json.dumps(dct, indent=indent, sort_keys=sort_keys, **kwargs)
+        return json.dumps(
+            dct, indent=indent, sort_keys=sort_keys, ensure_ascii=ensure_ascii, **kwargs
+        )
 
     @classmethod
     def _default_wrapper_classes(cls) -> Iterator[type[SchemaBase]]:

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -372,6 +372,20 @@ def test_to_from_json(dct):
     assert new_dct == dct
 
 
+def test_to_json_ensure_ascii():
+    """Test that to_json preserves UTF-8 characters by default (ensure_ascii=False)."""
+    # Create a schema with non-ASCII characters
+    dct = {"name": "test", "title": "中文标题"}
+    json_str = MySchema.from_dict(dct).to_json()
+
+    # By default, UTF-8 characters should be preserved
+    assert "中文标题" in json_str
+
+    # With ensure_ascii=True, characters should be escaped
+    json_str_ascii = MySchema.from_dict(dct).to_json(ensure_ascii=True)
+    assert "\\u4e2d" in json_str_ascii  # Unicode escape sequence for 中
+
+
 def test_to_from_pickle(dct):
     myschema = MySchema.from_dict(dct)
     output = io.BytesIO()

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -1243,6 +1243,7 @@ class SchemaBase:
         indent: int | str | None = 2,
         sort_keys: bool = True,
         *,
+        ensure_ascii: bool = False,
         ignore: list[str] | None = None,
         context: dict[str, Any] | None = None,
         **kwargs,
@@ -1258,6 +1259,9 @@ class SchemaBase:
             The number of spaces of indentation to use. The default is 2.
         sort_keys : bool, optional
             If True (default), sort keys in the output.
+        ensure_ascii : bool, optional
+            If False (default), non-ASCII characters are output as-is.
+            If True, non-ASCII characters are escaped as \\uXXXX sequences.
         ignore : list[str], optional
             A list of keys to ignore.
         context : dict[str, Any], optional
@@ -1280,7 +1284,9 @@ class SchemaBase:
         if context is None:
             context = {}
         dct = self.to_dict(validate=validate, ignore=ignore, context=context)
-        return json.dumps(dct, indent=indent, sort_keys=sort_keys, **kwargs)
+        return json.dumps(
+            dct, indent=indent, sort_keys=sort_keys, ensure_ascii=ensure_ascii, **kwargs
+        )
 
     @classmethod
     def _default_wrapper_classes(cls) -> Iterator[type[SchemaBase]]:


### PR DESCRIPTION
Fixes #3925

This change adds an `ensure_ascii` parameter to the `to_json()` method that:
- Defaults to `False` to preserve UTF-8 characters (better for international users)
- Allows users to explicitly set `ensure_ascii=True` for ASCII-only output

This helps international users who have non-ASCII characters in their charts.

## Changes
- Added `ensure_ascii: bool = False` parameter to `SchemaBase.to_json()` method
- Updated docstring to document the new parameter
- Passed the parameter to `json.dumps()`
- Updated both the runtime module (`altair/utils/schemapi.py`) and the template (`tools/schemapi/schemapi.py`)
- Added test case for the new functionality

## Example Usage
```python
import altair as alt

# Create a chart with non-ASCII characters (e.g., Chinese)
chart = alt.Chart(...).encode(
    alt.X('field').title('中文标题')  # Chinese title
)

# Default: UTF-8 characters preserved
json_output = chart.to_json()

# Explicit: ASCII-only output with escaped characters
json_output_ascii = chart.to_json(ensure_ascii=True)
```