### PR TITLE
ci: Prevent uv from dirtying worktree during publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   UV_SYSTEM_PYTHON: 1
+  UV_FROZEN: 1
 
 jobs:
   publish-release:


### PR DESCRIPTION
`uv run task build` can update `uv.lock` even though `uv sync` uses
`--frozen`, making the worktree dirty at build time. `versioningit`
then appends a +d<date> local version suffix, which PyPI rejects.

Set `UV_FROZEN=1` globally so all uv invocations in the publish
workflow use the checked-in lockfile.
