### PR TITLE
ci: Speed up and harden release draft workflow

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -38,7 +38,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-extras
       - name: Install Cocogitto
-        run: cargo install cocogitto --version 7.0.0 --locked
+        uses: cocogitto/cocogitto-action@390bda87a19bf627e03ad075c67a11e9ddbb7547 # v4
+        with:
+          install-only: true
       - name: Configure release git identity
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -17,6 +17,7 @@ concurrency:
 
 env:
   UV_SYSTEM_PYTHON: 1
+  UV_FROZEN: 1
   CARGO_TERM_COLOR: always
 
 jobs:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          # Use RELEASE_TOKEN when branch protection blocks github.token pushes.
           token: ${{ secrets.RELEASE_TOKEN || github.token }}
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,7 @@ Check all [Vega project](https://github.com/orgs/vega/repositories?type=source) 
 
 ### Semi-Automated Release
 
-1. Go to GitHub actions and start the `Prepare Release Draft` workflow.
-    - The workflow uses the default `GITHUB_TOKEN` unless a `RELEASE_TOKEN` secret is configured. If branch protection prevents GitHub Actions from pushing release commits or tags to `main`, configure `RELEASE_TOKEN` with a maintainer or bot token that is allowed to push through the repository's release rules.
+1. Go to "Actions" tab, click the `Prepare Release Draft` workflow to the left, and then "Run workflow".
     - This workflow automates the following steps:
         1. Checks for an existing draft release and exits if one already exists.
         2. Uses Cocogitto to inspect conventional commits since the latest `v*` tag.


### PR DESCRIPTION
The previous Cocogitto install step compiled from source, which added noticeable runtime to the workflow.

The release draft workflow also ran `uv sync --frozen`, but later `uv run` commands could still update `uv.lock`. That left the worktree dirty before `cog bump`, causing the release step to fail because Cocogitto requires a clean worktree.
