### PR TITLE
build: Handle mistune expression signature tokens

### DIFF
--- a/tests/test_vega_expr.py
+++ b/tests/test_vega_expr.py
@@ -1,0 +1,31 @@
+from tools.vega_expr import RAW, SOFTBREAK, TEXT, TYPE, VegaExprDef
+
+
+def test_split_signature_tokens_handles_embedded_open_bracket() -> None:
+    expr_def = VegaExprDef("quantileUniform", ())
+
+    tokens = expr_def._split_markers("probability[")
+
+    assert list(tokens) == ["probability", "["]
+
+
+def test_parameters_handle_mistune_3_3_signature_tokens() -> None:
+    expr_def = VegaExprDef(
+        "quantileUniform",
+        (
+            {TYPE: SOFTBREAK},
+            {TYPE: TEXT, RAW: "quantileUniform"},
+            {TYPE: TEXT, RAW: "(probability[, "},
+            {TYPE: TEXT, RAW: "min"},
+            {TYPE: TEXT, RAW: ", "},
+            {TYPE: TEXT, RAW: "max"},
+            {TYPE: TEXT, RAW: "]) "},
+            {TYPE: SOFTBREAK},
+        ),
+    ).with_parameters()
+
+    assert [(p.name, p.required) for p in expr_def.parameters] == [
+        ("probability", True),
+        ("min", False),
+        ("max", False),
+    ]

--- a/tools/vega_expr.py
+++ b/tools/vega_expr.py
@@ -624,6 +624,12 @@ class VegaExprDef:
         if s.isalnum():
             yield s
             return
+        if split := split_first_open_bracket(s):
+            before, after = split
+            yield from before
+            yield OPEN_BRACKET
+            yield from after
+            return
 
         end: list[str] = []
         original = s  # Save original string to detect changes
@@ -871,6 +877,16 @@ def expand_urls(url: str, /) -> str:
     else:
         url = url.replace(r"../", VEGA_DOCS_URL)
     return url
+
+
+def split_first_open_bracket(s: str, /) -> tuple[Iterator[str], Iterator[str]] | None:
+    """Split embedded optional-argument markers from mistune text tokens."""
+    if OPEN_BRACKET not in s:
+        return None
+    before, after = s.split(OPEN_BRACKET, maxsplit=1)
+    before_tokens = VegaExprDef._split_markers(before) if before else iter(())
+    after_tokens = VegaExprDef._split_markers(after) if after else iter(())
+    return before_tokens, after_tokens
 
 
 def format_doc(doc: str, /) -> str:


### PR DESCRIPTION
`mistune 3.3.0` changed how markdown text around optional argument brackets is tokenized. For signatures like:

```md
quantileUniform(probability[, <i>min</i>, <i>max</i>])
```

the parser now receives `probability[,`  as one text token instead of separate `probability` and `[` tokens. This caused `tools/generate_schema_wrapper.py` to drop the required first argument from several statistical expression helpers, [producing generated diffs in CI](https://github.com/vega/altair/actions/runs/28089590595/job/83163971660?pr=4075).
This PR updates the Vega expression parser to split embedded `[` markers before parameter parsing.