### PR TITLE
docs: remove altair_data_server references

### DIFF
--- a/doc/getting_started/resources.rst
+++ b/doc/getting_started/resources.rst
@@ -88,14 +88,6 @@ VegaFusion provides server-side scaling for Altair charts, which can accelerate 
 .. List of links.
 .. _VegaFusion: https://vegafusion.io/
 
-altair_data_server_
-~~~~~~~~~~~~~~~~~~~
-
-Data transformer plugin that transparently serves data for charts.
-
-.. List of links.
-.. _altair_data_server: https://github.com/altair-viz/altair_data_server
-
 altair_pandas_
 ~~~~~~~~~~~~~~
 

--- a/doc/user_guide/large_datasets.rst
+++ b/doc/user_guide/large_datasets.rst
@@ -214,24 +214,6 @@ This not only addresses the issue of large notebooks, but also leads to better
 interactivity performance with large datasets.
 
 
-Local Data Server
-^^^^^^^^^^^^^^^^^
-A convenient way to do this is by using the `altair_data_server <https://github.com/altair-viz/altair_data_server>`_
-package. It serves your data from a local threaded server. First install the package:
-
-.. code-block:: none
-
-   pip install altair_data_server
-
-And then enable the data transformer::
-
-    import altair as alt
-    alt.data_transformers.enable('data_server')
-
-Note that this approach may not work on some cloud-based Jupyter notebook services.
-A disadvantage of this method is that if you reopen the notebook, the plot may no longer display
-as the data server is no longer running.
-
 Local Filesystem
 ^^^^^^^^^^^^^^^^
 You can also persist the data to disk and then pass the path to Altair:


### PR DESCRIPTION
## Summary

`altair_data_server` was archived in April 2024 and fully replaced by VegaFusion, but the docs still referenced it (#3048). Per @dangotbanned's directive in the issue thread, this removes those references.

## Changes

- `doc/user_guide/large_datasets.rst` — removed the "Local Data Server" subsection (the `altair_data_server` install/enable instructions); "Passing Data by URL" now flows into "Local Filesystem".
- `doc/getting_started/resources.rst` — removed the `altair_data_server` resource entry and its link target. The VegaFusion entry (its replacement) is left intact.

`grep -rn altair_data_server doc/` is now empty, with no dangling cross-references.

Closes #3048
