### PR TITLE
build: Derive version from VCS via versioningit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 * text=auto eol=lf
+# Expand $Format:...$ placeholders in pyproject.toml when running git archive
+# (including GitHub source ZIPs), so versioningit can derive the version when
+# installing from a sdist or archive where no .git directory is present.
+pyproject.toml export-subst

--- a/.github/workflows/build-free-threaded.yml
+++ b/.github/workflows/build-free-threaded.yml
@@ -12,6 +12,8 @@ jobs:
     name: py 3.14t free-threaded
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.14t
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     name: py ${{ matrix.python-version }} with ${{ matrix.required-dependencies }} required deps
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.12
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
       with:
         python-version: "3.12"
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/altair/__init__.py
+++ b/altair/__init__.py
@@ -647,6 +647,7 @@ __all__ = [
     "vconcat",
     "vegalite",
     "vegalite_compilers",
+    "version",
     "when",
     "with_property_setters",
 ]

--- a/altair/__init__.py
+++ b/altair/__init__.py
@@ -1,5 +1,7 @@
 # ruff: noqa
-__version__ = "6.2.0dev"
+from importlib.metadata import version
+
+__version__ = version("altair")
 
 # The content of __all__ is automatically written by
 # tools/update_init_file.py. Do not modify directly.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,6 +21,8 @@ from datetime import datetime
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))  # noqa: PTH100
 
+import altair
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -82,7 +84,7 @@ author = "Vega-Altair Developers"
 # built documents.
 #
 # The short X.Y version.
-version = "6.2.0dev"
+version = altair.__version__
 # The full version, including alpha/beta/rc tags.
 release = f"{version}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 # - ty (experimental)
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "versioningit"]
 build-backend = "hatchling.build"
 
 [project]
@@ -122,7 +122,17 @@ vega-lite     = "v6.4.1" # https://github.com/vega/vega-lite
 [tool.hatch]
 build    = { include = ["/altair"], artifacts = ["altair/jupyter/js/index.js"] }
 metadata = { allow-direct-references = true }
-version  = { path = "altair/__init__.py" }
+
+[tool.hatch.version]
+source = "versioningit"
+
+[tool.hatch.version.vcs]
+# "git-archive" is required (not the default "git") so that version calculation
+# works when installing from a PyPI sdist or GitHub archive, where there is no
+# .git directory. The describe-subst placeholder is expanded by git at archive
+# time via the export-subst attribute in .gitattributes.
+method = "git-archive"
+describe-subst = "$Format:%(describe:tags,match=v[0-9]*)$"
 
 [tool.hatch.envs]
 # https://hatch.pypa.io/latest/how-to/environment/select-installer/#enabling-uv


### PR DESCRIPTION
Replace the hardcoded __version__ in altair/__init__.py with a
versioningit-based version source backed by git tags.

- Add versioningit to build-system.requires and configure it as the
  Hatch version source in pyproject.toml.
- Use the git-archive VCS method so version calculation works when
  installing from a PyPI sdist or GitHub source archive (no .git
  directory present). The `$Format:%(describe)$` placeholder in
  pyproject.toml is expanded by git at archive time via export-subst
  in .gitattributes.
- Replace `__version__ = "6.2.0dev"` with `importlib.metadata.version()`
  so the runtime value is always read from installed package metadata.
- Read the docs version from `altair.__version__` instead of a separate
  hardcoded string in doc/conf.py.

On a release tag (e.g. v6.1.0) the version is exactly "6.1.0".
Between releases it is "6.1.0.postN+g<hash>".

This will help us automate releases and make it easier to distinguish versions between releases. 