### PR TITLE
feat: Update olli integration to v3

### DIFF
--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -222,6 +222,7 @@ HTML_TEMPLATE_OLLI = jinja2.Template(
     position: relative;
   }
 </style>
+<link rel="stylesheet" href="{{ base_url }}/olli@{{ olli_version }}/dist/styles.css">
 <div id="{{ output_div }}"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
@@ -241,8 +242,6 @@ HTML_TEMPLATE_OLLI = jinja2.Template(
       "vega-lib": "{{ base_url }}/vega-lib?noext",
       "vega-lite": "{{ base_url }}/vega-lite@{{ vegalite_version }}?noext",
       "vega-embed": "{{ base_url }}/vega-embed@{{ vegaembed_version }}?noext",
-      "olli": "{{ base_url }}/olli@{{ olli_version }}?noext",
-      "olli-adapters": "{{ base_url }}/olli-adapters@{{ olli_adapters_version }}?noext",
     };
 
     function maybeLoadScript(lib, version) {
@@ -267,28 +266,52 @@ HTML_TEMPLATE_OLLI = jinja2.Template(
       throw err;
     }
 
-    function displayChart(vegaEmbed, olli, olliAdapters) {
-      vegaEmbed(outputDiv, spec, embedOpt)
-        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));
-      olliAdapters.VegaLiteAdapter(spec).then(olliVisSpec => {
-        const olliFunc = typeof olli === 'function' ? olli : olli.olli;
-        const olliRender = olliFunc(olliVisSpec);
-        olliDiv.append(olliRender);
+    function displayChart(vegaEmbed) {
+      Promise.all([
+        import("{{ base_url }}/olli@{{ olli_version }}/+esm"),
+        import("{{ base_url }}/olli@{{ olli_version }}/adapters/+esm"),
+        import("{{ base_url }}/@umwelt-data/umwelt-utils@{{ umwelt_utils_version }}/vl-bridge/+esm"),
+      ]).then(([olliModule, adaptersModule, utilsModule]) => {
+        const { olliVis } = olliModule;
+        const { VegaLiteAdapter, looksLikeFips, enrichWithUSGeo } = adaptersModule;
+        const { connectOlliToVegaLite, withExternalStateParam } = utilsModule;
+
+        const injectedSpec = withExternalStateParam(spec);
+        vegaEmbed(outputDiv, injectedSpec, embedOpt)
+          .then(async (result) => {
+            for (const ds of (result.vgSpec || {}).data || []) {
+              if (!ds.name) continue;
+              try {
+                const rows = result.view.data(ds.name);
+                if (rows && rows.length && looksLikeFips(rows, 'id')) {
+                  const enriched = enrichWithUSGeo(rows, 'id')
+                    .map(d => Object.fromEntries(Object.entries(d)));
+                  result.view.data(ds.name, enriched);
+                  await result.view.runAsync();
+                }
+              } catch (e) { /* dataset may not be queryable */ }
+            }
+            const olliVisSpec = await VegaLiteAdapter(spec);
+            const handle = olliVis(olliVisSpec, olliDiv);
+            connectOlliToVegaLite(handle, result.view);
+          })
+          .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));
+      }).catch(err => {
+        console.error("Error loading olli:", err);
+        vegaEmbed(outputDiv, spec, embedOpt)
+          .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));
       });
     }
 
     if(typeof define === "function" && define.amd) {
       requirejs.config({paths});
-      let deps = ["vega-embed", "olli", "olli-adapters"];
-      require(deps, displayChart, err => showError(`Error loading script: ${err.message}`));
+      require(["vega-embed"], displayChart, err => showError(`Error loading script: ${err.message}`));
     } else {
       maybeLoadScript("vega", "{{vega_version}}")
         .then(() => maybeLoadScript("vega-lite", "{{vegalite_version}}"))
         .then(() => maybeLoadScript("vega-embed", "{{vegaembed_version}}"))
-        .then(() => maybeLoadScript("olli", "{{olli_version}}"))
-        .then(() => maybeLoadScript("olli-adapters", "{{olli_adapters_version}}"))
         .catch(showError)
-        .then(() => displayChart(vegaEmbed, olli, OlliAdapters));
+        .then(() => displayChart(vegaEmbed));
     }
   })({{ spec }}, {{ embed_options }});
 </script>
