### PR TITLE
fix: Propagate params to outer level after add_params in concat charts

### DIFF
--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -4577,6 +4577,7 @@ class ConcatChart(TopLevelMixin, core.TopLevelConcatSpec):
             return self
         copy = self.copy()
         copy.concat = [chart.add_params(*params) for chart in copy.concat]
+        copy.params, copy.concat = _combine_subchart_params(copy.params, copy.concat)
         return copy
 
     @utils.deprecated(version="5.0.0", alternative="add_params")
@@ -4681,6 +4682,7 @@ class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
             return self
         copy = self.copy()
         copy.hconcat = [chart.add_params(*params) for chart in copy.hconcat]
+        copy.params, copy.hconcat = _combine_subchart_params(copy.params, copy.hconcat)
         return copy
 
     @utils.deprecated(version="5.0.0", alternative="add_params")
@@ -4787,6 +4789,7 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
             return self
         copy = self.copy()
         copy.vconcat = [chart.add_params(*params) for chart in copy.vconcat]
+        copy.params, copy.vconcat = _combine_subchart_params(copy.params, copy.vconcat)
         return copy
 
     @utils.deprecated(version="5.0.0", alternative="add_params")
@@ -5301,8 +5304,10 @@ def _combine_subchart_params(  # noqa: C901
             # At this stage in the loop, p must be a TopLevelSelectionParameter.
             # Get this subchart's view name from the subchart only (not p.views: params can share lists).
             view_to_add = _view_name_for_param(subchart, is_concat)
-            # MERGE: start from param's views; APPEND: start from [] so we don't pull in another param's views.
-            views_after = list(p.views or []) if found else []
+            # MERGE (found=True): start from p.views to accumulate all views for this param.
+            # APPEND (found=False, view_to_add set): start from [] to avoid pulling in sibling views.
+            # COMPOUND (found=False, no view_to_add): subchart already aggregated views into p.views; preserve them.
+            views_after = list(p.views or []) if (found or not view_to_add) else []
             if view_to_add and view_to_add not in views_after:
                 views_after.append(view_to_add)
 

--- a/tests/vegalite/v6/test_api.py
+++ b/tests/vegalite/v6/test_api.py
@@ -1494,6 +1494,24 @@ def test_compound_add_selections(charttype):
     assert chart1.to_dict() == chart2.to_dict()
 
 
+def test_nested_concat_add_params_views():
+    # Regression test for https://github.com/vega/altair/issues/4018
+    base = alt.Chart("data.csv").mark_line()
+    top = alt.hconcat(
+        base.encode(x="x:Q", y="y:Q").properties(name="top_1"),
+        base.encode(x="x:Q", y="y:Q").properties(name="top_2"),
+    )
+    bot = alt.hconcat(
+        base.encode(x="x:Q", y=alt.Y("y:Q", title="B")).properties(name="bot_1"),
+        base.encode(x="x:Q", y=alt.Y("y:Q", title="B")).properties(name="bot_2"),
+    )
+    chart = alt.vconcat(top, bot).add_params(
+        alt.selection_interval(bind="scales", name="zoom")
+    )
+    views = chart.to_dict()["params"][0]["views"]
+    assert views == ["top_1", "top_2", "bot_1", "bot_2"]
+
+
 def test_selection_property():
     sel = alt.selection_interval()
     chart = alt.Chart("data.csv").mark_point().properties(selection=sel)


### PR DESCRIPTION
Fixes #4018.

When calling `add_params` on a nested concat (e.g. `vconcat` of `hconcat` charts), params were not propagated to the outer level, causing `bind="scales"` zoom to silently apply only to the innermost charts.

Two changes:

1. For `ConcatChart`, `HConcatChart`, and `VConcatChart`, the `add_params` method now calls `_combine_subchart_params` after delegating to children, so `params` are propagated up to the outer level with the correct `views` list.
2. `_combine_subchart_params` now preserves already-aggregated `views` on a compound subchart (one with no single view name), rather than discarding them.

From the issue:

```python
import altair as alt
import pandas as pd

data = pd.DataFrame({"x": [1, 2, 3], "y": [1, 2, 3]})
top = alt.hconcat(
    alt.Chart(data).mark_line().encode(x="x:Q", y="y:Q").properties(name="top_1"),
    alt.Chart(data).mark_line().encode(x="x:Q", y="y:Q").properties(name="top_2"),
)
bot = alt.hconcat(
    alt.Chart(data).mark_line().encode(x="x:Q", y=alt.Y("y:Q", title="B")).properties(name="bot_1"),
    alt.Chart(data).mark_line().encode(x="x:Q", y=alt.Y("y:Q", title="B")).properties(name="bot_2"),
)
chart = alt.vconcat(top, bot).add_params(alt.selection_interval(bind="scales", name="zoom"))
chart.save("chart.html")

print(chart.to_dict()["params"][0]["views"])
# Expected: ['top_1', 'top_2', 'bot_1', 'bot_2']
# Actual:   ['bot_1', 'bot_2']   ← top_* missing
```

now produces


https://github.com/user-attachments/assets/ce32d589-7cb3-499a-a142-61e13f92f2a2

