### PR TITLE
ci: Group major GitHub Actions updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,7 @@ updates:
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
     commit-message:

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = context.payload.pull_request.title;

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -39,7 +39,7 @@ jobs:
         mkdir -p doc/_images
         uv run sphinx-build -b html -d doc/_build/doctrees doc doc/_build/html
     - name: Upload docs preview artifact
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: docs-html
         path: doc/_build/html


### PR DESCRIPTION
Update actions/github-script and actions/upload-artifact to their latest major versions in one PR and fix the pinned-version comments. Also allow Dependabot to group major GitHub Actions updates while keeping uv project dependency updates limited to minor and patch group, since these are not as critical.
