### PR TITLE
fix: unique view names per concat cell and correct param.views

### DIFF
--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -5204,44 +5204,30 @@ def _remove_duplicate_params(layer: list[ChartType]) -> list[ChartType]:
     return subcharts
 
 
-def _view_name_base(name: str | None) -> str:
-    """Strip a trailing _<digits> from a view name to get a reusable base."""
-    if not name:
-        return "view_0"
+def _view_base_for_chart(obj: Any) -> str:
+    """Return a base view name for a chart/layer (for building position-based names)."""
+    name = obj.name
     parts = name.rsplit("_", 1)
     if len(parts) == 2 and parts[1].isdigit():
         return parts[0] or name
     return name
 
 
-def _view_base_for_chart(obj: Any) -> str:
-    """Return a base view name for a chart/layer (for building position-based names)."""
-    name = getattr(obj, "name", None)
-    if name is None or name is Undefined:
-        name = (
-            obj._get_view_hash_name() if hasattr(obj, "_get_view_hash_name") else None
-        )
-    return _view_name_base(name)
-
-
-def _view_name_for_param(
-    subchart: ChartType, param_idx: int, is_concat: bool
-) -> str | None:
-    """View name for this subchart to add to a param's views, or None."""
+def _view_name_for_param(subchart: ChartType, is_concat: bool) -> str:
+    """View name for this subchart to add to a param's views."""
     if isinstance(subchart, Chart):
         return subchart.name
     if (
         is_concat
         and isinstance(subchart, FacetChart)
         and subchart.spec is not Undefined
-        and param_idx == 0
     ):
         spec = subchart.spec
         if isinstance(spec, Chart):
-            return getattr(spec, "name", None)
+            return spec.name
         if isinstance(spec, LayerChart) and spec.layer:
