### PR TITLE
chore: Move pytest `addopts` to `testpaths`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,12 +314,10 @@ norecursedirs = [
     "tests/examples_arguments_syntax",
     "tests/examples_methods_syntax"
 ]
+testpaths = ["tests","altair","tools"]
 addopts = [
     "--numprocesses=logical",
     "--doctest-modules",
-    "tests",
-    "altair",
-    "tools",
     "-m not datasets_debug and not no_xdist",
 ]
 # https://docs.pytest.org/en/stable/how-to/mark.html#registering-marks


### PR DESCRIPTION
See [testpaths](https://docs.pytest.org/en/stable/reference/reference.html#confval-testpaths)

The current config meant that trying to invoke a [single test](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) would pull in everything
