### PR TITLE
fix: raise TypeError for invalid property setter arguments

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -1662,6 +1662,19 @@ class _PropertySetter:
         return self
 
     def __call__(self, *args: Any, **kwargs: Any):
+        if len(args) > 1:
+            msg = (
+                f"{self.prop}() accepts at most one positional argument, "
+                f"but {len(args)} were given"
+            )
+            raise TypeError(msg)
+        if args and kwargs:
+            msg = (
+                f"{self.prop}() cannot combine a positional argument "
+                "with keyword arguments"
+            )
+            raise TypeError(msg)
+
         obj = self.obj.copy()
         # TODO: use schema to validate
         obj[self.prop] = args[0] if args else kwargs

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -1662,16 +1662,16 @@ class _PropertySetter:
         return self
 
     def __call__(self, *args: Any, **kwargs: Any):
+        name = f"{type(self.obj).__name__}.{self.prop}"
         if len(args) > 1:
             msg = (
-                f"{self.prop}() accepts at most one positional argument, "
+                f"{name}() accepts at most one positional argument, "
                 f"but {len(args)} were given"
             )
             raise TypeError(msg)
         if args and kwargs:
             msg = (
-                f"{self.prop}() cannot combine a positional argument "
-                "with keyword arguments"
+                f"{name}() cannot combine a positional argument with keyword arguments"
             )
             raise TypeError(msg)
 

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1151,14 +1151,14 @@ def test_property_setter_rejects_multiple_positional_arguments() -> None:
     with pytest.raises(
         TypeError, match=r"scale\(\) accepts at most one positional argument"
     ):
-        alt.Color().scale(["M", "F"], ["#1FC3AA", "#8624F5"])
+        alt.Color().scale(["M", "F"], ["#1FC3AA", "#8624F5"])  # type: ignore[call-overload]
 
 
 def test_property_setter_rejects_positional_and_keyword_arguments() -> None:
     with pytest.raises(
         TypeError, match=r"scale\(\) cannot combine a positional argument"
     ):
-        alt.Color().scale(alt.Scale(), domain=["M", "F"])
+        alt.Color().scale(alt.Scale(), domain=["M", "F"])  # type: ignore[call-overload]
 
 
 def test_to_dict_datetime_typing() -> None:

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1147,6 +1147,20 @@ def test_to_dict_datetime_unsupported_timezone(tzinfo: dt.timezone) -> None:
         alt.FieldEqualPredicate(datetime.replace(tzinfo=tzinfo), "column 1")
 
 
