### PR TITLE
ci: Schedule release drafts twice monthly

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -15,7 +15,7 @@ on:
     paths: *docbuild_paths
 
 jobs:
-  build:
+  docbuild:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -2,9 +2,8 @@
 name: Prepare Release Draft
 
 on:
-  # Enable this after the manual release flow has been tested.
-  # schedule:
-  #   - cron: '0 3 1-7 * 1'  # Every four weeks on the first Monday at 3am UTC
+  schedule:
+    - cron: '0 15 1-7,15-21 * 1'  # First and third Monday of each month at 15:00 UTC.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Enable the release draft workflow on the first and third Monday of each month at 15:00 UTC while preserving manual workflow_dispatch runs. Release notes are only drafted if there are qualifying commits in this period.

Close https://github.com/vega/altair/issues/4013
