### PR TITLE
ci: Make warning for doc preview page more prominent

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -177,9 +177,11 @@ html_theme_options = {
 
 if preview_tag := os.environ.get("ALTAIR_RELEASE_PREVIEW_TAG"):
     html_theme_options["announcement"] = (
-        f"This is a preview doc build for draft release {preview_tag}, "
-        'not the <a href="https://altair-viz.github.io/">'
-        "official Altair documentation</a>."
+        "<strong style='font-size:1.2em;'>"
+        f"⚠️ Preview build for draft release {preview_tag} &mdash; "
+        'not the <a href="https://altair-viz.github.io/" style="color:inherit;">'
+        "official Altair documentation</a>. ⚠️"
+        "</strong>"
     )
 
 html_context = {"default_mode": "light"}


### PR DESCRIPTION
Just so no one accidentally comes across this page and misses that is just a preview (the preview page stays up between build; we could add a clean-up step but I'm thinking the warning makes that redundant).