### PR TITLE
ci: Use only tag, not commit, for releases

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -86,7 +86,7 @@ jobs:
         if: steps.next-version.outputs.should-release == 'true'
         id: bump
         run: |
-          cog bump --auto --disable-bump-commit --annotated "chore(version): {{version}}"
+          cog bump --auto --disable-bump-commit --annotated "Version {{version}} release"
           git push origin "refs/tags/${{ steps.next-version.outputs.tag }}"
       - name: Create draft GitHub release
         if: steps.next-version.outputs.should-release == 'true'

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -82,12 +82,12 @@ jobs:
       - name: Test with pytest
         if: steps.next-version.outputs.should-release == 'true'
         run: uv run task test
-      - name: Create release commit and tag
+      - name: Create release tag
         if: steps.next-version.outputs.should-release == 'true'
         id: bump
         run: |
-          cog bump --auto --annotated "chore(version): {{version}}"
-          git push origin HEAD:main --follow-tags
+          cog bump --auto --disable-bump-commit --annotated "chore(version): {{version}}"
+          git push origin "refs/tags/${{ steps.next-version.outputs.tag }}"
       - name: Create draft GitHub release
         if: steps.next-version.outputs.should-release == 'true'
         env:


### PR DESCRIPTION
Simplify the release workflow by creating only a release tag, without pushing a release commit to `main`. The previous workflow ran `cog bump --auto`, which created both a release commit and a tag. It then pushed both to `main` with `--follow-tags`. This failed because branch protection requires all changes to go through a pull request.

Since Altair now uses VCS-derived versioning via `versioningit`, the release tag alone is the source of truth for the package version. There is no version file to update and no changelog to commit, so the release commit served no purpose.