+def test_property_setter_rejects_multiple_positional_arguments() -> None:
+    with pytest.raises(
+        TypeError, match=r"scale\(\) accepts at most one positional argument"
+    ):
+        alt.Color().scale(["M", "F"], ["#1FC3AA", "#8624F5"])
+
+
+def test_property_setter_rejects_positional_and_keyword_arguments() -> None:
+    with pytest.raises(
+        TypeError, match=r"scale\(\) cannot combine a positional argument"
+    ):
+        alt.Color().scale(alt.Scale(), domain=["M", "F"])
+
+
 def test_to_dict_datetime_typing() -> None:
     """
     Enumerating various places that need updated annotations.

--- a/tests/utils/test_schemapi.py
+++ b/tests/utils/test_schemapi.py
@@ -1147,18 +1147,22 @@ def test_to_dict_datetime_unsupported_timezone(tzinfo: dt.timezone) -> None:
         alt.FieldEqualPredicate(datetime.replace(tzinfo=tzinfo), "column 1")
 
 
-def test_property_setter_rejects_multiple_positional_arguments() -> None:
+@pytest.mark.parametrize("setter", ["scale", "axis", "sort"])
+def test_property_setter_rejects_multiple_positional_arguments(setter: str) -> None:
+    method = getattr(alt.X("field:Q"), setter)
     with pytest.raises(
-        TypeError, match=r"scale\(\) accepts at most one positional argument"
+        TypeError, match=rf"X\.{setter}\(\) accepts at most one positional argument"
     ):
-        alt.Color().scale(["M", "F"], ["#1FC3AA", "#8624F5"])  # type: ignore[call-overload]
+        method(["M", "F"], ["#1FC3AA", "#8624F5"])
 
 
-def test_property_setter_rejects_positional_and_keyword_arguments() -> None:
+@pytest.mark.parametrize("setter", ["scale", "axis", "sort"])
+def test_property_setter_rejects_positional_and_keyword_arguments(setter: str) -> None:
+    method = getattr(alt.X("field:Q"), setter)
     with pytest.raises(
-        TypeError, match=r"scale\(\) cannot combine a positional argument"
+        TypeError, match=rf"X\.{setter}\(\) cannot combine a positional argument"
     ):
-        alt.Color().scale(alt.Scale(), domain=["M", "F"])  # type: ignore[call-overload]
+        method(["M", "F"], domain=["M", "F"])
 
 
 def test_to_dict_datetime_typing() -> None:

--- a/tests/vegalite/v6/schema/test_channels.py
+++ b/tests/vegalite/v6/schema/test_channels.py
@@ -64,19 +64,14 @@ def test_channels_typing() -> None:
     ):
         positional_as_keyword.to_dict()
 
-    keyword_as_positional = angle.sort("field:Q", "min", "descending")  # type: ignore[call-overload]
-    with pytest.raises(SchemaValidationError):
-        keyword_as_positional.to_dict()
+    with pytest.raises(
+        TypeError, match=r"sort\(\) accepts at most one positional argument"
+    ):
+        angle.sort("field:Q", "min", "descending")  # type: ignore[call-overload]
     angle.sort(field="field:Q", op="min", order="descending")
 
-    # NOTE: Doesn't raise `SchemaValidationError`
-    # - `"ascending"` is silently ignored when positional
-    # - Caught as invalid statically, but not at runtime
-    bad = angle.sort("x", "ascending").to_dict()  # type: ignore[call-overload]
-    good = angle.sort(encoding="x", order="ascending").to_dict()
-    assert isinstance(bad, dict)
-    assert isinstance(good, dict)
     with pytest.raises(
-        AssertionError, match=r"'x' == {'encoding': 'x', 'order': 'ascending'}"
+        TypeError, match=r"sort\(\) accepts at most one positional argument"
     ):
-        assert bad["sort"] == good["sort"]
+        angle.sort("x", "ascending")  # type: ignore[call-overload]
+    assert angle.sort(encoding="x", order="ascending").to_dict()

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -1660,6 +1660,19 @@ class _PropertySetter:
         return self
 
     def __call__(self, *args: Any, **kwargs: Any):
+        if len(args) > 1:
+            msg = (
+                f"{self.prop}() accepts at most one positional argument, "
+                f"but {len(args)} were given"
+            )
+            raise TypeError(msg)
+        if args and kwargs:
+            msg = (
+                f"{self.prop}() cannot combine a positional argument "
+                "with keyword arguments"
+            )
+            raise TypeError(msg)
+
         obj = self.obj.copy()
         # TODO: use schema to validate
         obj[self.prop] = args[0] if args else kwargs

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -1660,16 +1660,16 @@ class _PropertySetter:
         return self
 
     def __call__(self, *args: Any, **kwargs: Any):
+        name = f"{type(self.obj).__name__}.{self.prop}"
         if len(args) > 1:
             msg = (
-                f"{self.prop}() accepts at most one positional argument, "
+                f"{name}() accepts at most one positional argument, "
                 f"but {len(args)} were given"
             )
             raise TypeError(msg)
         if args and kwargs:
             msg = (
-                f"{self.prop}() cannot combine a positional argument "
-                "with keyword arguments"
+                f"{name}() cannot combine a positional argument with keyword arguments"
             )
             raise TypeError(msg)
 


### PR DESCRIPTION
## Problem

`_PropertySetter.__call__` silently accepted multiple positional arguments and discarded every value after the first. It also ignored keyword arguments whenever a positional value was present, which made invalid method-style channel configuration appear successful.

## Solution

Argument validation now rejects multiple positional arguments and mixed positional/keyword calls with a clear `TypeError`. The message is prefixed with the owner class so the offending call is easy to locate (e.g. `X.scale()`). Both the schema generator source and the generated runtime module are updated, and the regression tests are parametrized over several setters (`scale`, `axis`, `sort`) to confirm the behaviour applies to every property setter.

This is a behavioural (breaking) change: calls that previously "succeeded" by silently dropping arguments now raise.

Closes #3661.

## Before / After

**Before** — extra positional arguments were silently dropped, and keyword arguments were ignored when a positional value was present, so an invalid call appeared to succeed:

```python
import altair as alt

# second argument silently discarded, no error
alt.X("field:Q").scale(["a", "b"], ["#1FC3AA", "#8624F5"])

# keyword arguments silently ignored, no error
alt.X("field:Q").axis(alt.Axis(), title="hi")
```

**After** — the invalid call raises immediately, naming the owner class and setter:

```python
alt.X("field:Q").scale(["a", "b"], ["#1FC3AA", "#8624F5"])
# TypeError: X.scale() accepts at most one positional argument, but 2 were given

alt.X("field:Q").axis(alt.Axis(), title="hi")
# TypeError: X.axis() cannot combine a positional argument with keyword arguments
```

If you hit this error, either pass a single value positionally (e.g. `.scale(alt.Scale(...))`) or use keyword arguments only (e.g. `.scale(domain=[...], range=[...])`).
