### PR TITLE
ci: Document how local versioning works and add base tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,26 @@ git clone https://github.com/YOUR-USERNAME/altair.git
 To keep your fork up to date with changes in this repo,
 you can [use the fetch upstream button on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
 
+> [!NOTE]
+> Altair's local version is derived from Git release tags. If your fork
+> is missing the latest upstream tags, the version reported by a local install
+> may be using an older tag as the base (or even fall back to a synthetic
+> `0...` version if no upstream tags are present). This doesn't affect the
+> development experience in any meaningful way and you can still see the latest
+> commit SHA in the reported version, but if you want more accurate version
+> reporting for a locally installed development version, make sure to fetch all
+> upstream tags:
+>
+> ```cmd
+> git fetch --tags https://github.com/vega/altair.git
+> ```
 
 [Install `uv`](https://docs.astral.sh/uv/getting-started/installation/), or update to the latest version:
 
 ```cmd
 uv self update
 ```
+
 Install Python:
 
 ```cmd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ source = "versioningit"
 # time via the export-subst attribute in .gitattributes.
 method = "git-archive"
 describe-subst = "$Format:%(describe:tags,match=v[0-9]*)$"
+default-tag = "v0"
 
 [tool.hatch.envs]
 # https://hatch.pypa.io/latest/how-to/environment/select-installer/#enabling-uv


### PR DESCRIPTION
Adding the base tag prevents that a current forked would be unable to find the tags. This shouldn't be an issue for new forks as they would include the required tags, but it seems like it could be an issue with existing forks as reported here https://github.com/vega/altair/pull/4036#issuecomment-4634507412