### PR TITLE
revert: "fix: Ensure name uniqueness for concatenated facets (#3964)"

### DIFF
--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -5166,10 +5166,6 @@ def _combine_subchart_params(  # noqa: C901
             # Use the hash as a base but append the position to ensure uniqueness
             base_name = subchart._get_view_hash_name()
             subchart.name = f"{base_name}_{i}"
-        # Increment names properly for concatenated facet charts to ensure uniqueness
-        elif i > 0 and isinstance(subchart, FacetChart):
-            name_prefix, _ = subchart.spec.name.rsplit("_", 1)
-            subchart.spec.name = f"{name_prefix}_{i}"
 
         for param in subchart.params:
             p = _prepare_to_lift(param)

--- a/tests/vegalite/v6/test_params.py
+++ b/tests/vegalite/v6/test_params.py
@@ -365,25 +365,3 @@ def test_interactive_name_respected():
     assert base_name_0 == expected_base_name, (
         f"Expected base name {expected_base_name}, got {base_name_0}"
     )
-
-
-def test_concat_facet_enumeration():
-    df = pd.DataFrame(
-        {
-            "x": [1, 2, 3, 4],
-            "y": [1, 2, 3, 4],
-            "z": [0, 0, 1, 1],
-        }
-    )
-    c = alt.Chart(df).mark_line().encode(x="x", y="y").facet("z")
-    # Unique names to since this is not related to parameter deduplication
-    p1 = alt.selection_point(name="p1")
-    p2 = alt.selection_point(name="p2")
-    p3 = alt.selection_point(name="p3")
-    concat_facet = c.add_params(p1) & c.add_params(p2) & c.add_params(p3)
-
-    # Test that concatenation of faceted charts result in a unique name for each chart.
-    # https://github.com/vega/altair/issues/3954
-    assert concat_facet.vconcat[0].spec.name != concat_facet.vconcat[1].spec.name
-    assert concat_facet.vconcat[0].spec.name != concat_facet.vconcat[2].spec.name
-    assert concat_facet.vconcat[1].spec.name != concat_facet.vconcat[2].spec.name


### PR DESCRIPTION
Given the discovery of failing test-case in https://github.com/vega/altair/pull/3964#issuecomment-3961158250 it is probably best to revert the last commit [2e53a1f63fffc1592f6a33f83760566411d511a9](https://github.com/vega/altair/commit/2e53a1f63fffc1592f6a33f83760566411d511a9).



