### PR TITLE
docs: Fix git push command for tagging release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,12 +51,12 @@
 
 12. On main, tag the release. If you work on a fork, replace `origin` with `upstream`:
 
-       git tag -a v6.0.0 -m "Version 6.0.0 release"
-       git push origin v6.0.0
+        git tag -a v6.0.0 -m "Version 6.0.0 release"
+        git push origin tag v6.0.0
 
 13. Create a new branch:
        
-       git switch -c maint_6.1.0dev
+        git switch -c maint_6.1.0dev
 
 14. Update version and add 'dev' suffix, e.g. 6.1.0dev:
 


### PR DESCRIPTION
Otherwise there can be duplicate refs with e.g. branch names. Also fixed some code note formatting properly