### PR TITLE
fix: Include layered concat views in selection params

### DIFF
--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -5232,17 +5232,23 @@ def _view_base_for_chart(obj: Any) -> str:
     return name
 
 
-def _view_name_for_param(subchart: ChartType, is_concat: bool) -> str:
-    """View name for this subchart to add to a param's views."""
+def _view_names_for_param(subchart: ChartType, is_concat: bool) -> list[str]:
+    """View names for this subchart to add to a param's views."""
     if isinstance(subchart, Chart):
-        return subchart.name
+        return [subchart.name]
+    if is_concat and isinstance(subchart, LayerChart):
+        return [
+            layer.name
+            for layer in subchart.layer
+            if isinstance(layer, Chart) and layer.name is not Undefined
+        ]
     if is_concat and isinstance(subchart, FacetChart):
         spec = subchart.spec
         if isinstance(spec, Chart):
-            return spec.name
+            return [spec.name]
         if isinstance(spec, LayerChart) and spec.layer:
-            return spec.layer[0].name
-    return ""
+            return [spec.layer[0].name]
+    return []
 
 
 def _combine_subchart_params(  # noqa: C901
@@ -5313,14 +5319,15 @@ def _combine_subchart_params(  # noqa: C901
                 continue
 
             # At this stage in the loop, p must be a TopLevelSelectionParameter.
-            # Get this subchart's view name from the subchart only (not p.views: params can share lists).
-            view_to_add = _view_name_for_param(subchart, is_concat)
+            # Get this subchart's view names from the subchart only (not p.views: params can share lists).
+            views_to_add = _view_names_for_param(subchart, is_concat)
             # MERGE (found=True): start from p.views to accumulate all views for this param.
-            # APPEND (found=False, view_to_add set): start from [] to avoid pulling in sibling views.
-            # COMPOUND (found=False, no view_to_add): subchart already aggregated views into p.views; preserve them.
-            views_after = list(p.views or []) if (found or not view_to_add) else []
-            if view_to_add and view_to_add not in views_after:
-                views_after.append(view_to_add)
+            # APPEND (found=False, views_to_add set): start from [] to avoid pulling in sibling views.
+            # COMPOUND (found=False, no views_to_add): subchart already aggregated views into p.views; preserve them.
+            views_after = list(p.views or []) if (found or not views_to_add) else []
+            for view_to_add in views_to_add:
+                if view_to_add not in views_after:
+                    views_after.append(view_to_add)
 
             if found:
                 merge_idx = dlist.index(pd)

--- a/tests/vegalite/v6/test_params.py
+++ b/tests/vegalite/v6/test_params.py
@@ -446,3 +446,33 @@ def test_vconcat_layered_charts_with_parent_transforms_have_unique_names():
     assert line_names[0] != line_names[1]
     assert line_names[0].endswith("_0")
     assert line_names[1].endswith("_1")
+
+
+def test_vconcat_layered_charts_include_all_views_for_selection_params():
+    df = pd.DataFrame(
+        {
+            "x": [1, 2, 3, 1, 2, 3],
+            "category": ["a", "a", "a", "b", "b", "b"],
+            "y": [1, 3, 2, 2, 4, 3],
+        }
+    )
+
+    hover = alt.selection_point(fields=["x"], on="mouseover", empty=False)
+    base = alt.Chart(df).encode(
+        x="x:O",
+        y="y:Q",
+    )
+    lines = base.mark_line(size=1)
+    points = base.encode(
+        size=alt.condition(hover, alt.value(120), alt.value(40))
+    ).mark_circle(filled=True)
+    layered = lines + points
+
+    mean_panel = layered.transform_aggregate(y="mean(y)", groupby=["x"])
+    detail_panel = layered.encode(detail="category:N")
+
+    spec = alt.vconcat(mean_panel, detail_panel).add_params(hover).to_dict()
+    line_names = [panel["layer"][0]["name"] for panel in spec["vconcat"]]
+    param_views = spec["params"][0]["views"]
+
+    assert param_views == line_names


### PR DESCRIPTION
This fixes selection param `views` accumulation for layered charts inside concat charts. After #4066, layered concat children receive distinct generated view names, which fixes duplicate view-name collisions. However, a related issue mentioned in #4065 remained: when a selection parameter was lifted/deduplicated from layered concat children, the generated top-level param could still reference only the first renamed view.

For example, before this PR a spec could produce:

```json
"views": ["view_..._0"]
```

even though the concat panels contained:

```json
["view_..._0", "view_..._1"]
```

That meant hover/click selections could be scoped to only the first panel. This change updates param view collection so layered concat children can contribute all relevant named child views.

Taking the following spec as an example:

```py
import altair as alt
import polars as pl

df = pl.DataFrame(
    {
        "x": [1, 2, 3, 1, 2, 3],
        "group": ["a", "a", "a", "b", "b", "b"],
        "y": [1, 3, 2, 2, 4, 3],
    }
)

hover = alt.selection_point(fields=["x"], on="mouseover", empty=False)

base = alt.Chart(df).encode(
    x="x:O",
    y="y:Q",
)

line = base.mark_line()

points = (
    base.mark_circle()
    .encode(size=alt.condition(hover, alt.value(150), alt.value(50)))
    .add_params(hover)
)

layered = line + points

left = layered.transform_filter(alt.datum.group == "a")
right = layered.transform_filter(alt.datum.group == "b")

chart = alt.hconcat(left, right)

chart
```

Before this PR, the params were only attached to one chart (ie hover only possible in the right-most chart):


https://github.com/user-attachments/assets/bf0ebd01-afcc-41ce-abbf-a7873da3dae7

After this PR, either chart can be hovered, as expected:

https://github.com/user-attachments/assets/6f67bdc6-1dcb-4caf-b910-f641e41d649a





