### PR TITLE
fix: preserve existing config in `configure()`

### DIFF
--- a/altair/vegalite/v6/schema/mixins.py
+++ b/altair/vegalite/v6/schema/mixins.py
@@ -1162,6 +1162,11 @@ class ConfigMethodMixin:
     @use_signature(core.Config)
     def configure(self, *args, **kwargs) -> Self:
         copy = self.copy(deep=["config"])  # type: ignore[attr-defined]
+        if not args and not kwargs:
+            # A bare ``configure()`` resets the config, preserving the
+            # behaviour it had before merging was introduced.
+            copy.config = core.Config()
+            return copy
         if args or copy.config is Undefined:
             copy.config = core.Config(*args, **kwargs)
         else:

--- a/altair/vegalite/v6/schema/mixins.py
+++ b/altair/vegalite/v6/schema/mixins.py
@@ -1161,8 +1161,15 @@ class ConfigMethodMixin:
 
     @use_signature(core.Config)
     def configure(self, *args, **kwargs) -> Self:
-        copy = self.copy(deep=False)  # type: ignore[attr-defined]
-        copy.config = core.Config(*args, **kwargs)
+        copy = self.copy(deep=["config"])  # type: ignore[attr-defined]
+        if args or copy.config is Undefined:
+            copy.config = core.Config(*args, **kwargs)
+        else:
+            # Merge into the existing config so that properties set by earlier
+            # ``configure_*()`` calls are kept instead of silently discarded.
+            for prop, val in core.Config(**kwargs)._kwds.items():
+                if val is not Undefined:
+                    copy.config[prop] = val
         return copy
 
     @use_signature(core.RectConfig)

--- a/tests/vegalite/v6/test_api.py
+++ b/tests/vegalite/v6/test_api.py
@@ -1552,6 +1552,51 @@ def test_themes():
         assert "config" not in chart.to_dict()
 
 
+def test_configure_preserves_existing_config():
+    # https://github.com/vega/altair/issues/3841
+    # `configure()` used to replace the whole config object, silently dropping
+    # anything an earlier `configure_*()` call had set.
+    base = alt.Chart("data.txt").mark_point().encode(x="x:Q", y="y:Q")
+
+    axis_first = base.configure_axisBottom(orient="top").configure(
+        tooltipFormat={"numberFormat": ".2f"}
+    )
+    axis_last = base.configure(
+        tooltipFormat={"numberFormat": ".2f"}
+    ).configure_axisBottom(orient="top")
+
+    config = axis_first.to_dict()["config"]
+    assert config["axisBottom"] == {"orient": "top"}
+    assert config["tooltipFormat"] == {"numberFormat": ".2f"}
+    assert config == axis_last.to_dict()["config"]
+
+
+def test_configure_merges_repeated_calls():
+    base = alt.Chart("data.txt").mark_point().encode(x="x:Q", y="y:Q")
+
+    # Properties from separate `configure()` calls accumulate ...
+    config = base.configure(background="red").configure(padding=5).to_dict()["config"]
+    assert config["background"] == "red"
+    assert config["padding"] == 5
+
+    # ... but a repeated property is overridden by the later call.
+    config = (
+        base.configure(background="red")
+        .configure(background="blue")
+        .to_dict()["config"]
+    )
+    assert config["background"] == "blue"
+
+
+def test_configure_does_not_mutate_source_chart():
+    base = alt.Chart("data.txt").mark_point().encode(x="x:Q", y="y:Q")
+    configured = base.configure_axisBottom(orient="top")
+
+    _ = configured.configure(background="red").to_dict()
+
+    assert "background" not in configured.to_dict()["config"]
+
+
 def test_chart_from_dict():
     base = alt.Chart("data.csv").mark_point().encode(x="x:Q", y="y:Q")
 

--- a/tests/vegalite/v6/test_api.py
+++ b/tests/vegalite/v6/test_api.py
@@ -1588,6 +1588,16 @@ def test_configure_merges_repeated_calls():
     assert config["background"] == "blue"
 
 
