### PR TITLE
ci: Upload docs build artifact for PR preview

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -38,6 +38,12 @@ jobs:
       run: |
         mkdir -p doc/_images
         uv run sphinx-build -b html -d doc/_build/doctrees doc doc/_build/html
+    - name: Upload docs preview artifact
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      with:
+        name: docs-html
+        path: doc/_build/html
+        retention-days: 7
     - name: Run doctests
       run: |
         uv run sphinx-build -b doctest -d doc/_build/doctrees doc doc/_build/doctest

--- a/NOTES_FOR_MAINTAINERS.md
+++ b/NOTES_FOR_MAINTAINERS.md
@@ -101,6 +101,19 @@ rewrites, because the internal structure of the schema changed appreciably.
 To cut a new release of Altair, follow the steps outlined in
 [RELEASING.md](RELEASING.md).
 
+## Previewing PR documentation
+
+The `docbuild` workflow uploads the built HTML documentation as a `docs-html`
+artifact. To download and serve the latest docs artifact for a pull request,
+run:
+
+```bash
+uv run task doc-preview-pr -- 1234
+```
+
+Replace `1234` with the pull request number. The command downloads the artifact
+to `./pr-preview-docs` and serves it at <http://localhost:8000>.
+
 ## Web analytics
 
 We use the privacy-friendly [plausible.io](https://plausible.io/) for tracking usage statistics of our documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,6 +302,7 @@ doc-clean = "python tools/docs_cli.py clean"
 doc-build = "python tools/docs_cli.py build"
 doc-serve = "python tools/docs_cli.py serve"
 doc-publish = "python tools/docs_cli.py publish"
+doc-preview-pr = "python tools/download_docs_artifact.py"
 
 clean   = "python -c \"import tools;tools.fs.rm('dist')\""
 build   = "task clean && uv build"

--- a/tools/download_docs_artifact.py
+++ b/tools/download_docs_artifact.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import webbrowser
+from pathlib import Path
+
+DEFAULT_DIR = Path("pr-preview-docs")
+WORKFLOW_NAME = "docbuild"
+WORKFLOW_PATH = ".github/workflows/docbuild.yml"
+
+
+def run_command(command: list[str]) -> str:
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def latest_docbuild_run_id(*, pr_number: int | None) -> str:
+    if pr_number is not None:
+        return latest_docbuild_run_id_for_pr(pr_number)
+
+    command = [
+        "gh",
+        "run",
+        "list",
+        "--workflow",
+        "docbuild",
+        "--limit",
+        "1",
+        "--json",
+        "databaseId",
+        "--jq",
+        ".[0].databaseId",
+    ]
+    run_id = run_command(command)
+    if not run_id:
+        msg = "No docbuild workflow run found."
+        raise RuntimeError(msg)
+    return run_id
+
+
+def latest_docbuild_run_id_for_pr(pr_number: int) -> str:
+    repo = run_command(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
+    )
+    workflow_id = run_command(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/actions/workflows",
+            "--jq",
+            (
+                f'.workflows[] | select(.name == "{WORKFLOW_NAME}" '
+                f'or .path == "{WORKFLOW_PATH}") | .id'
+            ),
+        ]
+    ).splitlines()[0]
+    query = (
+        ".workflow_runs[] | "
+        f"select(any(.pull_requests[]?; .number == {pr_number})) | "
+        ".id"
+    )
+    run_id = run_command(
+        [
+            "gh",
+            "api",
+            "--method",
+            "GET",
+            f"repos/{repo}/actions/workflows/{workflow_id}/runs",
+            "--field",
+            "event=pull_request",
+            "--field",
+            "per_page=50",
+            "--jq",
+            query,
+        ]
+    ).splitlines()
+    if not run_id:
+        msg = f"No docbuild workflow run found for PR #{pr_number}."
+        raise RuntimeError(msg)
+    return run_id[0]
+
+
+def download_artifact(*, run_id: str, output_dir: Path) -> None:
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "gh",
+            "run",
+            "download",
+            run_id,
+            "--name",
+            "docs-html",
+            "--dir",
+            str(output_dir),
+        ],
+        check=True,
+    )
+
+
+def serve_artifact(*, output_dir: Path, port: int) -> None:
+    url = f"http://localhost:{port}"
+    print(f"Serving docs artifact from {output_dir} at {url}")
+    webbrowser.open(url)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "http.server",
+            str(port),
+            "--directory",
+            str(output_dir),
+        ],
+        check=True,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download and serve the docs-html artifact from a docbuild run."
+    )
+    parser.add_argument(
+        "pr_number",
+        nargs="?",
+        type=int,
+        help="Pull request number. Defaults to the latest docbuild run.",
+    )
+    parser.add_argument(
+        "--run-id",
+        help="GitHub Actions run ID. Defaults to the latest docbuild run.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_DIR,
+        help=f"Directory to download the artifact into. Defaults to ./{DEFAULT_DIR}.",
+    )
+    parser.add_argument("--port", type=int, default=8000, help="Local server port.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_id = args.run_id or latest_docbuild_run_id(pr_number=args.pr_number)
+    download_artifact(run_id=run_id, output_dir=args.output_dir)
+    serve_artifact(output_dir=args.output_dir, port=args.port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is trying to make it more convenient to review PRs with docs changes. Since the docs are already built in CI for testing purposes, it is redundant that we need to sit through the full build locally, especially as it still takes many minutes.

Unfortunately, there doesn't seem to be a safe way to publish previews here directly (unless we use something like Netlify), so this PR instead uploads the HTML docs as a short-lived docs-html artifact from the docbuild workflow so maintainers can review rendered docs without building them locally.

To make this more convenient, I also added a `doc-preview-pr` task that resolves the latest docbuild run for a pull request, downloads the artifact with gh, and serves it locally. To try on e.g. PR 4050, you would run something like this:

```
uv run task doc-preview-pr -- 4050
```
