### PR TITLE
docs: Fix broken density example

### DIFF
--- a/doc/user_guide/transform/density.rst
+++ b/doc/user_guide/transform/density.rst
@@ -37,17 +37,16 @@ argument. Here we split the above density computation across movie genres:
        width=120,
        height=80
    ).transform_filter(
-       'isValid(datum.Major_Genre)'
+       'isValid(datum["Major Genre"])'
    ).transform_density(
        'IMDB Rating',
-       groupby=['Major_Genre'],
+       groupby=['Major Genre'],
        as_=['IMDB Rating', 'density'],
-       extent=[1, 10],
    ).mark_area().encode(
        x="IMDB Rating:Q",
        y='density:Q',
    ).facet(
-       'Major_Genre:N',
+       'Major Genre:N',
        columns=4
    )
 

--- a/tests/examples_arguments_syntax/strip_plot_jitter.py
+++ b/tests/examples_arguments_syntax/strip_plot_jitter.py
@@ -1,7 +1,7 @@
 """
 Strip Plot with Jitter
 ----------------------
-In this chart, we encode the ``Major_Genre`` column from the ``movies`` dataset
+In this chart, we encode the ``Major Genre`` column from the ``movies`` dataset
 in the ``y``-channel. In the default presentation of this data, it would be
 difficult to gauge the relative frequencies with which different values occur
 because there would be so much overlap. To address this, we use the ``yOffset``

--- a/tests/examples_methods_syntax/strip_plot_jitter.py
+++ b/tests/examples_methods_syntax/strip_plot_jitter.py
@@ -1,7 +1,7 @@
 """
 Strip Plot with Jitter
 ----------------------
-In this chart, we encode the ``Major_Genre`` column from the ``movies`` dataset
+In this chart, we encode the ``Major Genre`` column from the ``movies`` dataset
 in the ``y``-channel. In the default presentation of this data, it would be
 difficult to gauge the relative frequencies with which different values occur
 because there would be so much overlap. To address this, we use the ``yOffset``


### PR DESCRIPTION
Currently [broken in the docs](https://altair-viz.github.io/user_guide/transform/density.html):
<img width="750" height="670" alt="image" src="https://github.com/user-attachments/assets/77b1116f-4b3c-4d29-814c-035df6a03d98" />



After fix:
<img width="646" height="425" alt="image" src="https://github.com/user-attachments/assets/65259fa0-1cf2-4eb0-83ca-f7f459e82371" />
