### PR TITLE
feat: add ensure_ascii option to to_json() with default False

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -1286,7 +1286,9 @@ class SchemaBase:
         if context is None:
             context = {}
         dct = self.to_dict(validate=validate, ignore=ignore, context=context)
-        return json.dumps(dct, indent=indent, sort_keys=sort_keys, ensure_ascii=ensure_ascii, **kwargs)
+        return json.dumps(
+            dct, indent=indent, sort_keys=sort_keys, ensure_ascii=ensure_ascii, **kwargs
+        )
 
     @classmethod
     def _default_wrapper_classes(cls) -> Iterator[type[SchemaBase]]:

--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -2218,7 +2218,13 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         spec = self.to_dict(
             validate=validate, format=format, ignore=ignore, context=context
         )
-        return json.dumps(spec, indent=indent, sort_keys=sort_keys, ensure_ascii=ensure_ascii, **kwargs)
+        return json.dumps(
+            spec,
+            indent=indent,
+            sort_keys=sort_keys,
+            ensure_ascii=ensure_ascii,
+            **kwargs,
+        )
 
     def to_html(
         self,

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -1284,7 +1284,9 @@ class SchemaBase:
         if context is None:
             context = {}
         dct = self.to_dict(validate=validate, ignore=ignore, context=context)
-        return json.dumps(dct, indent=indent, sort_keys=sort_keys, ensure_ascii=ensure_ascii, **kwargs)
+        return json.dumps(
+            dct, indent=indent, sort_keys=sort_keys, ensure_ascii=ensure_ascii, **kwargs
+        )
 
     @classmethod
     def _default_wrapper_classes(cls) -> Iterator[type[SchemaBase]]:


### PR DESCRIPTION
Add ensure_ascii parameter to to_json() method with default False to preserve UTF-8 characters for better international user support.

This re-creates the functionality from the original PR #3948.