### PR TITLE
fix: report missing anywidget for JupyterChart

### DIFF
--- a/altair/jupyter/__init__.py
+++ b/altair/jupyter/__init__.py
@@ -1,21 +1,34 @@
-try:
-    import anywidget  # noqa: F401
-except ImportError:
-    # When anywidget isn't available, create stand-in JupyterChart class
-    # that raises an informative import error on construction. This
+from importlib.util import find_spec
+from typing import TYPE_CHECKING, NoReturn
+
+_ANYWIDGET_IMPORT_ERROR = (
+    "The Altair JupyterChart requires the anywidget \n"
+    "Python package which may be installed using pip with\n"
+    "    pip install anywidget\n"
+    "or using conda with\n"
+    "    conda install -c conda-forge anywidget\n"
+    "Afterwards, you will need to restart your Python kernel."
+)
+
+
+def _raise_anywidget_import_error() -> NoReturn:
+    raise ImportError(_ANYWIDGET_IMPORT_ERROR)
+
+
+if TYPE_CHECKING:
+    from .jupyter_chart import JupyterChart
+elif find_spec("anywidget") is None:
+    # When anywidget isn't available, create a stand-in JupyterChart class
+    # that raises an informative import error when its API is used. This
     # way we can make JupyterChart available in the altair namespace
-    # when anywidget is not installed
+    # when anywidget is not installed.
     class JupyterChart:
-        def __init__(self, *args, **kwargs):
-            msg = (
-                "The Altair JupyterChart requires the anywidget \n"
-                "Python package which may be installed using pip with\n"
-                "    pip install anywidget\n"
-                "or using conda with\n"
-                "    conda install -c conda-forge anywidget\n"
-                "Afterwards, you will need to restart your Python kernel."
-            )
-            raise ImportError(msg)
+        def __init__(self, *args: object, **kwargs: object) -> NoReturn:
+            _raise_anywidget_import_error()
+
+        @classmethod
+        def enable_offline(cls, offline: bool = True) -> NoReturn:
+            _raise_anywidget_import_error()
 
 else:
-    from .jupyter_chart import JupyterChart  # noqa: F401
+    from .jupyter_chart import JupyterChart as JupyterChart

--- a/altair/vegalite/v6/display.py
+++ b/altair/vegalite/v6/display.py
@@ -96,17 +96,14 @@ def jupyter_renderer(spec: dict, **metadata):
     # Configure offline mode
     offline = metadata.get("offline", False)
 
-    # mypy doesn't see the enable_offline class method for some reason
-    JupyterChart.enable_offline(offline=offline)  # type: ignore
+    JupyterChart.enable_offline(offline=offline)
 
     # propagate embed options
     embed_options = metadata.get("embed_options")
 
-    # Need to ignore attr-defined mypy rule because mypy doesn't see _repr_mimebundle_
-    # conditionally defined in AnyWidget
     return JupyterChart(
         chart=Chart.from_dict(spec), embed_options=embed_options
-    )._repr_mimebundle_()  # type: ignore
+    )._repr_mimebundle_()
 
 
 def browser_renderer(

--- a/tests/test_jupyter_chart.py
+++ b/tests/test_jupyter_chart.py
@@ -1,5 +1,3 @@
-import sys
-from importlib import import_module
 from importlib.metadata import version as importlib_version
 
 import pandas as pd
@@ -9,7 +7,7 @@ from packaging.version import Version
 import altair as alt
 from altair.datasets import data
 
-# If anywidget is not installed, we will skip the tests in this file.
+# Tests requiring anywidget are skipped when it is not installed.
 try:
     import anywidget  # noqa: F401
 
@@ -49,24 +47,14 @@ else:
     jupyter_marks = skip_requires_anywidget(param_transformers)
 
 
-def test_jupyter_chart_without_anywidget(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.skipif(has_anywidget, reason="anywidget is importable")
+def test_jupyter_chart_without_anywidget() -> None:
     """JupyterChart should report how to install its optional dependency."""
-    original_jupyter = sys.modules["altair.jupyter"]
+    with pytest.raises(ImportError, match="requires the anywidget"):
+        alt.JupyterChart.enable_offline()
 
-    with monkeypatch.context() as mp:
-        mp.setattr(alt, "jupyter", original_jupyter)
-        mp.setitem(sys.modules, "anywidget", None)
-        mp.delitem(sys.modules, "altair.jupyter")
-        jupyter = import_module("altair.jupyter")
-
-        with pytest.raises(ImportError, match="requires the anywidget"):
-            jupyter.JupyterChart.enable_offline()
-
-        with pytest.raises(ImportError, match="requires the anywidget"):
-            jupyter.JupyterChart()
-
-    assert sys.modules["altair.jupyter"] is original_jupyter
-    assert alt.jupyter is original_jupyter
+    with pytest.raises(ImportError, match="requires the anywidget"):
+        alt.JupyterChart(alt.Chart())
 
 
 @jupyter_marks

--- a/tests/test_jupyter_chart.py
+++ b/tests/test_jupyter_chart.py
@@ -1,3 +1,5 @@
+import sys
+from importlib import import_module
 from importlib.metadata import version as importlib_version
 
 import pandas as pd
@@ -45,6 +47,26 @@ if Version(importlib_version("ipywidgets")) < Version("8.1.4"):
     )
 else:
     jupyter_marks = skip_requires_anywidget(param_transformers)
+
+
+def test_jupyter_chart_without_anywidget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JupyterChart should report how to install its optional dependency."""
+    original_jupyter = sys.modules["altair.jupyter"]
+
+    with monkeypatch.context() as mp:
+        mp.setattr(alt, "jupyter", original_jupyter)
+        mp.setitem(sys.modules, "anywidget", None)
+        mp.delitem(sys.modules, "altair.jupyter")
+        jupyter = import_module("altair.jupyter")
+
+        with pytest.raises(ImportError, match="requires the anywidget"):
+            jupyter.JupyterChart.enable_offline()
+
+        with pytest.raises(ImportError, match="requires the anywidget"):
+            jupyter.JupyterChart()
+
+    assert sys.modules["altair.jupyter"] is original_jupyter
+    assert alt.jupyter is original_jupyter
 
 
 @jupyter_marks


### PR DESCRIPTION
## Summary

- add the missing `enable_offline()` API to the `JupyterChart` fallback used when `anywidget` is unavailable
- detect the optional dependency with `find_spec()` and expose the real class during type checking
- remove obsolete type ignores from the Jupyter renderer
- add regression coverage for the missing-dependency behavior and restore imported module state after the test

Fixes #3801

## Testing

- `uv run task test`
- `uv run pytest tests/test_jupyter_chart.py -q --numprocesses=1`
- `uv run pytest tests/vegalite/v6/test_renderers.py -q --numprocesses=1`
- verified a base-only installation without `anywidget` reports the intended `ImportError` for `alt.JupyterChart`, `enable_offline()`, and the `jupyter` renderer
