### PR TITLE
ci: Allow overriding the release bump type

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -5,6 +5,16 @@ on:
   schedule:
     - cron: '30 14 1,15 * *'  # 1st and 15th of each month at 14:30 UTC.
   workflow_dispatch:
+    inputs:
+      bump-type:
+        description: 'Version bump type (override auto-detection from commit history)'
+        type: choice
+        default: 'auto'
+        options:
+          - auto
+          - major
+          - minor
+          - patch
 
 permissions:
   contents: write
@@ -71,9 +81,11 @@ jobs:
       - name: Determine next release version
         if: steps.existing-review.outputs.should-release == 'true'
         id: next-version
+        env:
+          BUMP_TYPE: ${{ inputs.bump-type || 'auto' }}
         run: |
           set +e
-          DRY_RUN_OUTPUT=$(cog bump --dry-run --auto 2>&1)
+          DRY_RUN_OUTPUT=$(cog bump --dry-run --"$BUMP_TYPE" 2>&1)
           STATUS=$?
           set -e
           printf '%s\n' "$DRY_RUN_OUTPUT"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,8 @@ Check that all [Vega project](https://github.com/orgs/vega/repositories?type=sou
 The `release` environment in the repository settings must have at least one required reviewer. The workflow verifies this before creating a version tag.
 
 1. A couple of times a month, GitHub Actions will check if notable commits have been made to main (e.g. fixes and features) since the last release. If so, a release candidate will be prepared and an issue will be opened tagging the maintainers to review it before releasing.
-    - It is also possible to trigger this release workflow manually: go to the "Actions" tab, click the `Prepare Release Draft` workflow to the left, and then "Run workflow".
+    - If a scheduled candidate proposes an undesired version bump, reject its pending deployment, close its review issue, and rerun the workflow manually. Manual workflow dispatch let's you choose whether to use a `major`, `minor`, or `patch` bump.
+        - To trigger this release workflow manually: go to the "Actions" tab, click the `Prepare Release Draft` workflow to the left, and then "Run workflow".
     - This workflow automates the following steps:
         1. Checks for an existing release review issue or draft release and exits if one already exists.
         2. Uses Cocogitto to inspect conventional commits since the latest `v*` tag.


### PR DESCRIPTION
Fix for #4092

Following description is generated by an LLM: 

# Problem
Cocogitto's `--auto` flag infers the next version purely from conventional-commit markers already in git history (e.g. the `fix!:` subject on #4068's merge commit), and `release-draft.yml` hardcodes `--auto` with no way to override it, so a single breaking-marked commit forces a major bump on every subsequent run until it's tagged, even when maintainers decide to treat it as non-breaking for a given release, as discussed in #4092.

# Reproduce

**Before this PR** dispatching the workflow always runs:
```
cog bump --dry-run --auto
```
which reports `v7.0.0` as long as any breaking-marked commit sits in history since the last tag, with no way to ask for a minor/patch bump instead short of editing the workflow file directly.

**With this PR** triggering the workflow via `workflow_dispatch` now exposes a `bump-type` choice input (`auto`/`major`/`minor`/`patch`, default `auto`). Selecting `minor` runs `cog bump --dry-run --minor`, producing e.g. `v6.3.0` regardless of the breaking marker already in history. The scheduled cron trigger is untouched, it has no inputs, so it still resolves to `auto`.

# Proposed solution
- Added `workflow_dispatch.inputs.bump-type` as a `choice` input (`auto`/`major`/`minor`/`patch`, default `auto`).
- Threaded it into the "Determine next release version" step as `BUMP_TYPE`, replacing the hardcoded `--auto` with `--"$BUMP_TYPE"`.
- Used `inputs.bump-type || 'auto'` so schedule-triggered runs (where `inputs` isn't populated) keep today's default behavior exactly.
- Used a `choice` type rather than a free-text string, so only the four valid Cocogitto flags can ever reach the shell command — nothing else flows into `cog bump --dry-run --"$BUMP_TYPE"`.

A few notes on my reasoning, and where I'm not fully certain:
- I considered making the default itself conditional instead of adding an input, but that risked silently changing the monthly scheduled behavior. I'd rather this only kick in when a maintainer deliberately dispatches with a non-default choice.
- I chose "bump type" over "explicit target version string" to keep the input surface small and to mirror Cocogitto's own manual-override flags (`--major`/`--minor`/`--patch`) rather than inventing a new mechanism.
- `create-draft-release` doesn't need any changes, it just consumes whatever `next-version` output is produced, regardless of how that version was derived.