### PR TITLE
fix: Expression objects not working in alt.value()

### DIFF
--- a/altair/vegalite/v6/api.py
+++ b/altair/vegalite/v6/api.py
@@ -1397,6 +1397,8 @@ def when(
 
 def value(value: Any, **kwargs: Any) -> _Value:
     """Specify a value for use in an encoding."""
+    if isinstance(value, _expr_core.Expression):
+        value = core.ExprRef(expr=repr(value))
     return _Value(value=value, **kwargs)  # type: ignore
 
 


### PR DESCRIPTION
Closes #4082

## Problem

Passing an `Expression` object (from `alt.expr.*`) to `alt.value()` fails with a schema validation error. The string form (`alt.expr("...")`) works fine, but the object form does not:

```python
import altair as alt

# This works:
alt.value(alt.expr("scale('x', datum.c1)"))

# This fails with SchemaValidationError:
alt.value(alt.expr.scale("x", alt.datum.c1) + alt.expr.bandwidth("x") / 2)
```

## Cause

`Expression.to_dict()` returns a plain string (the JS expression text). When `alt.value(expr_obj)` creates `{"value": <Expression>}` and this gets serialized, the value becomes a raw string like `"scale('x',datum.c1,null)"`. But the Vega-Lite schema expects `value` to be either a number or a mapping like `{"expr": "..."}`, so validation rejects it.

The `alt.expr("...")` form works because it returns an `ExprRef` object whose `to_dict()` produces `{"expr": "..."}` directly.

## Fix

In `alt.value()`, detect `Expression` instances and wrap them in `ExprRef` before storing. This produces the correct `{"value": {"expr": "..."}}` output.

```python
def value(value, **kwargs):
    if isinstance(value, _expr_core.Expression):
        value = core.ExprRef(expr=repr(value))
    return _Value(value=value, **kwargs)
```

## Testing

- Verified the exact reproduction from the issue works
- Tested with BinaryExpression, FunctionExpression, UnaryExpression, datum expressions
- Confirmed SelectionExpression (which uses a different path) still works
- Confirmed plain numeric and string values are unaffected
- All 257 runnable existing tests pass
