### PR TITLE
build: Keep tagless forks compatible with sphinxext-altair's altair>=4 requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,10 @@ you can [use the fetch upstream button on GitHub](https://docs.github.com/en/pul
 > [!NOTE]
 > Altair's local version is derived from Git release tags. If your fork
 > is missing the latest upstream tags, the version reported by a local install
-> may be using an older tag as the base (or fall back to the minimum compatible
-> version if no upstream tags are present). You can still see the latest commit
-> SHA in the reported version, but if you want more accurate version reporting
-> for a locally installed development version, make sure to fetch all upstream
-> tags:
+> may be using an older tag as the base (or be reported as
+> `4.0.0+fallback` if no upstream tags are present). If you want accurate
+> version reporting for a locally installed development version, make sure to
+> fetch all upstream tags:
 >
 > ```cmd
 > git fetch --tags https://github.com/vega/altair.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,11 @@ you can [use the fetch upstream button on GitHub](https://docs.github.com/en/pul
 > [!NOTE]
 > Altair's local version is derived from Git release tags. If your fork
 > is missing the latest upstream tags, the version reported by a local install
-> may be using an older tag as the base (or even fall back to a synthetic
-> `0...` version if no upstream tags are present). This doesn't affect the
-> development experience in any meaningful way and you can still see the latest
-> commit SHA in the reported version, but if you want more accurate version
-> reporting for a locally installed development version, make sure to fetch all
-> upstream tags:
+> may be using an older tag as the base (or fall back to the minimum compatible
+> version if no upstream tags are present). You can still see the latest commit
+> SHA in the reported version, but if you want more accurate version reporting
+> for a locally installed development version, make sure to fetch all upstream
+> tags:
 >
 > ```cmd
 > git fetch --tags https://github.com/vega/altair.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ metadata = { allow-direct-references = true }
 
 [tool.hatch.version]
 source = "versioningit"
+default-version = "4.0.0+fallback"  # Must satisfy sphinxext-altair's altair>=4
 
 [tool.hatch.version.vcs]
 # "git-archive" is required (not the default "git") so that version calculation
@@ -133,8 +134,6 @@ source = "versioningit"
 # time via the export-subst attribute in .gitattributes.
 method = "git-archive"
 describe-subst = "$Format:%(describe:tags,match=v[0-9]*)$"
-# Keep tagless forks compatible with sphinxext-altair's altair>=4 requirement.
-default-tag = "v4.0.0"
 
 [tool.hatch.envs]
 # https://hatch.pypa.io/latest/how-to/environment/select-installer/#enabling-uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,8 @@ source = "versioningit"
 # time via the export-subst attribute in .gitattributes.
 method = "git-archive"
 describe-subst = "$Format:%(describe:tags,match=v[0-9]*)$"
-default-tag = "v0"
+# Keep tagless forks compatible with sphinxext-altair's altair>=4 requirement.
+default-tag = "v4.0.0"
 
 [tool.hatch.envs]
 # https://hatch.pypa.io/latest/how-to/environment/select-installer/#enabling-uv


### PR DESCRIPTION
close #4096, see details there


