### PR TITLE
ci: Rename docbuild job from 'build' to 'docbuild'

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -15,7 +15,7 @@ on:
     paths: *docbuild_paths
 
 jobs:
-  build:
+  docbuild:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
The `docbuild` workflow defines its job with the key `build`, which
causes it to report a check also named `build` — the same name as the
required status check from the `build` workflow.

This creates a problem for PRs that only touch files outside the
`docbuild` path filter (e.g. `.github/workflows/`): the `docbuild`
workflow never runs, GitHub has seen a `build` report from it on other
PRs, and so it marks the PR as blocked waiting for a `build` result
that will never arrive.

Rename the job key from `build` to `docbuild` so it registers under a
distinct check name. The required `build` check will then be satisfied
solely by the `build` workflow's matrix jobs, regardless of whether
`docbuild` runs on a given PR.

*edit* I don't konw if this actually was the issue, it seems like the "expect" workflow hiccup remained after