### PR TITLE
ci: Label PRs based on semantic title prefix

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,4 +1,5 @@
-name: "Lint PR"
+---
+name: Lint and label PR
 
 on:
   pull_request_target:
@@ -7,14 +8,56 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read
-
 jobs:
-  main:
+  validate-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  label:
+    name: Apply label from PR title
+    runs-on: ubuntu-latest
+    needs: validate-title
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+
+            const mapping = [
+              { pattern: /^(feat|feat!)(\(.+\))?!?:/, label: "enhancement" },
+              { pattern: /^(fix|fix!)(\(.+\))?!?:/,  label: "bug" },
+              { pattern: /^docs(\(.+\))?:/,           label: "documentation" },
+              { pattern: /^(chore|build|ci|style|test|refactor|perf)(\(.+\))?:/, label: "maintainance" },
+            ];
+
+            // Check for breaking change: trailing ! before colon or BREAKING CHANGE in body
+            const isBreaking = /^[a-z]+(\(.+\))?!:/.test(title);
+            if (isBreaking) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ["breaking"],
+              });
+              return;
+            }
+
+            for (const { pattern, label } of mapping) {
+              if (pattern.test(title)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: [label],
+                });
+                return;
+              }
+            }


### PR DESCRIPTION
Since our release notes are organized automatically from the PR labels, I thought it would be helpful to have them added automatically instead of needing to go through and manually label PR; particularly for trying to make releases more automatic.