### PR TITLE
ci: Gate release tags on approval

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -161,7 +161,7 @@ jobs:
           ## Release notes preview
           EOF
 
-          cat release-notes-preview.md >> release-review-issue.md
+          sed -E 's/ by @[A-Za-z0-9-]+//g' release-notes-preview.md >> release-review-issue.md
 
           gh issue create \
             --title "Review release candidate $TAG" \

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -20,14 +20,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  prepare-release-draft:
+  prepare-release-candidate:
     runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.candidate.outputs.commit }}
+      should-release: ${{ steps.next-version.outputs.should-release }}
+      tag: ${{ steps.next-version.outputs.tag }}
+      version: ${{ steps.next-version.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           # Use RELEASE_TOKEN when branch protection blocks github.token pushes.
           token: ${{ secrets.RELEASE_TOKEN || github.token }}
+      - name: Record release candidate commit
+        id: candidate
+        run: echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -46,19 +54,22 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Check for an existing draft release
-        id: existing-draft
+      - name: Check for existing release candidate
+        id: existing-review
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
         run: |
-          if gh release list --limit 20 --json isDraft,tagName --jq '.[] | select(.isDraft) | .tagName' | grep -q .; then
-            echo "A draft release already exists. Review or delete it before preparing another one."
+          if gh release list --limit 20 --json isDraft --jq '[.[] | select(.isDraft)] | length' | grep -qv '^0$'; then
+            echo "A draft release already exists. Publish or delete it before preparing another candidate."
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
+          elif gh issue list --state open --search "Review release candidate in:title" --json number --jq 'length' | grep -qv '^0$'; then
+            echo "An open release review issue already exists. Review or close it before preparing another one."
             echo "should-release=false" >> "$GITHUB_OUTPUT"
           else
             echo "should-release=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Determine next release version
-        if: steps.existing-draft.outputs.should-release == 'true'
+        if: steps.existing-review.outputs.should-release == 'true'
         id: next-version
         run: |
           set +e
@@ -81,23 +92,18 @@ jobs:
       - name: Test with pytest
         if: steps.next-version.outputs.should-release == 'true'
         run: uv run task test
-      - name: Create release tag
-        if: steps.next-version.outputs.should-release == 'true'
-        id: bump
-        run: |
-          cog bump --auto --disable-bump-commit --annotated "Version {{version}} release"
-          git push origin "refs/tags/${{ steps.next-version.outputs.tag }}"
-      - name: Create draft GitHub release
+      - name: Generate release notes preview
         if: steps.next-version.outputs.should-release == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
         run: |
           TAG="${{ steps.next-version.outputs.tag }}"
-          gh release create "$TAG" \
-            --draft \
-            --verify-tag \
-            --title "$TAG" \
-            --generate-notes
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            --method POST \
+            -f tag_name="$TAG" \
+            -f target_commitish="${{ steps.candidate.outputs.commit }}" \
+            --jq .body > release-notes-preview.md
       - name: Build docs preview
         if: steps.next-version.outputs.should-release == 'true'
         env:
@@ -141,15 +147,87 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
         run: |
           TAG="${{ steps.next-version.outputs.tag }}"
+          COMMIT="${{ steps.candidate.outputs.commit }}"
           cat > release-review-issue.md <<EOF
           @joelostblom @mattijn @alec-bike
-          A tag and release note draft for $TAG has been created. Please assign yourself to this issue if you have capacity to release this version.
+          A release candidate for $TAG has been prepared from commit \`$COMMIT\`. Please assign yourself to this issue if you have capacity to release this version.
 
-          Next, review [the draft release notes](https://github.com/vega/altair/releases) and [the docs preview](${{ steps.docs-preview.outputs.url }}) (scan the gallery thumbnails for broken examples). If everything looks correct, publish the release on GitHub; this will also trigger a PyPI release.
+          No version tag or GitHub release has been created yet. This keeps version tags immutable and avoids burning a version number if this candidate is rejected.
+
+          Next, review the release notes preview below and [the docs preview](${{ steps.docs-preview.outputs.url }}) (scan the gallery thumbnails for broken examples). If everything looks correct, [approve the release deployment](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}); otherwise reject it and close this issue. Approval creates the immutable version tag at the candidate commit and a draft GitHub release. Publishing the GitHub release will trigger the PyPI release; close this issue after publishing.
 
           You can read [the general release notes](https://github.com/vega/altair/blob/main/RELEASING.md) for more details, including what to do after a release.
+
+          ## Release notes preview
           EOF
 
+          cat release-notes-preview.md >> release-review-issue.md
+
           gh issue create \
-            --title "Review draft release $TAG" \
+            --title "Review release candidate $TAG" \
             --body-file release-review-issue.md
+
+  create-draft-release:
+    needs: prepare-release-candidate
+    if: needs.prepare-release-candidate.outputs.should-release == 'true'
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify release environment requires approval
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+        run: |
+          REVIEWER_COUNT=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/environments/release" \
+            --jq '[.protection_rules[] | select(.type == "required_reviewers") | .reviewers[]] | length')
+          if [ "$REVIEWER_COUNT" -eq 0 ]; then
+            echo "The release environment must have at least one required reviewer."
+            exit 1
+          fi
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.prepare-release-candidate.outputs.commit }}
+          fetch-depth: 0
+          # Use RELEASE_TOKEN when branch protection blocks github.token pushes.
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
+      - name: Configure release git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Create immutable release tag
+        env:
+          COMMIT: ${{ needs.prepare-release-candidate.outputs.commit }}
+          TAG: ${{ needs.prepare-release-candidate.outputs.tag }}
+          VERSION: ${{ needs.prepare-release-candidate.outputs.version }}
+        run: |
+          git fetch --force --tags origin
+          if git show-ref --verify --quiet "refs/tags/$TAG"; then
+            TAG_COMMIT=$(git rev-list -n 1 "$TAG")
+            if [ "$TAG_COMMIT" != "$COMMIT" ]; then
+              echo "Tag $TAG already exists at $TAG_COMMIT, not candidate commit $COMMIT."
+              exit 1
+            fi
+            echo "Tag $TAG already exists at the candidate commit; reusing it."
+          else
+            git tag -a "$TAG" "$COMMIT" -m "Version $VERSION release"
+            git push origin "refs/tags/$TAG"
+          fi
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+          TAG: ${{ needs.prepare-release-candidate.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            IS_DRAFT=$(gh release view "$TAG" --json isDraft --jq .isDraft)
+            if [ "$IS_DRAFT" != "true" ]; then
+              echo "A non-draft GitHub release for $TAG already exists."
+              exit 1
+            fi
+            echo "Draft GitHub release for $TAG already exists; nothing to do."
+          else
+            gh release create "$TAG" \
+              --draft \
+              --verify-tag \
+              --title "$TAG" \
+              --generate-notes
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,19 +13,21 @@ Check that all [Vega project](https://github.com/orgs/vega/repositories?type=sou
 
 ### Semi-Automated Release
 
-1. A couple of times a month, GitHub actions will check if notable commits has been made to main (e.g. fixes and features) since the last release. If so, a draft release will be prepared and an issue will be opened tagging the maintainers to review it before releasing.
+The `release` environment in the repository settings must have at least one required reviewer. The workflow verifies this before creating a version tag.
+
+1. A couple of times a month, GitHub Actions will check if notable commits have been made to main (e.g. fixes and features) since the last release. If so, a release candidate will be prepared and an issue will be opened tagging the maintainers to review it before releasing.
     - It is also possible to trigger this release workflow manually: go to the "Actions" tab, click the `Prepare Release Draft` workflow to the left, and then "Run workflow".
     - This workflow automates the following steps:
-        1. Checks for an existing draft release and exits if one already exists.
+        1. Checks for an existing release review issue or draft release and exits if one already exists.
         2. Uses Cocogitto to inspect conventional commits since the latest `v*` tag.
         3. Skips the release if no SemVer-relevant changes are found.
         4. Runs the test suite.
-        5. Commits the release version and creates a `vX.Y.Z` tag.
-        6. Creates a draft GitHub release.
-        7. Builds and publishes docs preview with a draft-release banner at `release-preview/latest/`.
-        8. Opens an issue with the instructions for manual review before releasing.
-2. Review the issue that was opened by the workflow. This contains instructions on what to review before publishing the draft release, e.g. the release notes and the preview version of the docs.
-3. Publish the release on Github.
+        5. Generates a release notes preview without creating a version tag.
+        6. Builds and publishes a docs preview from the candidate commit with a release-candidate banner at `release-preview/latest/`.
+        7. Opens an issue with the candidate commit, release notes, docs preview, and review instructions.
+        8. Waits for approval through the protected `release` environment.
+2. Review the issue opened by the workflow. Approve the pending release deployment if the release notes and docs preview look correct, or reject it to abort the release. Rejection creates no version tag or GitHub release.
+3. Approval creates an immutable `vX.Y.Z` tag at the exact reviewed commit and creates a draft GitHub release. Review the draft, publish it on GitHub, and close the release review issue.
     - Publishing a non-prerelease GitHub release whose tag matches `vX.Y.Z` triggers the `Publish Release to PyPI` workflow. That workflow checks out the release tag, builds the package, publishes to PyPI using trusted publishing, and updates the official documentation.
 
 ### Manual Release


### PR DESCRIPTION
Rework the semi-automated release workflow so official version tags are only created after maintainer approval.

Previously, the workflow created the `vX.Y.Z` tag and draft GitHub release before review. If maintainers decided not to publish the release, the official tag had to be deleted. This workflow instead prepares a release candidate at a pinned commit and waits for approval through a protected GitHub environment before creating the permanent tag.

## Changes

- Split the release workflow into two jobs:
  - `prepare-release-candidate`
  - `create-draft-release`
- Pin each release candidate to the exact commit reviewed by maintainers.
- Generate a release notes preview without creating a tag or GitHub release.
- Include the generated notes and candidate commit in the release review issue.
- Remove contributor `by @username` mentions from the issue preview to avoid notifying non-maintainers.
- Build and publish the documentation preview before requesting approval.
- Gate official tag and draft release creation through the protected `release` environment.
- Verify that the `release` environment has at least one required reviewer before creating a tag.
- Allow reviewers to reject a candidate without creating an official tag or GitHub release.
- Create the permanent `vX.Y.Z` tag at the exact reviewed commit after approval.
- Safely handle retries when the expected tag or draft release already exists.
- Continue regenerating the GitHub release notes when creating the draft so maintainers can compare them with the reviewed preview and make manual edits.
- Block new candidates while an existing release review issue or draft release is open.
- Update `RELEASING.md` to document the approval flow.

## Release Flow

1. The scheduled or manually triggered workflow calculates the next version with Cocogitto.
2. It records the candidate commit, runs the test suite, generates release notes, and publishes a docs preview.
3. It opens a release review issue containing the candidate commit, generated notes, docs preview, and approval link.
4. The `create-draft-release` job waits for approval through the protected `release` environment.
5. Rejecting the deployment creates no tag or GitHub release.
6. Approving the deployment creates the immutable version tag at the reviewed commit and creates a draft GitHub release.
7. Publishing the draft release continues to trigger the existing PyPI and documentation publishing workflow.

## Repository Setup

Before using the new flow, configure a GitHub environment named `release` with at least one required reviewer:

1. Go to **Settings → Environments**.
2. Create or select the `release` environment.
3. Enable **Required reviewers** and add the relevant maintainers or team.
4. Optionally enable **Prevent self-review**.

The workflow fails before creating a tag if the environment has no required reviewers.