-            return getattr(spec.layer[0], "name", None)
-    return None
+            return spec.layer[0].name
+    return ""
 
 
 def _combine_subchart_params(  # noqa: C901
@@ -5288,7 +5274,7 @@ def _combine_subchart_params(  # noqa: C901
             elif isinstance(spec, Chart):
                 spec.name = f"{_view_base_for_chart(spec)}_{i}"
 
-        for param_idx, param in enumerate(subchart.params):
+        for param in subchart.params:
             p = _prepare_to_lift(param)
             pd = _viewless_dict(p)
 
@@ -5304,7 +5290,7 @@ def _combine_subchart_params(  # noqa: C901
 
             # At this stage in the loop, p must be a TopLevelSelectionParameter.
             # Get this subchart's view name from the subchart only (not p.views: params can share lists).
-            view_to_add = _view_name_for_param(subchart, param_idx, is_concat)
+            view_to_add = _view_name_for_param(subchart, is_concat)
             # MERGE: start from param's views; APPEND: start from [] so we don't pull in another param's views.
             views_after = list(p.views or []) if found else []
             if view_to_add and view_to_add not in views_after:

--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -5219,9 +5219,7 @@ def _view_base_for_chart(obj: Any) -> str:
     name = getattr(obj, "name", None)
     if name is None or name is Undefined:
         name = (
-            obj._get_view_hash_name()
-            if hasattr(obj, "_get_view_hash_name")
-            else None
+            obj._get_view_hash_name() if hasattr(obj, "_get_view_hash_name") else None
         )
     return _view_name_base(name)
 
@@ -5261,7 +5259,9 @@ def _combine_subchart_params(  # noqa: C901
         views = (
             []
             if isinstance(p, core.VariableParameter)
-            else list(p.views) if p.views else []
+            else list(p.views)
+            if p.views
+            else []
         )
         param_info.append((p, _viewless_dict(p), views))
 

--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -5217,11 +5217,7 @@ def _view_name_for_param(subchart: ChartType, is_concat: bool) -> str:
     """View name for this subchart to add to a param's views."""
     if isinstance(subchart, Chart):
         return subchart.name
-    if (
-        is_concat
-        and isinstance(subchart, FacetChart)
-        and subchart.spec is not Undefined
-    ):
+    if is_concat and isinstance(subchart, FacetChart):
         spec = subchart.spec
         if isinstance(spec, Chart):
             return spec.name

--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -5204,27 +5204,69 @@ def _remove_duplicate_params(layer: list[ChartType]) -> list[ChartType]:
     return subcharts
 
 
+def _view_name_base(name: str | None) -> str:
+    """Strip a trailing _<digits> from a view name to get a reusable base."""
+    if not name:
+        return "view_0"
+    parts = name.rsplit("_", 1)
+    if len(parts) == 2 and parts[1].isdigit():
+        return parts[0] or name
+    return name
+
+
+def _view_base_for_chart(obj: Any) -> str:
+    """Return a base view name for a chart/layer (for building position-based names)."""
+    name = getattr(obj, "name", None)
+    if name is None or name is Undefined:
+        name = (
+            obj._get_view_hash_name()
+            if hasattr(obj, "_get_view_hash_name")
+            else None
+        )
+    return _view_name_base(name)
+
+
+def _view_name_for_param(
+    subchart: ChartType, param_idx: int, is_concat: bool
+) -> str | None:
+    """View name for this subchart to add to a param's views, or None."""
+    if isinstance(subchart, Chart):
+        return subchart.name
+    if (
+        is_concat
+        and isinstance(subchart, FacetChart)
+        and subchart.spec is not Undefined
+        and param_idx == 0
+    ):
+        spec = subchart.spec
+        if isinstance(spec, Chart):
+            return getattr(spec, "name", None)
+        if isinstance(spec, LayerChart) and spec.layer:
+            return getattr(spec.layer[0], "name", None)
+    return None
+
+
 def _combine_subchart_params(  # noqa: C901
     params: Optional[Sequence[_Parameter]], subcharts: list[ChartType]
 ) -> tuple[Optional[Sequence[_Parameter]], list[ChartType]]:
     if utils.is_undefined(params):
         params = []
-
     # List of triples related to params, (param, dictionary minus views, views)
     param_info: list[tuple[_Parameter, dict[str, Any], list[str]]] = []
 
-    # Put parameters already found into `param_info` list.
+    # Put parameters already found into `param_info`. Copy each param's views so we can
+    # mutate the list in the MERGE branch and so no two entries share the same list.
     for param in params:
         p = _prepare_to_lift(param)
-        param_info.append(
-            (
-                p,
-                _viewless_dict(p),
-                [] if isinstance(p, core.VariableParameter) else p.views,
-            )
+        views = (
+            []
+            if isinstance(p, core.VariableParameter)
+            else list(p.views) if p.views else []
         )
+        param_info.append((p, _viewless_dict(p), views))
 
     subcharts = [subchart.copy() for subchart in subcharts]
+    is_concat = len(subcharts) > 1
 
     for i, subchart in enumerate(subcharts):
         if (not hasattr(subchart, "params")) or (utils.is_undefined(subchart.params)):
@@ -5236,7 +5278,17 @@ def _combine_subchart_params(  # noqa: C901
             base_name = subchart._get_view_hash_name()
             subchart.name = f"{base_name}_{i}"
 
-        for param in subchart.params:
+        # In concat, FacetCharts get the same content-hash view name; disambiguate by position.
+        if is_concat and isinstance(subchart, FacetChart):
+            spec = subchart.spec
+            subchart.spec = spec.copy(deep=True)
+            spec = subchart.spec
+            if isinstance(spec, LayerChart) and spec.layer:
+                spec.layer[0].name = f"{_view_base_for_chart(spec.layer[0])}_{i}"
+            elif isinstance(spec, Chart):
+                spec.name = f"{_view_base_for_chart(spec)}_{i}"
+
+        for param_idx, param in enumerate(subchart.params):
             p = _prepare_to_lift(param)
             pd = _viewless_dict(p)
 
@@ -5251,14 +5303,17 @@ def _combine_subchart_params(  # noqa: C901
                 continue
 
             # At this stage in the loop, p must be a TopLevelSelectionParameter.
-
-            if isinstance(subchart, Chart) and (subchart.name not in p.views):
-                p.views.append(subchart.name)
+            # Get this subchart's view name from the subchart only (not p.views: params can share lists).
+            view_to_add = _view_name_for_param(subchart, param_idx, is_concat)
+            # MERGE: start from param's views; APPEND: start from [] so we don't pull in another param's views.
+            views_after = list(p.views or []) if found else []
+            if view_to_add and view_to_add not in views_after:
+                views_after.append(view_to_add)
 
             if found:
-                i = dlist.index(pd)
-                _, _, old_views = param_info[i]
-                new_views = [v for v in p.views if v not in old_views]
+                merge_idx = dlist.index(pd)
+                _, _, old_views = param_info[merge_idx]
+                new_views = [v for v in views_after if v not in old_views]
                 old_views += new_views
 
                 # Warn when parameters get deduplicated
@@ -5270,7 +5325,7 @@ def _combine_subchart_params(  # noqa: C901
                     stacklevel=5,
                 )
             else:
-                param_info.append((p, pd, p.views))
+                param_info.append((p, pd, views_after))
 
         subchart.params = Undefined
 

--- a/tests/vegalite/v6/test_api.py
+++ b/tests/vegalite/v6/test_api.py
@@ -2165,3 +2165,21 @@ def test_concat_faceted_shared_param_both_views_issue_3954():
         _view_name_of_concat_cell(vconcat[0]),
         _view_name_of_concat_cell(vconcat[1]),
     }
+
+
+def test_concat_faceted_two_shared_params_both_views_issue_3954():
+    """Regression for #3954: concat of two faceted charts with two shared params — each param must list both cell views."""
+    data = pd.DataFrame({"x": [1, 2, 3, 4], "y": [1, 2, 3, 4], "z": [0, 0, 1, 1]})
+    c = alt.Chart(data).mark_line().encode(x="x", y="y").facet("z")
+    p1 = alt.selection_point(name="p1")
+    p2 = alt.selection_point(name="p2")
+    with warnings.catch_warnings(record=True):
+        spec = (c.add_params(p1, p2) & c.add_params(p1, p2)).to_dict()
+    params = spec["params"]
+    vconcat = spec["vconcat"]
+    assert len(params) == 2
+    assert len(vconcat) == 2
+    view0 = _view_name_of_concat_cell(vconcat[0])
+    view1 = _view_name_of_concat_cell(vconcat[1])
+    for p in params:
+        assert set(p["views"]) == {view0, view1}

--- a/tests/vegalite/v6/test_api.py
+++ b/tests/vegalite/v6/test_api.py
@@ -2139,14 +2139,17 @@ def test_concat_faceted_three_params_unique_views_per_param_issue_3954():
         spec = (c.add_params(p1) & c.add_params(p2) & c.add_params(p3)).to_dict()
     params = spec["params"]
     vconcat = spec["vconcat"]
-    assert len(params) == 3 and len(vconcat) == 3
+    assert len(params) == 3
+    assert len(vconcat) == 3
     for i in range(3):
         assert params[i]["views"] == [_view_name_of_concat_cell(vconcat[i])]
 
 
 def test_concat_faceted_shared_param_both_views_issue_3954():
     """Regression for #3954: concat of two faceted charts with one shared param — param lists both cell views."""
-    data = pd.DataFrame({"x": [1, 2], "y": [3, 4], "row": ["a", "b"], "col": ["c", "d"]})
+    data = pd.DataFrame(
+        {"x": [1, 2], "y": [3, 4], "row": ["a", "b"], "col": ["c", "d"]}
+    )
     manual = alt.layer(
         alt.Chart(data).mark_point().encode(x="x:Q", y="y:Q"),
         alt.Chart(data).mark_line().encode(x="x:Q", y="y:Q"),
@@ -2156,7 +2159,8 @@ def test_concat_faceted_shared_param_both_views_issue_3954():
         spec = (manual & manual).add_params(selection).to_dict()
     params = spec["params"]
     vconcat = spec["vconcat"]
-    assert len(params) == 1 and len(vconcat) == 2
+    assert len(params) == 1
+    assert len(vconcat) == 2
     assert set(params[0]["views"]) == {
         _view_name_of_concat_cell(vconcat[0]),
         _view_name_of_concat_cell(vconcat[1]),

--- a/tests/vegalite/v6/test_api.py
+++ b/tests/vegalite/v6/test_api.py
@@ -2116,3 +2116,48 @@ def test_binding() -> None:
     # NOTE: Both type checkers can detect the issue on the new signature
     with pytest.raises(TypeError, match=MISSING_INPUT):
         alt.binding(placeholder="Country", name="Search")  # type: ignore[call-arg]
+
+
+def _view_name_of_concat_cell(cell: dict) -> str:
+    """View name used by a single vconcat/hconcat cell (facet spec)."""
+    spec = cell.get("spec", {})
+    if "layer" in spec:
+        return spec["layer"][0]["name"]
+    return spec["name"]
+
+
+def test_concat_faceted_three_params_unique_views_per_param_issue_3954():
+    """Regression for #3954: concat of three faceted charts with p1, p2, p3 — each param gets only its cell's view."""
+    data = pd.DataFrame({"x": [1, 2, 3, 4], "y": [1, 2, 3, 4], "z": [0, 0, 1, 1]})
+    c = alt.Chart(data).mark_line().encode(x="x", y="y").facet("z")
+    p1, p2, p3 = (
+        alt.selection_point(name="p1"),
+        alt.selection_point(name="p2"),
+        alt.selection_point(name="p3"),
+    )
+    with warnings.catch_warnings(record=True):
+        spec = (c.add_params(p1) & c.add_params(p2) & c.add_params(p3)).to_dict()
+    params = spec["params"]
+    vconcat = spec["vconcat"]
+    assert len(params) == 3 and len(vconcat) == 3
+    for i in range(3):
+        assert params[i]["views"] == [_view_name_of_concat_cell(vconcat[i])]
+
+
+def test_concat_faceted_shared_param_both_views_issue_3954():
+    """Regression for #3954: concat of two faceted charts with one shared param — param lists both cell views."""
+    data = pd.DataFrame({"x": [1, 2], "y": [3, 4], "row": ["a", "b"], "col": ["c", "d"]})
+    manual = alt.layer(
+        alt.Chart(data).mark_point().encode(x="x:Q", y="y:Q"),
+        alt.Chart(data).mark_line().encode(x="x:Q", y="y:Q"),
+    ).facet(row="row:N", column="col:N")
+    selection = alt.selection_interval(bind="scales")
+    with warnings.catch_warnings(record=True):
+        spec = (manual & manual).add_params(selection).to_dict()
+    params = spec["params"]
+    vconcat = spec["vconcat"]
+    assert len(params) == 1 and len(vconcat) == 2
+    assert set(params[0]["views"]) == {
+        _view_name_of_concat_cell(vconcat[0]),
+        _view_name_of_concat_cell(vconcat[1]),
+    }


### PR DESCRIPTION
After some hours digging.

**What’s going wrong (v6.0.0):** View and param names in v6.0.0 use content-based hashing for thread-safety. When you concatenate two (or more) **identical** faceted charts, they get the **same** content hash, so they all receive the **same** view name (e.g. `view_9f1740faf6e66b88_0`). As a result, each param’s `views` array ends up pointing at that single view instead of one view per concat cell. The compiler then sees duplicate or incorrect bindings and can error or behave wrongly.

**What v5 did:** v5 used a simple counter for view names (`view_5`, `view_6`, …), so each concat cell had a **distinct** name and each param could correctly list its views (e.g. `param.views = ["view_5", "view_6"]` for a vconcat of two faceted charts).

**Fix direction:** Keep content-based hashing, but in the **concat** case (multiple sibling subcharts), disambiguate by **position**: assign each subchart a unique view name, e.g. `f"{base}_{i}"` where `i` is the concat index. For a FacetChart whose inner spec is a single Chart, put the name on `spec.name`; for a FacetChart whose inner spec is a LayerChart, put it on the **first layer** (so `param.views` can point at those). In `_combine_subchart_params`, when creating a new param entry (APPEND) we use only this subchart’s view for that entry’s `views` list (not the param’s existing `views`), so params that share or reuse view lists don’t get the wrong views. That restores the intended one-view-per-concat-cell behaviour and fixes the error.

Fix #3954 