+def test_configure_without_arguments_resets_config():
+    # A bare ``configure()`` still clears the config, as it does on ``main`` —
+    # merging must not turn that into a no-op (see review on #4035).
+    base = alt.Chart("data.txt").mark_point().encode(x="x:Q", y="y:Q")
+    configured = base.configure_axis(labelColor="red")
+
+    assert configured.to_dict()["config"]["axis"] == {"labelColor": "red"}
+    assert "axis" not in configured.configure().to_dict()["config"]
+
+
 def test_configure_does_not_mutate_source_chart():
     base = alt.Chart("data.txt").mark_point().encode(x="x:Q", y="y:Q")
     configured = base.configure_axisBottom(orient="top")

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -236,6 +236,11 @@ CONFIG_METHOD: Final = """
 @use_signature(core.{classname})
 def {method}(self, *args, **kwargs) -> Self:
     copy = self.copy(deep=['config'])  # type: ignore[attr-defined]
+    if not args and not kwargs:
+        # A bare ``configure()`` resets the config, preserving the
+        # behaviour it had before merging was introduced.
+        copy.config = core.{classname}()
+        return copy
     if args or copy.config is Undefined:
         copy.config = core.{classname}(*args, **kwargs)
     else:

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -235,8 +235,15 @@ def mark_{mark}(self, **kwds: Any) -> Self:
 CONFIG_METHOD: Final = """
 @use_signature(core.{classname})
 def {method}(self, *args, **kwargs) -> Self:
-    copy = self.copy(deep=False)  # type: ignore[attr-defined]
-    copy.config = core.{classname}(*args, **kwargs)
+    copy = self.copy(deep=['config'])  # type: ignore[attr-defined]
+    if args or copy.config is Undefined:
+        copy.config = core.{classname}(*args, **kwargs)
+    else:
+        # Merge into the existing config so that properties set by earlier
+        # ``configure_*()`` calls are kept instead of silently discarded.
+        for prop, val in core.{classname}(**kwargs)._kwds.items():
+            if val is not Undefined:
+                copy.config[prop] = val
     return copy
 """
 


### PR DESCRIPTION
## Description

`configure()` replaced `chart.config` wholesale, so any sub-config set by an earlier `configure_*()` call was silently discarded. The two orderings gave different specs:

```python
import pandas as pd, altair as alt

data = pd.DataFrame(dict(foo=[1.1, 2.2, 3.3], bar=[3, 2, 4]))
base = alt.Chart(data).mark_circle().encode(x="foo", y="bar")

base.configure_axisBottom(orient="top").configure(tooltipFormat={"numberFormat": ".2f"})
# config -> {"view": ..., "tooltipFormat": ...}                  <- axisBottom dropped

base.configure(tooltipFormat={"numberFormat": ".2f"}).configure_axisBottom(orient="top")
# config -> {"view": ..., "axisBottom": ..., "tooltipFormat": ...}
```

The `configure_*()` family already merges into an existing config (`copy.config[prop] = ...`); `configure()` was the outlier, and the failure was silent — no error, just a missing property in the output spec.

Fixes #3841

## Changes

- `CONFIG_METHOD` in `tools/generate_schema_wrapper.py`: `configure()` now copies with `deep=["config"]` and merges the set properties of the newly built `Config` into the existing one, rather than overwriting it. Regenerated `altair/vegalite/v6/schema/mixins.py` accordingly.
- Added regression tests in `tests/vegalite/v6/test_api.py` covering both orderings, accumulation and override across repeated `configure()` calls, and that the source chart is not mutated.

## Notes

- Properties are still last-write-wins: `configure(background="red").configure(background="blue")` yields `"blue"`.
- A **positional** argument (`configure({...})`) keeps the old replacement behaviour, since there are no keywords to merge. That path's behaviour is unchanged from `main`.
- `deep=["config"]` matches what every `configure_*()` method already does, so the merge does not mutate the chart it was called on.

## Testing

- `python tools/generate_schema_wrapper.py` — `mixins.py` is the only regenerated file that changes.
- `pytest tests` passes, except `tests/test_transformed_data.py::test_primitive_chart_examples[annual_weather_heatmap.py]` and `test_compound_chart_examples[layered_chart_with_dual_axis.py]`, which fail identically on unmodified `main` on this machine and are unrelated to this change.
- The two behavioural tests added here fail without the `mixins.py` change.
- `ruff check`, `ruff format --check` and `mypy tools` are clean.