### PR TITLE
ci: Run docs build only for docs-related changes and don't duplicate builds on PRs

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -2,6 +2,8 @@ name: docbuild
 
 on:
   push:
+    branches:
+      - main
     paths: &docbuild_paths
       - ".github/workflows/docbuild.yml"
       - "doc/**"

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -1,6 +1,16 @@
 name: docbuild
 
-on: [push, pull_request]
+on:
+  push:
+    paths: &docbuild_paths
+      - ".github/workflows/docbuild.yml"
+      - "doc/**"
+      - "pyproject.toml"
+      - "tests/examples_*/**"
+      - "tools/**"
+      - "uv.lock"
+  pull_request:
+    paths: *docbuild_paths
 
 jobs:
   build:


### PR DESCRIPTION
Limit the docbuild workflow to changes that can affect documentation: docs, Altair source/API, example tests, docs tooling, dependency files, and the workflow itself. This avoids spending CI time on unrelated PRs. I'm skipping the main src here since that should be covered by our test suite and not impact the ability of building the docs. The implementation uses [yaml anchors](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases) instead of repeating the paths.

This also ensures that PRs only run one doc build by only triggering the push build on pushes to main, to avoid this situation we have currently:

<img width="610" height="195" alt="image" src="https://github.com/user-attachments/assets/3862bd5b-fa51-4c88-9948-b14de877748b" />
