### PR TITLE
fix: disambiguate inner layer names when identical LayerCharts are concatenated

### DIFF
--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -5289,6 +5289,17 @@ def _combine_subchart_params(  # noqa: C901
             elif isinstance(spec, Chart):
                 spec.name = f"{_view_base_for_chart(spec)}_{i}"
 
+        if is_concat and isinstance(subchart, LayerChart) and subchart.layer:
+            subchart.layer = [layer.copy() for layer in subchart.layer]
+            for j, layer in enumerate(subchart.layer):
+                if isinstance(layer, Chart):
+                    base_name = (
+                        layer._get_view_hash_name()
+                        if layer.name is Undefined
+                        else _view_base_for_chart(layer)
+                    )
+                    layer.name = f"{base_name}_{i}_{j}"
+
         for param in subchart.params:
             p = _prepare_to_lift(param)
             pd = _viewless_dict(p)

--- a/tests/vegalite/v6/test_params.py
+++ b/tests/vegalite/v6/test_params.py
@@ -413,3 +413,31 @@ def test_vconcat_different_data_unique_names():
             f"Layers should have unique names when data differs, "
             f"but both got name: {line_names[0]}"
         )
+
+
+def test_vconcat_identical_layered_charts_unique_inner_layer_names():
+    df = pd.DataFrame({"site": [1, 2, 3, 4, 5], "escape": [0.1, 0.9, 0.1, 0.2, 0.1]})
+    selection = alt.selection_point(fields=["site"], on="mouseover", empty=False)
+
+    def make_layered_chart():
+        base = alt.Chart(df).encode(
+            x="site:O",
+            y=alt.Y("escape:Q", scale=alt.Scale(domain=[0, 1])),
+        )
+        lines = base.mark_line(size=1)
+        points = base.encode(
+            size=alt.condition(selection, alt.value(80), alt.value(30)),
+        ).mark_circle(filled=True)
+        return (lines + points).add_params(selection)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        spec = alt.vconcat(make_layered_chart(), make_layered_chart()).to_dict()
+
+    layers0 = spec["vconcat"][0]["layer"]
+    layers1 = spec["vconcat"][1]["layer"]
+    names0 = [layer["name"] for layer in layers0]
+    names1 = [layer["name"] for layer in layers1]
+
+    assert names0[0] != names1[0]
+    assert names0[1] != names1[1]


### PR DESCRIPTION
Fixes #4065

## Problem

When two structurally identical layered `(line + circle)` charts are concatenated via `alt.vconcat` / `alt.hconcat`, their inner `mark_line` layers receive the same auto-generated content-hash view name. Vega-Lite then deduplicates the two same-named views, so both line marks render from a single data pipeline. The result: in one panel the line is drawn from the other panel's data.

This is the same class of bug as #3981 (fixed by #3982), but that fix only handles the case where DataFrames differ. Here both panels share one DataFrame and differ only by transforms/encodings on the parent unit spec, so the inner layers still hash identically.

## Fix

In `_combine_subchart_params`, add positional disambiguation for `LayerChart` subcharts in concat. When `is_concat and isinstance(subchart, LayerChart)`, copy the inner layers and append `_{i}_{j}` to each layer's name, matching the existing `FacetChart` handling pattern.

## Changes

- `altair/vegalite/v6/api.py`: 11 lines added. New branch in `_combine_subchart_params` that disambiguates LayerChart inner layer names by position.
- `tests/vegalite/v6/test_params.py`: 28 lines added. Regression test reproducing the exact scenario from the issue (two identical `(line + circle)` charts sharing one DataFrame, concatenated via `vconcat`).

## Tests

```
uv run pytest tests/vegalite/v6/test_params.py -k "vconcat_identical_layered_charts_unique_inner_layer_names or vconcat_different_data_unique_names" -v
```

2 passed. Full `uv run task test` passes formatting and pytest; mypy reports pre-existing import-not-found errors for optional modules (`vl_convert`, `anywidget`) unrelated to this change.
