### PR TITLE
ci: Change timing to actually be only twice a month

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -3,7 +3,7 @@ name: Prepare Release Draft
 
 on:
   schedule:
-    - cron: '0 15 1-7,15-21 * 1'  # First and third Monday of each month at 15:00 UTC.
+    - cron: '30 14 1,15 * *'  # 1st and 15th of each month at 14:30 UTC.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -143,7 +143,7 @@ jobs:
           TAG="${{ steps.next-version.outputs.tag }}"
           cat > release-review-issue.md <<EOF
           @joelostblom @mattijn @alec-bike
-          A draft release for $TAG has been created. Please assign yourself to this issue if you have capacity to release this version.
+          A tag and release note draft for $TAG has been created. Please assign yourself to this issue if you have capacity to release this version.
 
           Next, review [the draft release notes](https://github.com/vega/altair/releases) and [the docs preview](${{ steps.docs-preview.outputs.url }}) (scan the gallery thumbnails for broken examples). If everything looks correct, publish the release on GitHub; this will also trigger a PyPI release.
 


### PR DESCRIPTION
The previous cron job was every day of the date ranges plus Mondays, rather than only Mondays in those date ranges. It seems a bit tricky to do "every other Monday",
so instead the release drafts are now generated twice a month on the 1st and 15th (if there are relevant changes)
