### PR TITLE
chore: Fix two typos in datasets module

### DIFF
--- a/altair/datasets/_cache.py
+++ b/altair/datasets/_cache.py
@@ -239,7 +239,7 @@ class SchemaCache(CompressedCache["_Dataset", "_FlSchema"]):
 
     def by_dtype(self, name: _Dataset, *dtypes: type[DType]) -> list[str]:
         """
-        Return column names specfied in ``name``'s schema.
+        Return column names specified in ``name``'s schema.
 
         Parameters
         ----------

--- a/altair/datasets/_reader.py
+++ b/altair/datasets/_reader.py
@@ -554,8 +554,8 @@ def _into_suffix(obj: Path | str, /) -> Any:
 def _steal_eager_parquet(
     read_fns: Sequence[Read[IntoDataFrameT]], /
 ) -> Sequence[Scan[Any]] | None:
-    if convertable := next((rd for rd in read_fns if rd.include <= is_parquet), None):
-        return (_readimpl.into_scan(convertable),)
+    if convertible := next((rd for rd in read_fns if rd.include <= is_parquet), None):
+        return (_readimpl.into_scan(convertible),)
     return None
 
 


### PR DESCRIPTION
Fix two spelling mistakes found in the datasets module:

- `specfied` → `specified` in docstring of `SchemaCache.by_dtype()` (`altair/datasets/_cache.py`)
- `convertable` → `convertible` in walrus-assignment variable name in `_steal_eager_parquet()` (`altair/datasets/_reader.py`)