### PR TITLE
fix: Avoid layered concat view name collisions

### DIFF
--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -5269,6 +5269,15 @@ def _combine_subchart_params(  # noqa: C901
     subcharts = [subchart.copy() for subchart in subcharts]
     is_concat = len(subcharts) > 1
 
+    if is_concat:
+        for i, subchart in enumerate(subcharts):
+            if not (isinstance(subchart, LayerChart) and subchart.layer):
+                continue
+            subchart.layer = [layer.copy() for layer in subchart.layer]
+            for layer in subchart.layer:
+                if isinstance(layer, Chart) and layer.name is not Undefined:
+                    layer.name = f"{_view_base_for_chart(layer)}_{i}"
+
     for i, subchart in enumerate(subcharts):
         if (not hasattr(subchart, "params")) or (utils.is_undefined(subchart.params)):
             continue

--- a/tests/vegalite/v6/test_params.py
+++ b/tests/vegalite/v6/test_params.py
@@ -413,3 +413,36 @@ def test_vconcat_different_data_unique_names():
             f"Layers should have unique names when data differs, "
             f"but both got name: {line_names[0]}"
         )
+
+
+def test_vconcat_layered_charts_with_parent_transforms_have_unique_names():
+    # Regression test for issue #4065: layered charts in a concat can have
+    # identical inner layer specs while differing only on the parent layer chart.
+    df = pd.DataFrame(
+        {
+            "site": [1, 2, 3, 4, 5] * 2,
+            "antibody": ["a"] * 5 + ["b"] * 5,
+            "escape": [0.2, 0.8, 0.2, 0.3, 0.2, 0.4, 1.0, 0.4, 0.5, 0.4],
+        }
+    )
+
+    hover = alt.selection_point(fields=["site"], on="mouseover", empty=False)
+    base = alt.Chart(df).encode(
+        x="site:O",
+        y=alt.Y("escape:Q", scale=alt.Scale(domain=[0, 1])),
+    )
+    lines = base.mark_line(size=1)
+    points = base.encode(
+        size=alt.condition(hover, alt.value(120), alt.value(40))
+    ).mark_circle(filled=True)
+    layered = lines + points
+
+    mean_panel = layered.transform_aggregate(escape="mean(escape)", groupby=["site"])
+    indiv_panel = layered.encode(detail="antibody:N")
+
+    spec = alt.vconcat(mean_panel, indiv_panel).add_params(hover).to_dict()
+    line_names = [panel["layer"][0]["name"] for panel in spec["vconcat"]]
+
+    assert line_names[0] != line_names[1]
+    assert line_names[0].endswith("_0")
+    assert line_names[1].endswith("_1")


### PR DESCRIPTION
This PR fixes #4065 by disambiguating auto-generated inner layer view names for `LayerChart` specs used inside concat charts.

When structurally identical layered charts are concatenated, their inner unit charts can receive the same content-hash view name. If the panels differ only through transforms or encodings on the parent `LayerChart`, the inner layer specs still hash identically. Vega-Lite can then compile duplicate same-named marks/data pipelines, causing one panel’s line mark to render from another panel’s data.

This change adds a concat-specific pass that renames already-named child `Chart` layers inside `LayerChart` concat children using the existing positional suffix convention:

```text
view_<content_hash>_0
view_<content_hash>_1
```

With the spec from #4605, this is what it looked like before this PR (line drawn for the wrong data on top):

<img width="185" height="639" alt="image" src="https://github.com/user-attachments/assets/bac59b8e-bb45-4d76-bdba-e17e37cb0f21" />

This if what it looks like after this PR:

<img width="185" height="639" alt="image" src="https://github.com/user-attachments/assets/06151767-db0b-4c54-974d-939d0f2f053d" />


The fix here is somewhat different to what was suggested in that issue where it was suggested that updating param_info while renaming the child layer views would be the fix. This implementation intentionally keeps the rendering-collision fix narrower. The primary bug is caused by duplicate view/mark names. To fix that, it is sufficient to rename the already-named child layers before concat param processing exits early for LayerChart children without params.

This PR does not attempt to update selection param views during that pre-pass because those views are assembled later by the existing param lifting/deduplication flow. Changing that behavior would affect interaction scoping semantics and should be handled as a separate, focused change with its own tests.