@@ -386,10 +409,10 @@ def spec_to_html(
         vl_version = vl_version_for_vl_convert()
         render_kwargs["vegaembed_script"] = vlc.javascript_bundle(vl_version=vl_version)
     elif template == "olli":
-        OLLI_VERSION = "2"
-        OLLI_ADAPTERS_VERSION = "2"
+        OLLI_VERSION = "3"
+        UMWELT_UTILS_VERSION = "0.1"
         render_kwargs["olli_version"] = OLLI_VERSION
-        render_kwargs["olli_adapters_version"] = OLLI_ADAPTERS_VERSION
+        render_kwargs["umwelt_utils_version"] = UMWELT_UTILS_VERSION
 
     jinja_template = TEMPLATES.get(template, template)  # type: ignore[arg-type]
     if not hasattr(jinja_template, "render"):

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -714,4 +714,4 @@ see :ref:`display-general`.
 .. _Spyder: https://www.spyder-ide.org/
 .. _IPython QtConsole: https://qtconsole.readthedocs.io/en/stable/
 .. _webbrowser module: https://docs.python.org/3/library/webbrowser.html#webbrowser.register
-.. _Olli: https://mitvis.github.io/olli/
+.. _Olli: https://umwelt-data.github.io/olli/

--- a/tests/utils/test_html.py
+++ b/tests/utils/test_html.py
@@ -50,3 +50,24 @@ def test_spec_to_html(requirejs, fullhtml, spec):
     assert f"vega-lite@{vegalite_version}" in html
     assert f"vega@{vega_version}" in html
     assert f"vega-embed@{vegaembed_version}" in html
+
+
+def test_spec_to_html_olli(spec):
+    html = spec_to_html(
+        spec,
+        mode="vega-lite",
+        vegalite_version="6.0",
+        vegaembed_version="7",
+        vega_version="6",
+        template="olli",
+    )
+
+    assert "olli@3" in html
+    assert "+esm" in html
+    assert "styles.css" in html
+    assert "olliVis" in html
+    assert "connectOlliToVegaLite" in html
+    assert "withExternalStateParam" in html
+    assert "looksLikeFips" in html
+    assert "enrichWithUSGeo" in html
+    assert "olli-adapters@" not in html


### PR DESCRIPTION
## Summary

Updates Altair's Olli accessibility integration from v2 to v3, aligning with the [Olli v3 release](https://data-and-design.org/blog/2026/05/27/announcing-olli-v3/).

Key changes:
- **Consolidated packages**: Olli v3 merges the separate `olli` and `olli-adapters` packages into a single `olli` package with subpath exports. This removes the `olli-adapters` dependency and switches from AMD/requirejs loading to ESM dynamic `import()` for olli modules.
- **New API surface**: Updates to the new `olliVis` entry point (replacing the old `olli()` function) and the `OlliHandle`-based mounting pattern.
- **Visual highlighting for VL**: Adds `@umwelt-data/umwelt-utils` for `connectOlliToVegaLite` (bidirectional selection linking between Olli and Vega-Lite views) and `withExternalStateParam` (external state injection into specs).
- **Updated Olli docs URL**: Points to the new `umwelt-data.github.io/olli/` site.

## Test plan

- [x] Added `test_spec_to_html_olli` unit test verifying olli v3 integration markers in rendered HTML (ESM imports, `olliVis`, `connectOlliToVegaLite`, `styles.css`, no legacy `olli-adapters` references)
- [x] Verified existing `test_spec_to_html` tests still pass (`pytest tests/utils/test_html.py`)
- [x] Manually tested `chart.save("chart.html", template="olli")` in a browser to confirm the Olli accessible tree structure renders alongside the Vega-Lite chart
