### PR TITLE
fix: clear active plugin when unregistering from PluginRegistry

### DIFF
--- a/altair/theme.py
+++ b/altair/theme.py
@@ -300,11 +300,13 @@ def __getattr__(name: str) -> Any:
 def _register(
     name: LiteralString, fn: Plugin[ThemeConfig] | None, /
 ) -> Plugin[ThemeConfig] | None:
-    if fn is None:
-        return _themes._plugins.pop(name, None)
-    elif _themes.plugin_type(fn):
-        _themes._plugins[name] = fn
-        return fn
-    else:
-        msg = f"{type(fn).__name__!r} is not a callable theme\n\n{fn!r}"
-        raise TypeError(msg)
+    # Route through PluginRegistry.register so unregister clears active state
+    # when the removed theme was enabled (#3619).
+    try:
+        return _themes.register(name, fn)
+    except TypeError as err:
+        # Preserve theme-specific error text for non-callable values.
+        if fn is not None and not _themes.plugin_type(fn):
+            msg = f"{type(fn).__name__!r} is not a callable theme\n\n{fn!r}"
+            raise TypeError(msg) from err
+        raise

--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -164,7 +164,14 @@ class PluginRegistry(Generic[PluginT, R]):
             The plugin that was registered or unregistered.
         """
         if value is None:
-            return self._plugins.pop(name, None)
+            # Unregister. If this was the active plugin, clear active state so
+            # `active` does not keep returning a removed name (#3619).
+            plugin = self._plugins.pop(name, None)
+            if name == self._active_name:
+                self._active = None
+                self._active_name = ""
+                self._options = {}
+            return plugin
         elif self.plugin_type(value):
             self._plugins[name] = value
             return value

--- a/tests/utils/test_plugin_registry.py
+++ b/tests/utils/test_plugin_registry.py
@@ -130,3 +130,17 @@ def test_plugin_registry_context():
 
     assert plugins.active == "default"
     assert plugins.options == {"p": 2}
+
+
+def test_plugin_registry_unregister_clears_active():
+    """Unregistering the active plugin must clear active name/state (#3619)."""
+    plugins = TypedCallableRegistry()
+    plugins.register("temp", lambda x: x + 1)
+    plugins.enable("temp")
+    assert plugins.active == "temp"
+    removed = plugins.register("temp", None)
+    assert removed is not None
+    assert removed(1) == 2
+    assert plugins.active == ""
+    assert plugins.get() is None
+    assert "temp" not in plugins.names()

--- a/tests/vegalite/v6/test_theme.py
+++ b/tests/vegalite/v6/test_theme.py
@@ -107,10 +107,12 @@ def test_theme_unregister() -> None:
 
     assert theme.active == "big square"
     fn = theme.unregister("big square")
+    assert fn is not None
     assert fn() == custom_theme()
     assert theme.active == theme._themes.active
-    # BUG: https://github.com/vega/altair/issues/3619
-    # assert theme.active != "big square"
+    # Unregistering the active theme must clear active state (#3619).
+    assert theme.active != "big square"
+    assert theme.active == ""
 
     with pytest.raises(
         TypeError, match=r"Found no theme named 'big square' in registry."


### PR DESCRIPTION
## Thanks for contributing to Altair!

### 1. PR Description

`PluginRegistry.register(name, None)` removed the plugin from `_plugins` but left `_active` / `_active_name` pointing at the removed entry. After `theme.unregister(...)` on the currently enabled theme, `theme.active` still returned the old name.

Also, `altair.theme._register` duplicated registry logic and bypassed `PluginRegistry.register`, so a registry-only fix would not cover the public theme API.

**Fix:**
- On unregister, clear `_active`, `_active_name`, and `_options` when the removed name was active.
- Route `theme._register` through `_themes.register(...)`.

### 2. Tests and Docs

```text
pytest tests/utils/test_plugin_registry.py::test_plugin_registry_unregister_clears_active tests/vegalite/v6/test_theme.py::test_theme_unregister -q
# 2 passed
```

### 3. Commit Message

`fix: clear active plugin when unregistering from PluginRegistry`

## Linked Issue

Closes #3619
