### PR TITLE
fix: configure() no longer overwrites config set by configure_*() sub-methods

### DIFF
--- a/altair/vegalite/v6/schema/mixins.py
+++ b/altair/vegalite/v6/schema/mixins.py
@@ -1157,8 +1157,11 @@ class ConfigMethodMixin:
 
     @use_signature(core.Config)
     def configure(self, *args, **kwargs) -> Self:
-        copy = self.copy(deep=False)  # type: ignore[attr-defined]
-        copy.config = core.Config(*args, **kwargs)
+        copy = self.copy(deep=["config"])  # type: ignore[attr-defined]
+        if copy.config is Undefined:
+            copy.config = core.Config(*args, **kwargs)
+        else:
+            copy.config = core.Config(*args, **{**copy.config._kwds, **kwargs})
         return copy
 
     @use_signature(core.RectConfig)

--- a/tests/vegalite/v6/test_api.py
+++ b/tests/vegalite/v6/test_api.py
@@ -376,6 +376,34 @@ def test_chart_operations():
     assert len(chart.vconcat) == 4
 
 
+def test_configure_merges_with_configure_prop_methods() -> None:
+    # https://github.com/altair-viz/altair/issues/3841
+    # `configure()` used to overwrite the whole `config` object, silently
+    # discarding anything set by an earlier `configure_axisBottom()` (or any
+    # other `configure_*` sub-method) call earlier in the chain.
+    data = pd.DataFrame({"foo": [1.1, 2.2, 3.3], "bar": [3, 2, 4]})
+    chart = (
+        alt.Chart(data)
+        .mark_circle()
+        .encode(x="foo", y="bar")
+        .configure_axisBottom(orient="top")
+        .configure(tooltipFormat={"numberFormat": ".2f"})
+    )
+    config = chart.config.to_dict()
+    assert config["axisBottom"] == {"orient": "top"}
+    assert config["tooltipFormat"] == {"numberFormat": ".2f"}
+
+    # A later `configure()` call for the same top-level key still overrides it.
+    chart2 = (
+        alt.Chart(data)
+        .mark_circle()
+        .encode(x="foo", y="bar")
+        .configure(background="white")
+        .configure(background="red")
+    )
+    assert chart2.config.to_dict()["background"] == "red"
+
+
 def test_when() -> None:
     select = alt.selection_point(name="select", on="click")
     condition = alt.condition(select, alt.value(1), "two", empty=False)["condition"]

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -235,8 +235,11 @@ def mark_{mark}(self, **kwds: Any) -> Self:
 CONFIG_METHOD: Final = """
 @use_signature(core.{classname})
 def {method}(self, *args, **kwargs) -> Self:
-    copy = self.copy(deep=False)  # type: ignore[attr-defined]
-    copy.config = core.{classname}(*args, **kwargs)
+    copy = self.copy(deep=['config'])  # type: ignore[attr-defined]
+    if copy.config is Undefined:
+        copy.config = core.{classname}(*args, **kwargs)
+    else:
+        copy.config = core.{classname}(*args, **{{**copy.config._kwds, **kwargs}})
     return copy
 """
 


### PR DESCRIPTION
## Summary

Fixes #3841.

`configure()` unconditionally replaced the whole `config` object:

```python
def configure(self, *args, **kwargs) -> Self:
    copy = self.copy(deep=False)
    copy.config = core.Config(*args, **kwargs)
    return copy
```

So calling it after any `configure_*()` sub-method (`configure_axisBottom()`, `configure_view()`, etc.) silently discarded everything the sub-method had set, e.g.:

```python
chart = (
    alt.Chart(data)
    .mark_circle()
    .encode(x="foo", y="bar")
    .configure_axisBottom(orient="top")  # discarded by the next call
    .configure(tooltipFormat={"numberFormat": ".2f"})
)
```

The `configure_*()` sub-methods already merge into the existing config (`copy.config["{prop}"] = ...`), so `configure()` was the odd one out.

## Fix

Updated the `CONFIG_METHOD` template in `tools/generate_schema_wrapper.py` (this generates `ConfigMethodMixin.configure` in `altair/vegalite/v6/schema/mixins.py`) so `configure()` merges its kwargs into the existing config instead of replacing it outright — same-key values still get overridden as expected, but unrelated keys set by earlier calls survive. Ran `uv run python tools/generate_schema_wrapper.py` to regenerate `mixins.py` from the updated template (the only functional change in the regenerated file is this method; unrelated dataset/theme metadata files that also get touched by the generator were left untouched).

## Testing

- Added `test_configure_merges_with_configure_prop_methods` in `tests/vegalite/v6/test_api.py`, covering both the reported case (config set by `configure_axisBottom()` survives a later `configure()` call) and that `configure()` still overrides a key it set previously.
- `uv run pytest tests/ -k config -q` — 14 passed.
- Manually reproduced the exact repro from #3841 before the fix (bug confirmed) and after (fixed).
