### PR TITLE
docs: document lookup key compatibility

### DIFF
--- a/doc/user_guide/transform/lookup.rst
+++ b/doc/user_guide/transform/lookup.rst
@@ -100,10 +100,11 @@ extract.
 .. note::
 
    Make sure the lookup fields use compatible values and data types. For
-   example, a zero-padded FIPS code such as ``"06001"`` will not match the
-   numeric county ID ``6001``. If a pandas column contains zero-padded FIPS
-   strings while the geographic data uses numeric IDs, convert it before
-   creating the chart, for example with ``df["id"] = df["fips"].astype(int)``.
+   example, a zero-padded spatial ID such as ``"06001"`` will not match the
+   numeric spatial ID ``6001``. If your dataframe contains zero-padded spatial 
+   IDs as strings while the geographic data uses numeric IDs, convert the column
+   to a compatible type before creating the chart. For example, in pandas use
+   ``df["id"] = df["spatial_id"].astype(int)``.
 
 Example: Lookup Transforms for Geographical Visualization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/user_guide/transform/lookup.rst
+++ b/doc/user_guide/transform/lookup.rst
@@ -97,6 +97,14 @@ and the ``from_`` argument specifies a :class:`~LookupData` structure where
 we supply the second dataset, the lookup key, and the fields we would like to
 extract.
 
+.. note::
+
+   Make sure the lookup fields use compatible values and data types. For
+   example, a zero-padded FIPS code such as ``"06001"`` will not match the
+   numeric county ID ``6001``. If a pandas column contains zero-padded FIPS
+   strings while the geographic data uses numeric IDs, convert it before
+   creating the chart, for example with ``df["id"] = df["fips"].astype(int)``.
+
 Example: Lookup Transforms for Geographical Visualization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Lookup transforms are often particularly important for geographic visualization,


### PR DESCRIPTION
The lookup guide did not explain that lookup values need compatible types and formatting. This is especially easy to miss with geographic data: a zero-padded FIPS string such as `"06001"` does not match the numeric county ID `6001`.

This adds a note next to the `LookupData` explanation and shows how to normalize a pandas FIPS column before creating the chart.

Fixes #2323

## Validation

- `uv run task doc-build -- --clean --no-autosummary --no-gallery`

The build succeeded. Its only warning references the unchanged `case_studies/index.rst` file, and the rendered lookup page contains the new note.

## Risk

Documentation only; runtime behavior is unchanged.
