### PR TITLE
docs: add date input gallery example

### DIFF
--- a/tests/examples_arguments_syntax/interactive_date_input.py
+++ b/tests/examples_arguments_syntax/interactive_date_input.py
@@ -1,0 +1,57 @@
+"""
+Filter a Time Series with a Date Input
+======================================
+This example shows how to bind an HTML date input to a parameter and use the
+selected date to filter a time-series chart.
+"""
+
+# :new:
+# category: interactive charts
+import altair as alt
+import pandas as pd
+
+source = pd.DataFrame(
+    {
+        "date": pd.date_range("2024-01-01", periods=14, freq="D"),
+        "visitors": [
+            120,
+            135,
+            128,
+            142,
+            160,
+            175,
+            168,
+            155,
+            172,
+            184,
+            191,
+            205,
+            198,
+            214,
+        ],
+    }
+)
+
+start_date = alt.param(
+    name="start_date",
+    value="2024-01-05",
+    bind=alt.binding(input="date", name="Start date: "),
+)
+
+chart = (
+    alt.Chart(source)
+    .mark_line(point=True)
+    .encode(
+        x=alt.X("date:T", title="Date"),
+        y=alt.Y("visitors:Q", title="Visitors"),
+        tooltip=[
+            alt.Tooltip("date:T", title="Date"),
+            alt.Tooltip("visitors:Q", title="Visitors"),
+        ],
+    )
+    .transform_filter(alt.datum.date >= alt.expr.timeParse(start_date, "%Y-%m-%d"))
+    .add_params(start_date)
+    .properties(width=600)
+)
+
+chart

--- a/tests/examples_arguments_syntax/interactive_date_input.py
+++ b/tests/examples_arguments_syntax/interactive_date_input.py
@@ -42,8 +42,8 @@ chart = (
     alt.Chart(source)
     .mark_line(point=True)
     .encode(
-        x=alt.X("date:T", title="Date"),
-        y=alt.Y("visitors:Q", title="Visitors"),
+        x=alt.X("date:T"),
+        y=alt.Y("visitors:Q"),
         tooltip=[
             alt.Tooltip("date:T", title="Date"),
             alt.Tooltip("visitors:Q", title="Visitors"),
@@ -51,7 +51,6 @@ chart = (
     )
     .transform_filter(alt.datum.date >= alt.expr.timeParse(start_date, "%Y-%m-%d"))
     .add_params(start_date)
-    .properties(width=600)
 )
 
 chart

--- a/tests/examples_methods_syntax/interactive_date_input.py
+++ b/tests/examples_methods_syntax/interactive_date_input.py
@@ -1,0 +1,56 @@
+"""
+Filter a Time Series with a Date Input
+======================================
+This example shows how to bind an HTML date input to a parameter and use the
+selected date to filter a time-series chart.
+"""
+
+# category: interactive charts
+import altair as alt
+import pandas as pd
+
+source = pd.DataFrame(
+    {
+        "date": pd.date_range("2024-01-01", periods=14, freq="D"),
+        "visitors": [
+            120,
+            135,
+            128,
+            142,
+            160,
+            175,
+            168,
+            155,
+            172,
+            184,
+            191,
+            205,
+            198,
+            214,
+        ],
+    }
+)
+
+start_date = alt.param(
+    name="start_date",
+    value="2024-01-05",
+    bind=alt.binding(input="date", name="Start date: "),
+)
+
+chart = (
+    alt.Chart(source)
+    .mark_line(point=True)
+    .encode(
+        alt.X("date:T").title("Date"),
+        alt.Y("visitors:Q").title("Visitors"),
+        tooltip=[
+            alt.Tooltip("date:T", title="Date"),
+            alt.Tooltip("visitors:Q", title="Visitors"),
+        ],
+    )
+    .transform_filter(alt.datum.date >= alt.expr.timeParse(start_date, "%Y-%m-%d"))
+    .add_params(start_date)
+    .properties(width=600)
+)
+
+chart

--- a/tests/examples_methods_syntax/interactive_date_input.py
+++ b/tests/examples_methods_syntax/interactive_date_input.py
@@ -41,8 +41,8 @@ chart = (
     alt.Chart(source)
     .mark_line(point=True)
     .encode(
-        alt.X("date:T").title("Date"),
-        alt.Y("visitors:Q").title("Visitors"),
+        alt.X("date:T"),
+        alt.Y("visitors:Q"),
         tooltip=[
             alt.Tooltip("date:T", title="Date"),
             alt.Tooltip("visitors:Q", title="Visitors"),
@@ -50,7 +50,6 @@ chart = (
     )
     .transform_filter(alt.datum.date >= alt.expr.timeParse(start_date, "%Y-%m-%d"))
     .add_params(start_date)
-    .properties(width=600)
 )
 
 chart


### PR DESCRIPTION
## What I changed

- added a date input example that filters a small time series
- added both the arguments and methods syntax versions
- used `timeParse` so the selected date works the same way across time zones
- kept the default chart width and default axis titles so the example stays focused

The data is kept in the example, so it does not depend on an external URL.

Related to #3403.

## Preview

This is the chart with the default January 5 selection. The gallery version has the date picker above it.

![Date input example with the default January 5 selection](https://raw.githubusercontent.com/Kato-MT/altair/pr-4088-assets/pr-assets/interactive_date_input.png)

## Testing

- `pytest tests/test_examples.py -k interactive_date_input -q -n0 -p no:cacheprovider` (`6 passed`)
- checked both files with Ruff format
- confirmed both versions generate the same Vega-Lite spec
- confirmed the default width and field-name axis titles are used
